### PR TITLE
Fix rust docs build

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -40,10 +40,17 @@ pushd cpp/doxygen
 doxygen Doxyfile
 popd
 
+rapids-logger "Build Rust docs"
+pushd rust
+export LIBCLANG_PATH=$(dirname $(find /opt/conda -name libclang.so | head -n 1))
+cargo doc -p cuvs --no-deps
+popd
+
 rapids-logger "Build Python docs"
 pushd docs
 sphinx-build -b dirhtml source _html
 sphinx-build -b text source _text
+rsync -av ../rust/target/doc ./_html/_static/rust
 mkdir -p "${RAPIDS_DOCS_DIR}/cuvs/"{html,txt}
 mv _html/* "${RAPIDS_DOCS_DIR}/cuvs/html"
 mv _text/* "${RAPIDS_DOCS_DIR}/cuvs/txt"

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -50,7 +50,7 @@ rapids-logger "Build Python docs"
 pushd docs
 sphinx-build -b dirhtml source _html
 sphinx-build -b text source _text
-rsync -av ../rust/target/doc ./_html/_static/rust
+mv ../rust/target/doc ./_html/_static/rust
 mkdir -p "${RAPIDS_DOCS_DIR}/cuvs/"{html,txt}
 mv _html/* "${RAPIDS_DOCS_DIR}/cuvs/html"
 mv _text/* "${RAPIDS_DOCS_DIR}/cuvs/txt"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -47,6 +47,7 @@ files:
       - py_version
       - rust
       - build
+      - cuda
   rust:
     output: none
     includes:


### PR DESCRIPTION
The rust API docs aren't being generated on docs.rapids.ai/cuvs . While the `build.sh docs` script was including the rust api docs, the `ci/build_docs.sh` wasn't. Fix.

