### PR TITLE
ConfigureCUDA.cmake now sets CUVS_ prefixed variables

### DIFF
--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -51,7 +51,7 @@ endif()
 
 # Debug options
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-  message(VERBOSE "RAFT: Building with debugging flags")
+  message(VERBOSE "cuVS: Building with debugging flags")
   list(APPEND CUVS_CUDA_FLAGS -G -Xcompiler=-rdynamic)
   list(APPEND CUVS_CUDA_FLAGS -Xptxas --suppress-stack-size-warning)
 endif()

--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -13,45 +13,45 @@
 # =============================================================================
 
 if(DISABLE_DEPRECATION_WARNINGS)
-  list(APPEND RAFT_CXX_FLAGS -Wno-deprecated-declarations)
-  list(APPEND RAFT_CUDA_FLAGS -Xcompiler=-Wno-deprecated-declarations)
+  list(APPEND CUVS_CXX_FLAGS -Wno-deprecated-declarations)
+  list(APPEND CUVS_CUDA_FLAGS -Xcompiler=-Wno-deprecated-declarations)
 endif()
 
 # Be very strict when compiling with GCC as host compiler (and thus more lenient when compiling with
 # clang)
 if(CMAKE_COMPILER_IS_GNUCXX)
-  list(APPEND RAFT_CXX_FLAGS -Wall -Werror -Wno-unknown-pragmas -Wno-error=deprecated-declarations)
-  list(APPEND RAFT_CUDA_FLAGS -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations)
+  list(APPEND CUVS_CXX_FLAGS -Wall -Werror -Wno-unknown-pragmas -Wno-error=deprecated-declarations)
+  list(APPEND CUVS_CUDA_FLAGS -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations)
 
   # set warnings as errors
   if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.2.0)
-    list(APPEND RAFT_CUDA_FLAGS -Werror=all-warnings)
+    list(APPEND CUVS_CUDA_FLAGS -Werror=all-warnings)
   endif()
 endif()
 
 if(CUDA_LOG_COMPILE_TIME)
-  list(APPEND RAFT_CUDA_FLAGS "--time=nvcc_compile_log.csv")
+  list(APPEND CUVS_CUDA_FLAGS "--time=nvcc_compile_log.csv")
 endif()
 
-list(APPEND RAFT_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr)
-list(APPEND RAFT_CXX_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")
-list(APPEND RAFT_CUDA_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")
+list(APPEND CUVS_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr)
+list(APPEND CUVS_CXX_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")
+list(APPEND CUVS_CUDA_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")
 # make sure we produce smallest binary size
-list(APPEND RAFT_CUDA_FLAGS -Xfatbin=-compress-all)
+list(APPEND CUVS_CUDA_FLAGS -Xfatbin=-compress-all)
 
 # Option to enable line info in CUDA device compilation to allow introspection when profiling /
 # memchecking
 if(CUDA_ENABLE_LINEINFO)
-  list(APPEND RAFT_CUDA_FLAGS -lineinfo)
+  list(APPEND CUVS_CUDA_FLAGS -lineinfo)
 endif()
 
 if(OpenMP_FOUND)
-  list(APPEND RAFT_CUDA_FLAGS -Xcompiler=${OpenMP_CXX_FLAGS})
+  list(APPEND CUVS_CUDA_FLAGS -Xcompiler=${OpenMP_CXX_FLAGS})
 endif()
 
 # Debug options
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   message(VERBOSE "RAFT: Building with debugging flags")
-  list(APPEND RAFT_CUDA_FLAGS -G -Xcompiler=-rdynamic)
-  list(APPEND RAFT_CUDA_FLAGS -Xptxas --suppress-stack-size-warning)
+  list(APPEND CUVS_CUDA_FLAGS -G -Xcompiler=-rdynamic)
+  list(APPEND CUVS_CUDA_FLAGS -Xptxas --suppress-stack-size-warning)
 endif()

--- a/cpp/src/neighbors/ivf_pq_index.cpp
+++ b/cpp/src/neighbors/ivf_pq_index.cpp
@@ -47,13 +47,13 @@ index<IdxT>::index(raft::resources const& handle,
     pq_bits_(pq_bits),
     pq_dim_(pq_dim == 0 ? calculate_pq_dim(dim) : pq_dim),
     conservative_memory_allocation_(conservative_memory_allocation),
-    pq_centers_{raft::make_device_mdarray<float>(handle, make_pq_centers_extents())},
     lists_{n_lists},
-    rotation_matrix_{
-      raft::make_device_matrix<float, uint32_t>(handle, this->rot_dim(), this->dim())},
     list_sizes_{raft::make_device_vector<uint32_t, uint32_t>(handle, n_lists)},
+    pq_centers_{raft::make_device_mdarray<float>(handle, make_pq_centers_extents())},
     centers_{raft::make_device_matrix<float, uint32_t>(handle, n_lists, this->dim_ext())},
     centers_rot_{raft::make_device_matrix<float, uint32_t>(handle, n_lists, this->rot_dim())},
+    rotation_matrix_{
+      raft::make_device_matrix<float, uint32_t>(handle, this->rot_dim(), this->dim())},
     data_ptrs_{raft::make_device_vector<uint8_t*, uint32_t>(handle, n_lists)},
     inds_ptrs_{raft::make_device_vector<IdxT*, uint32_t>(handle, n_lists)},
     accum_sorted_sizes_{raft::make_host_vector<IdxT, uint32_t>(n_lists + 1)}

--- a/cpp/test/neighbors/ann_ivf_pq.cuh
+++ b/cpp/test/neighbors/ann_ivf_pq.cuh
@@ -354,8 +354,8 @@ class ivf_pq_test : public ::testing::TestWithParam<ivf_pq_inputs> {
                                   cuvs::Compare<uint8_t>{}));
 
     // Another test with the API that take list_data directly
-    auto list_data  = index->lists()[label]->data.view();
-    uint32_t n_take = 4;
+    [[maybe_unused]] auto list_data = index->lists()[label]->data.view();
+    uint32_t n_take                 = 4;
     ASSERT_TRUE(row_offset + n_take < n_rows);
     auto codes2 = raft::make_device_matrix<uint8_t>(handle_, n_take, index->pq_dim());
     ivf_pq::helpers::codepacker::unpack_list_data(


### PR DESCRIPTION
This makes sure that CUVS uses the compile flags that are required for RAPIDS C++ projects.