### PR TITLE
Update pre-commit-hooks to v0.0.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,7 +102,7 @@ repos:
         hooks:
               - id: check-json
       - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v0.0.1
+        rev: v0.0.3
         hooks:
           - id: verify-copyright
             files: |


### PR DESCRIPTION
This fixes an issue with how the `verify-copyright` hook handles multiple merge bases.
