### PR TITLE
Add CAGRA-Q compression

### DIFF
--- a/cpp/include/cuvs/neighbors/cagra.h
+++ b/cpp/include/cuvs/neighbors/cagra.h
@@ -40,39 +40,6 @@ enum cuvsCagraGraphBuildAlgo {
   NN_DESCENT
 };
 
-/**
- * @brief Supplemental parameters to build CAGRA Index
- *
- */
-struct cuvsCagraIndexParams {
-  /** Degree of input graph for pruning. */
-  size_t intermediate_graph_degree;
-  /** Degree of output graph. */
-  size_t graph_degree;
-  /** ANN algorithm to build knn graph. */
-  enum cuvsCagraGraphBuildAlgo build_algo;
-  /** Number of Iterations to run if building with NN_DESCENT */
-  size_t nn_descent_niter;
-};
-
-typedef struct cuvsCagraIndexParams* cuvsCagraIndexParams_t;
-
-/**
- * @brief Allocate CAGRA Index params, and populate with default values
- *
- * @param[in] params cuvsCagraIndexParams_t to allocate
- * @return cuvsError_t
- */
-cuvsError_t cuvsCagraIndexParamsCreate(cuvsCagraIndexParams_t* params);
-
-/**
- * @brief De-allocate CAGRA Index params
- *
- * @param[in] params
- * @return cuvsError_t
- */
-cuvsError_t cuvsCagraIndexParamsDestroy(cuvsCagraIndexParams_t params);
-
 /** Parameters for VPQ compression. */
 struct cuvsCagraCompressionParams {
   /**
@@ -111,6 +78,45 @@ struct cuvsCagraCompressionParams {
 };
 
 typedef struct cuvsCagraCompressionParams* cuvsCagraCompressionParams_t;
+
+/**
+ * @brief Supplemental parameters to build CAGRA Index
+ *
+ */
+struct cuvsCagraIndexParams {
+  /** Degree of input graph for pruning. */
+  size_t intermediate_graph_degree;
+  /** Degree of output graph. */
+  size_t graph_degree;
+  /** ANN algorithm to build knn graph. */
+  enum cuvsCagraGraphBuildAlgo build_algo;
+  /** Number of Iterations to run if building with NN_DESCENT */
+  size_t nn_descent_niter;
+  /**
+   * Optional: specify compression parameters if compression is desired.
+   *
+   * NOTE: this is experimental new API, consider it unsafe.
+   */
+  cuvsCagraCompressionParams_t compression;
+};
+
+typedef struct cuvsCagraIndexParams* cuvsCagraIndexParams_t;
+
+/**
+ * @brief Allocate CAGRA Index params, and populate with default values
+ *
+ * @param[in] params cuvsCagraIndexParams_t to allocate
+ * @return cuvsError_t
+ */
+cuvsError_t cuvsCagraIndexParamsCreate(cuvsCagraIndexParams_t* params);
+
+/**
+ * @brief De-allocate CAGRA Index params
+ *
+ * @param[in] params
+ * @return cuvsError_t
+ */
+cuvsError_t cuvsCagraIndexParamsDestroy(cuvsCagraIndexParams_t params);
 
 /**
  * @brief Allocate CAGRA Compression params, and populate with default values
@@ -313,23 +319,6 @@ cuvsError_t cuvsCagraBuild(cuvsResources_t res,
                            cuvsCagraIndexParams_t params,
                            DLManagedTensor* dataset,
                            cuvsCagraIndex_t index);
-
-/**
- * @brief Build a CAGRA index with compression
- *
- * @param[in] res cuvsResources_t opaque C handle
- * @param[in] params cuvsCagraIndexParams_t used to build CAGRA index
- * @param[in] compression_params cuvsCagraCompressionParams_t used to compress the input dataset for
- * CAGRA index
- * @param[in] dataset DLManagedTensor* training dataset
- * @param[out] index cuvsCagraIndex_t Newly built CAGRA index
- * @return cuvsError_t
- */
-cuvsError_t cuvsCagraBuildCompressed(cuvsResources_t res,
-                                     cuvsCagraIndexParams_t params,
-                                     cuvsCagraCompressionParams_t compression_params,
-                                     DLManagedTensor* dataset,
-                                     cuvsCagraIndex_t index);
 
 /**
  * @}

--- a/cpp/include/cuvs/neighbors/cagra.h
+++ b/cpp/include/cuvs/neighbors/cagra.h
@@ -325,11 +325,11 @@ cuvsError_t cuvsCagraBuild(cuvsResources_t res,
  * @param[out] index cuvsCagraIndex_t Newly built CAGRA index
  * @return cuvsError_t
  */
-cuvsError_t cuvsCagraBuild(cuvsResources_t res,
-                           cuvsCagraIndexParams_t params,
-                           cuvsCagraCompressionParams_t compression_params,
-                           DLManagedTensor* dataset,
-                           cuvsCagraIndex_t index);
+cuvsError_t cuvsCagraBuildCompressed(cuvsResources_t res,
+                                     cuvsCagraIndexParams_t params,
+                                     cuvsCagraCompressionParams_t compression_params,
+                                     DLManagedTensor* dataset,
+                                     cuvsCagraIndex_t index);
 
 /**
  * @}

--- a/cpp/include/cuvs/neighbors/cagra.h
+++ b/cpp/include/cuvs/neighbors/cagra.h
@@ -83,31 +83,31 @@ struct cuvsCagraCompressionParams {
    * Hint: the smaller the 'pq_bits', the smaller the index size and the better the search
    * performance, but the lower the recall.
    */
-  uint32_t pq_bits = 8;
+  uint32_t pq_bits;
   /**
    * The dimensionality of the vector after compression by PQ.
    * When zero, an optimal value is selected using a heuristic.
    *
    * TODO: at the moment `dim` must be a multiple `pq_dim`.
    */
-  uint32_t pq_dim = 0;
+  uint32_t pq_dim;
   /**
    * Vector Quantization (VQ) codebook size - number of "coarse cluster centers".
    * When zero, an optimal value is selected using a heuristic.
    */
-  uint32_t vq_n_centers = 0;
+  uint32_t vq_n_centers;
   /** The number of iterations searching for kmeans centers (both VQ & PQ phases). */
-  uint32_t kmeans_n_iters = 25;
+  uint32_t kmeans_n_iters;
   /**
    * The fraction of data to use during iterative kmeans building (VQ phase).
    * When zero, an optimal value is selected using a heuristic.
    */
-  double vq_kmeans_trainset_fraction = 0;
+  double vq_kmeans_trainset_fraction;
   /**
    * The fraction of data to use during iterative kmeans building (PQ phase).
    * When zero, an optimal value is selected using a heuristic.
    */
-  double pq_kmeans_trainset_fraction = 0;
+  double pq_kmeans_trainset_fraction;
 };
 
 typedef struct cuvsCagraCompressionParams* cuvsCagraCompressionParams_t;

