### PR TITLE
expose cuvsResources_t to python

### DIFF
--- a/python/cuvs/cuvs/common/CMakeLists.txt
+++ b/python/cuvs/cuvs/common/CMakeLists.txt
@@ -13,7 +13,7 @@
 # =============================================================================
 
 # Set the list of Cython files to build
-set(cython_sources cydlpack.pyx exceptions.pyx)
+set(cython_sources cydlpack.pyx exceptions.pyx resources.pyx)
 set(linked_libraries cuvs::cuvs cuvs_c)
 
 # Build all of the Cython targets

--- a/python/cuvs/cuvs/common/c_api.pxd
+++ b/python/cuvs/cuvs/common/c_api.pxd
@@ -30,4 +30,5 @@ cdef extern from "cuvs/core/c_api.h":
     cuvsError_t cuvsResourcesCreate(cuvsResources_t* res)
     cuvsError_t cuvsResourcesDestroy(cuvsResources_t res)
     cuvsError_t cuvsStreamSet(cuvsResources_t res, cudaStream_t stream)
+    cuvsError_t cuvsStreamSync(cuvsResources_t res)
     const char * cuvsGetLastErrorText()

--- a/python/cuvs/cuvs/common/resources.pxd
+++ b/python/cuvs/cuvs/common/resources.pxd
@@ -1,18 +1,22 @@
+#
 # Copyright (c) 2024, NVIDIA CORPORATION.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# cython: language_level=3
+
+from cuvs.common.c_api cimport cuvsResources_t
 
 
-from .resources import Resources, auto_sync_resources
-
-__all__ = ["auto_sync_resources", "Resources"]
+cdef class Resources:
+    cdef cuvsResources_t c_obj

--- a/python/cuvs/cuvs/common/resources.pyx
+++ b/python/cuvs/cuvs/common/resources.pyx
@@ -1,0 +1,120 @@
+#
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# cython: language_level=3
+
+import functools
+
+from cuda.ccudart cimport cudaStream_t
+
+from cuvs.common.c_api cimport (
+    cuvsResources_t,
+    cuvsResourcesCreate,
+    cuvsResourcesDestroy,
+    cuvsStreamSet,
+    cuvsStreamSync,
+)
+
+from cuvs.common.exceptions import check_cuvs
+
+
+cdef class Resources:
+    """
+    Resources  is a lightweight python wrapper around the corresponding
+    C++ class of resources exposed by RAFT's C++ interface. Refer to
+    the header file raft/core/resources.hpp for interface level
+    details of this struct.
+
+    Parameters
+    ----------
+    stream : Optional stream to use for ordering CUDA instructions
+
+    Examples
+    --------
+
+    Basic usage:
+
+    >>> from cuvs.common import Resources
+    >>> handle = Resources()
+    >>>
+    >>> # call algos here
+    >>>
+    >>> # final sync of all work launched in the stream of this handle
+    >>> handle.sync()
+
+    Using a cuPy stream with cuVS Resources:
+
+    >>> import cupy
+    >>> from cuvs.common import Resources
+    >>>
+    >>> cupy_stream = cupy.cuda.Stream()
+    >>> handle = Resources(stream=cupy_stream.ptr)
+    """
+
+    def __cinit__(self, stream=None):
+        check_cuvs(cuvsResourcesCreate(&self.c_obj))
+        if stream:
+            check_cuvs(cuvsStreamSet(self.c_obj, <cudaStream_t>stream))
+
+    def sync(self):
+        check_cuvs(cuvsStreamSync(self.c_obj))
+
+    def get_c_obj(self):
+        """
+        Return the pointer to the underlying c_obj as a size_t
+        """
+        return <size_t> self.c_obj
+
+    def __dealloc__(self):
+        check_cuvs(cuvsResourcesDestroy(self.c_obj))
+
+
+_resources_param_string = """
+     resources : Optional cuVS Resource handle for reusing CUDA resources.
+        If Resources aren't supplied, CUDA resources will be
+        allocated inside this function and synchronized before the
+        function exits. If resources are supplied, you will need to
+        explicitly synchronize yourself by calling `resources.sync()`
+        before accessing the output.
+""".strip()
+
+
+def auto_sync_resources(f):
+    """Decorator to automatically call sync on a cuVS Resources object when
+    it isn't passed to a function.
+
+    When a resources=None is passed to the wrapped function, this decorator
+    will automatically create a default resources for the function, and
+    call sync on that resources when the function exits.
+
+    This will also insert the appropriate docstring for the resources parameter
+    """
+
+    @functools.wraps(f)
+    def wrapper(*args, resources=None, **kwargs):
+        sync_resources = resources is None
+        resources = resources if resources is not None else Resources()
+
+        ret_value = f(*args, resources=resources, **kwargs)
+
+        if sync_resources:
+            resources.sync()
+
+        return ret_value
+
+    wrapper.__doc__ = wrapper.__doc__.format(
+        resources_docstring=_resources_param_string
+    )
+    return wrapper

--- a/python/cuvs/cuvs/test/test_doctests.py
+++ b/python/cuvs/cuvs/test/test_doctests.py
@@ -90,6 +90,7 @@ def _find_doctests_in_obj(obj, finder=None, criteria=None):
 # doctests for here
 DOC_STRINGS = list(_find_doctests_in_obj(cuvs.neighbors))
 DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.neighbors.cagra))
+DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.common))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The current python code was creating a cuvsResources_t to pass to the CAGRA apis on the build/search code. This both ignored the passed in `resources` object, and also leaked memory since it wasn't calling cuvsResourcesDestroy.

Fix by exposing the cuvsResources_t object to python.
