### PR TITLE
When using CUDA 12.4+ use zstd compression

### DIFF
--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -38,6 +38,10 @@ list(APPEND RAFT_CXX_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")
 list(APPEND RAFT_CUDA_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")
 # make sure we produce smallest binary size
 list(APPEND RAFT_CUDA_FLAGS -Xfatbin=-compress-all)
+if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND
+   CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.4.0)
+  list(APPEND RAFT_CUDA_FLAGS -Xfatbin=-compress-algo=5)
+endif()
 
 # Option to enable line info in CUDA device compilation to allow introspection when profiling /
 # memchecking


### PR DESCRIPTION
The zsd compression with nvcc 12.4 produces significantly ( 20-40% ) smaller
binaries with no impact on runtime or compile time performance.