--- a/cpp/include/cuvs/neighbors/cagra.h
+++ b/cpp/include/cuvs/neighbors/cagra.h
@@ -73,6 +73,61 @@ cuvsError_t cuvsCagraIndexParamsCreate(cuvsCagraIndexParams_t* params);
  */
 cuvsError_t cuvsCagraIndexParamsDestroy(cuvsCagraIndexParams_t params);
 
+/** Parameters for VPQ compression. */
+struct cuvsCagraCompressionParams {
+  /**
+   * The bit length of the vector element after compression by PQ.
+   *
+   * Possible values: [4, 5, 6, 7, 8].
+   *
+   * Hint: the smaller the 'pq_bits', the smaller the index size and the better the search
+   * performance, but the lower the recall.
+   */
+  uint32_t pq_bits = 8;
+  /**
+   * The dimensionality of the vector after compression by PQ.
+   * When zero, an optimal value is selected using a heuristic.
+   *
+   * TODO: at the moment `dim` must be a multiple `pq_dim`.
+   */
+  uint32_t pq_dim = 0;
+  /**
+   * Vector Quantization (VQ) codebook size - number of "coarse cluster centers".
+   * When zero, an optimal value is selected using a heuristic.
+   */
+  uint32_t vq_n_centers = 0;
+  /** The number of iterations searching for kmeans centers (both VQ & PQ phases). */
+  uint32_t kmeans_n_iters = 25;
+  /**
+   * The fraction of data to use during iterative kmeans building (VQ phase).
+   * When zero, an optimal value is selected using a heuristic.
+   */
+  double vq_kmeans_trainset_fraction = 0;
+  /**
+   * The fraction of data to use during iterative kmeans building (PQ phase).
+   * When zero, an optimal value is selected using a heuristic.
+   */
+  double pq_kmeans_trainset_fraction = 0;
+};
+
+typedef struct cuvsCagraCompressionParams* cuvsCagraCompressionParams_t;
+
+/**
+ * @brief Allocate CAGRA Compression params, and populate with default values
+ *
+ * @param[in] params cuvsCagraCompressionParams_t to allocate
+ * @return cuvsError_t
+ */
+cuvsError_t cuvsCagraCompressionParamsCreate(cuvsCagraCompressionParams_t* params);
+
+/**
+ * @brief De-allocate CAGRA Compression params
+ *
+ * @param[in] params
+ * @return cuvsError_t
+ */
+cuvsError_t cuvsCagraCompressionParamsDestroy(cuvsCagraCompressionParams_t params);
+
 /**
  * @}
  */
