### PR TITLE
fix library name in docs ('cuvs' not 'pycuvs')

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ cuVS contains state-of-the-art implementations of several algorithms for running
 
 cuVS comes with pre-built packages that can be installed through [conda](https://conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-python). Different packages are available for the different languages supported by cuVS:
 
-| Python | C++ | C |
-|--------|-----|---|
-| `cuvs`| `libcuvs` | `libcuvs_c` |
+| Python | C/C++                       |
+|--------|-----------------------------|
+| `cuvs` | `libcuvs`, `libcuvs-static` |
 
 ### Stable release
 

--- a/README.md
+++ b/README.md
@@ -36,19 +36,21 @@ cuVS comes with pre-built packages that can be installed through [conda](https:/
 
 | Python | C++ | C |
 |--------|-----|---|
-| `pycuvs`| `libcuvs` | `libcuvs_c` |
+| `cuvs`| `libcuvs` | `libcuvs_c` |
 
 ### Stable release
 
-It is recommended to use [mamba](https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html) to install the desired packages. The following command will install the Python package. You can substitute `pycuvs` for any of the packages in the table above:
+It is recommended to use [mamba](https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html) to install the desired packages. The following command will install the Python package. You can substitute `cuvs` for any of the packages in the table above:
+
 ```bash
-mamba install -c conda-forge -c nvidia -c rapidsai pycuvs
+mamba install -c conda-forge -c nvidia -c rapidsai cuvs
 ```
 
 ### Nightlies
 If installing a version that has not yet been released, the `rapidsai` channel can be replaced with `rapidsai-nightly`:
+
 ```bash
-mamba install -c conda-forge -c nvidia -c rapidsai-nightly pycuvs=24.08
+mamba install -c conda-forge -c nvidia -c rapidsai-nightly cuvs=24.08
 ```
 
 Please see the [Build and Install Guide](docs/source/build.md) for more information on installing cuVS and building from source.

--- a/docs/source/build.rst
+++ b/docs/source/build.rst
@@ -50,7 +50,7 @@ C Package
 
 .. code-block:: bash
 
-    mamba install -c rapidsai -c conda-forge -c nvidia libcuvs_c cuda-version=12.0
+    mamba install -c rapidsai -c conda-forge -c nvidia libcuvs cuda-version=12.0
 
 Python Package
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
The Python library is distributed as conda package `cuvs`, but the installation docs say `pycuvs`. This fixes that.

Looked for other uses like this:

```shell
git grep -i pycuvs
```

Didn't find any.