### PR TITLE
Remove libnvjitlink dependency.

### DIFF
--- a/conda/environments/all_cuda-122_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-122_arch-aarch64.yaml
@@ -32,7 +32,6 @@ dependencies:
 - libcurand-dev
 - libcusolver-dev
 - libcusparse-dev
-- libnvjitlink
 - make
 - nccl>=2.9.9
 - ninja

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -32,7 +32,6 @@ dependencies:
 - libcurand-dev
 - libcusolver-dev
 - libcusparse-dev
-- libnvjitlink
 - make
 - nccl>=2.9.9
 - ninja

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -220,7 +220,6 @@ dependencies:
               - cuda-nvtx-dev
               - cuda-cudart-dev
               - cuda-profiler-api
-              - libnvjitlink
               - libcublas-dev
               - libcurand-dev
               - libcusolver-dev


### PR DESCRIPTION
PR #85 added a dependency on `libnvjitlink`. This was needed only temporarily, due to an issue with a particular build of `cupy`. This should be safe to remove.