@@ -256,6 +311,23 @@ cuvsError_t cuvsCagraIndexDestroy(cuvsCagraIndex_t index);
  */
 cuvsError_t cuvsCagraBuild(cuvsResources_t res,
                            cuvsCagraIndexParams_t params,
+                           DLManagedTensor* dataset,
+                           cuvsCagraIndex_t index);
+
+/**
+ * @brief Build a CAGRA index with compression
+ *
+ * @param[in] res cuvsResources_t opaque C handle
+ * @param[in] params cuvsCagraIndexParams_t used to build CAGRA index
+ * @param[in] compression_params cuvsCagraCompressionParams_t used to compress the input dataset for
+ * CAGRA index
+ * @param[in] dataset DLManagedTensor* training dataset
+ * @param[out] index cuvsCagraIndex_t Newly built CAGRA index
+ * @return cuvsError_t
+ */
+cuvsError_t cuvsCagraBuild(cuvsResources_t res,
+                           cuvsCagraIndexParams_t params,
+                           cuvsCagraCompressionParams_t compression_params,
                            DLManagedTensor* dataset,
                            cuvsCagraIndex_t index);
 

--- a/cpp/src/neighbors/cagra_c.cpp
+++ b/cpp/src/neighbors/cagra_c.cpp
@@ -35,7 +35,7 @@ namespace {
 template <typename T>
 void* _build(cuvsResources_t res,
              cuvsCagraIndexParams params,
-             std::optional<cuvsCagraCompressionParams_t> cparams,
+             std::optional<cuvsCagraCompressionParams> cparams,
              DLManagedTensor* dataset_tensor)
 {
   auto dataset = dataset_tensor->dl_tensor;

--- a/cpp/src/neighbors/cagra_c.cpp
+++ b/cpp/src/neighbors/cagra_c.cpp
@@ -52,12 +52,12 @@ void* _build(cuvsResources_t res,
 
   if (cparams.has_value()) {
     auto compression_params                        = cuvs::neighbors::cagra::vpq_params();
-    compression_params.pq_bits                     = cparams->pq_bits();
-    compression_params.pq_dim                      = cparams->pq_dim();
-    compression_params.vq_n_centers                = cparams->vq_n_centers();
-    compression_params.kmeans_n_iters              = cparams->kmeans_n_iters();
-    compression_params.vq_kmeans_trainset_fraction = cparams->vq_kmeans_trainset_fraction();
-    compression_params.pq_kmeans_trainset_fraction = cparams->pq_kmeans_trainset_fraction();
+    compression_params.pq_bits                     = cparams->pq_bits;
+    compression_params.pq_dim                      = cparams->pq_dim;
+    compression_params.vq_n_centers                = cparams->vq_n_centers;
+    compression_params.kmeans_n_iters              = cparams->kmeans_n_iters;
+    compression_params.vq_kmeans_trainset_fraction = cparams->vq_kmeans_trainset_fraction;
+    compression_params.pq_kmeans_trainset_fraction = cparams->pq_kmeans_trainset_fraction;
     build_params.compression.emplace(compression_params);
   }
 

--- a/cpp/src/neighbors/cagra_c.cpp
+++ b/cpp/src/neighbors/cagra_c.cpp
@@ -157,7 +157,8 @@ extern "C" cuvsError_t cuvsCagraBuildCompressed(cuvsResources_t res,
         reinterpret_cast<uintptr_t>(_build<int8_t>(res, *params, cparams, dataset_tensor));
       index->dtype.code = kDLInt;
     } else if (dataset.dtype.code == kDLUInt && dataset.dtype.bits == 8) {
-      index->addr = reinterpret_cast<uintptr_t>(_build<uint8_t>(res, *params, dataset_tensor));
+      index->addr =
+        reinterpret_cast<uintptr_t>(_build<uint8_t>(res, *params, cparams, dataset_tensor));
       index->dtype.code = kDLUInt;
     } else {
       RAFT_FAIL("Unsupported dataset DLtensor dtype: %d and bits: %d",

--- a/cpp/src/neighbors/cagra_c.cpp
+++ b/cpp/src/neighbors/cagra_c.cpp
@@ -138,11 +138,11 @@ extern "C" cuvsError_t cuvsCagraIndexDestroy(cuvsCagraIndex_t index_c_ptr)
   });
 }
 
-extern "C" cuvsError_t cuvsCagraBuild(cuvsResources_t res,
-                                      cuvsCagraIndexParams_t params,
-                                      cuvsCagraCompressionParams_t compression_params,
-                                      DLManagedTensor* dataset_tensor,
-                                      cuvsCagraIndex_t index)
+extern "C" cuvsError_t cuvsCagraBuildCompressed(cuvsResources_t res,
+                                                cuvsCagraIndexParams_t params,
+                                                cuvsCagraCompressionParams_t compression_params,
+                                                DLManagedTensor* dataset_tensor,
+                                                cuvsCagraIndex_t index)
 {
   return cuvs::core::translate_exceptions([=] {
     auto dataset = dataset_tensor->dl_tensor;
@@ -172,7 +172,7 @@ extern "C" cuvsError_t cuvsCagraBuild(cuvsResources_t res,
                                       DLManagedTensor* dataset_tensor,
                                       cuvsCagraIndex_t index)
 {
-  return cuvsCagraBuild(res, params, nullptr, dataset_tensor, index);
+  return cuvsCagraBuildCompressed(res, params, nullptr, dataset_tensor, index);
 }
 
 extern "C" cuvsError_t cuvsCagraSearch(cuvsResources_t res,

--- a/cpp/test/neighbors/ann_cagra.cuh
+++ b/cpp/test/neighbors/ann_cagra.cuh
@@ -39,6 +39,7 @@
 
 #include <cstddef>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -144,6 +145,7 @@ struct AnnCagraInputs {
   bool include_serialized_dataset;
   // std::optional<double>
   double min_recall;  // = std::nullopt;
+  std::optional<vpq_params> compression = std::nullopt;
 };
 
 inline ::std::ostream& operator<<(::std::ostream& os, const AnnCagraInputs& p)
@@ -154,7 +156,13 @@ inline ::std::ostream& operator<<(::std::ostream& os, const AnnCagraInputs& p)
      << ", k=" << p.k << ", " << algo.at((int)p.algo) << ", max_queries=" << p.max_queries
      << ", itopk_size=" << p.itopk_size << ", search_width=" << p.search_width
      << ", metric=" << static_cast<int>(p.metric) << (p.host_dataset ? ", host" : ", device")
-     << ", build_algo=" << build_algo.at((int)p.build_algo) << '}' << std::endl;
+     << ", build_algo=" << build_algo.at((int)p.build_algo);
+  if (p.compression.has_value()) {
+    auto vpq = p.compression.value();
+    os << ", pq_bits=" << vpq.pq_bits << ", pq_dim=" << vpq.pq_dim
+       << ", vq_n_centers=" << vpq.vq_n_centers;
+  }
+  os << '}' << std::endl;
   return os;
 }
 
@@ -204,7 +212,8 @@ class AnnCagraTest : public ::testing::TestWithParam<AnnCagraInputs> {
         cagra::index_params index_params;
         index_params.metric = ps.metric;  // Note: currently ony the cagra::index_params metric is
                                           // not used for knn_graph building.
-        index_params.build_algo = ps.build_algo;
+        index_params.build_algo  = ps.build_algo;
+        index_params.compression = ps.compression;
         cagra::search_params search_params;
         search_params.algo        = ps.algo;
         search_params.max_queries = ps.max_queries;
@@ -261,17 +270,20 @@ class AnnCagraTest : public ::testing::TestWithParam<AnnCagraInputs> {
                                   ps.k,
                                   0.003,
                                   min_recall));
-      EXPECT_TRUE(eval_distances(handle_,
-                                 database.data(),
-                                 search_queries.data(),
-                                 indices_dev.data(),
-                                 distances_dev.data(),
-                                 ps.n_rows,
-                                 ps.dim,
-                                 ps.n_queries,
-                                 ps.k,
-                                 ps.metric,
-                                 1.0e-4));
+      if (!ps.compression.has_value()) {
+        // Don't evaluate distances for CAGRA-Q for now as the error can be somewhat large
+        EXPECT_TRUE(eval_distances(handle_,
+                                   database.data(),
+                                   search_queries.data(),
+                                   indices_dev.data(),
+                                   distances_dev.data(),
+                                   ps.n_rows,
+                                   ps.dim,
+                                   ps.n_queries,
+                                   ps.k,
+                                   ps.metric,
+                                   1.0e-4));
+      }
     }
   }
 
@@ -393,6 +405,32 @@ inline std::vector<AnnCagraInputs> generate_inputs()
     {false},
     {0.995});
   inputs.insert(inputs.end(), inputs2.begin(), inputs2.end());
+
+  // a few PQ configurations
+  inputs2 = raft::util::itertools::product<AnnCagraInputs>(
+    {100},
+    {10000},
+    {64, 128, 192, 256, 512, 1024},  // dim
+    {16},                            // k
+    {graph_build_algo::IVF_PQ},
+    {search_algo::AUTO},
+    {10},
+    {0},
+    {64},
+    {1},
+    {cuvs::distance::DistanceType::L2Expanded},
+    {false},
+    {true},
+    {0.6});                      // don't demand high recall without refinement
+  for (uint32_t pq_len : {2}) {  // for now, only pq_len = 2 is supported, more options coming soon
+    for (uint32_t vq_n_centers : {100, 1000}) {
+      for (auto input : inputs2) {
+        input.compression.emplace(
+          vpq_params{.pq_dim = input.dim / pq_len, .vq_n_centers = vq_n_centers});
+        inputs.push_back(input);
+      }
+    }
+  }
 
   return inputs;
 }

--- a/cpp/test/neighbors/ann_cagra.cuh
+++ b/cpp/test/neighbors/ann_cagra.cuh
@@ -425,8 +425,10 @@ inline std::vector<AnnCagraInputs> generate_inputs()
   for (uint32_t pq_len : {2}) {  // for now, only pq_len = 2 is supported, more options coming soon
     for (uint32_t vq_n_centers : {100, 1000}) {
       for (auto input : inputs2) {
-        input.compression.emplace(
-          vpq_params{.pq_dim = input.dim / pq_len, .vq_n_centers = vq_n_centers});
+        vpq_params ps{};
+        ps.pq_dim       = input.dim / pq_len;
+        ps.vq_n_centers = vq_n_centers;
+        input.compression.emplace(ps);
         inputs.push_back(input);
       }
     }


### PR DESCRIPTION
Minimal code changes to add CAGRA-Q compression to the CAGRA index.
When built with compression, the index uses the compressed dataset automatically during search. At this moment, there's not new search parameters compared to standard CAGRA.