### PR TITLE
DOC: update notebook link

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@ Useful Resources
 
 .. _cuvs_reference: https://docs.rapids.ai/api/cuvs/stable/
 
-- `Example Notebooks <https://github.com/rapidsai/cuvs/tree/HEAD/exmples>`_: Self-contained Code examples
+- `Example Notebooks <https://github.com/rapidsai/cuvs/tree/branch-24.08/notebooks>`_: Self-contained Code examples
 - `RAPIDS Community <https://rapids.ai/community.html>`_: Get help, contribute, and collaborate.
 - `GitHub repository <https://github.com/rapidsai/cuvs>`_: Download the cuVS source code.
 - `Issue tracker <https://github.com/rapidsai/cuvs/issues>`_: Report issues or request features.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@ Useful Resources
 
 .. _cuvs_reference: https://docs.rapids.ai/api/cuvs/stable/
 
-- `Example Notebooks <https://github.com/rapidsai/cuvs/tree/branch-24.08/notebooks>`_: Self-contained Code examples
+- `Example Notebooks <https://github.com/rapidsai/cuvs/tree/HEAD/notebooks>`_: Self-contained Code examples
 - `RAPIDS Community <https://rapids.ai/community.html>`_: Get help, contribute, and collaborate.
 - `GitHub repository <https://github.com/rapidsai/cuvs>`_: Download the cuVS source code.
 - `Issue tracker <https://github.com/rapidsai/cuvs/issues>`_: Report issues or request features.


### PR DESCRIPTION
This updates the notebook link from https://github.com/rapidsai/cuvs/tree/HEAD/exmples (doesn't exist) to https://github.com/rapidsai/cuvs/tree/branch-24.08/notebooks