### PR TITLE
Mark the rust brute force unittest as flaky

### DIFF
--- a/rust/cuvs/Cargo.toml
+++ b/rust/cuvs/Cargo.toml
@@ -14,3 +14,4 @@ ndarray = "0.15"
 
 [dev-dependencies]
 ndarray-rand = "0.14"
+mark-flaky-tests = "1"

--- a/rust/cuvs/src/brute_force.rs
+++ b/rust/cuvs/src/brute_force.rs
@@ -106,6 +106,7 @@ mod tests {
     use ndarray::s;
     use ndarray_rand::rand_distr::Uniform;
     use ndarray_rand::RandomExt;
+    use mark_flaky_tests::flaky;
 
     fn test_bfknn(metric: DistanceType) {
         let res = Resources::new().unwrap();
@@ -174,7 +175,7 @@ mod tests {
     }
 */
 
-    #[test]
+    #[flaky]
     fn test_l2() {
         test_bfknn(DistanceType::L2Expanded);
     }

--- a/rust/cuvs/src/distance/mod.rs
+++ b/rust/cuvs/src/distance/mod.rs
@@ -15,8 +15,6 @@
  */
 
 
-use std::io::{stderr, Write};
-
 use crate::distance_type::DistanceType;
 use crate::dlpack::ManagedTensor;
 use crate::error::{check_cuvs, Result};
@@ -55,7 +53,6 @@ pub fn pairwise_distance(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ndarray::s;
     use ndarray_rand::rand_distr::Uniform;
     use ndarray_rand::RandomExt;
 


### PR DESCRIPTION
The rust `brute_force::tests::test_l2` test can sometimes randomly fail (https://github.com/rapidsai/cuvs/issues/127).

We should figure out whats causing the test failure, but in the meantime - this PR marks the test as flaky using the `mark_flaky_tests` crate, which will retry the test 3 times and pass it if any of those runs succeed. 