### PR TITLE
skip CMake 3.30.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -12,7 +12,7 @@ dependencies:
 - clang
 - clang-tools=16.0.6
 - clang==16.0.6
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-nvtx=11.8
 - cuda-profiler-api=11.8.86
 - cuda-python>=11.7.1,<12.0a0

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -12,7 +12,7 @@ dependencies:
 - clang
 - clang-tools=16.0.6
 - clang==16.0.6
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-nvtx=11.8
 - cuda-profiler-api=11.8.86
 - cuda-python>=11.7.1,<12.0a0

--- a/conda/environments/all_cuda-122_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-122_arch-aarch64.yaml
@@ -12,7 +12,7 @@ dependencies:
 - clang
 - clang-tools=16.0.6
 - clang==16.0.6
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -12,7 +12,7 @@ dependencies:
 - clang
 - clang-tools=16.0.6
 - clang==16.0.6
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/recipes/cuvs/conda_build_config.yaml
+++ b/conda/recipes/cuvs/conda_build_config.yaml
@@ -17,4 +17,4 @@ c_stdlib_version:
   - "2.17"
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"

--- a/conda/recipes/libcuvs/conda_build_config.yaml
+++ b/conda/recipes/libcuvs/conda_build_config.yaml
@@ -17,7 +17,7 @@ c_stdlib_version:
   - "2.17"
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"
 
 nccl_version:
   - ">=2.9.9"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -111,7 +111,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &cmake_ver cmake>=3.26.4
+          - &cmake_ver cmake>=3.26.4,!=3.30.0
           - cython>=3.0.0
           - ninja
       - output_types: [conda]

--- a/python/cuvs/pyproject.toml
+++ b/python/cuvs/pyproject.toml
@@ -118,7 +118,7 @@ regex = "(?P<value>.*)"
 
 [tool.rapids-build-backend]
 requires = [
-    "cmake>=3.26.4",
+    "cmake>=3.26.4,!=3.30.0",
     "cuda-python",
     "cython>=3.0.0",
     "ninja",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/80

Adds constraints to avoid pulling in CMake 3.30.0, for the reasons described in that issue.
