### PR TITLE
Fix rust api docs

### DIFF
--- a/docs/source/api_docs.rst
+++ b/docs/source/api_docs.rst
@@ -8,4 +8,4 @@ API Reference
    c_api.rst
    cpp_api.rst
    python_api.rst
-   rust_api.rst
+   rust_api/index.rst

--- a/docs/source/rust_api/index.rst
+++ b/docs/source/rust_api/index.rst
@@ -4,7 +4,7 @@ Rust API Documentation
 
 .. raw:: html
 
-    <iframe src="./_static/rust/cuvs/index.html" height="720px" width="100%"></iframe>
+    <iframe src="../_static/rust/cuvs/index.html" height="720px" width="100%"></iframe>
 
     <!-- hide the 'view source' section here, since it doesn't work with the iframe
     and we want the iframe to use the space -->


### PR DESCRIPTION
The rust api docs on docs.rapids.ai are deployed to https://docs.rapids.ai/api/cuvs/nightly/rust_api/index.html but the relative link in the iframe was assuming that these were at  https://docs.rapids.ai/api/cuvs/nightly/rust_api.html. (There seems to be some difference in the url structure depending on whether you build locally or not)

Fix by forcing the url structure to always be `rust_api/index.html`

