### PR TITLE
Use `raft::util::popc(...)` public API

### DIFF
--- a/cpp/src/neighbors/detail/knn_brute_force.cuh
+++ b/cpp/src/neighbors/detail/knn_brute_force.cuh
@@ -28,8 +28,9 @@
 #include "./knn_utils.cuh"
 
 #include <raft/core/bitmap.cuh>
-#include <raft/core/detail/popc.cuh>
 #include <raft/core/device_csr_matrix.hpp>
+#include <raft/core/host_mdspan.hpp>
+#include <raft/core/popc.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resource/cuda_stream_pool.hpp>
 #include <raft/core/resource/device_memory_resource.hpp>
@@ -591,10 +592,12 @@ void brute_force_search_filtered(
   auto nnz_view = raft::make_device_scalar_view<IdxT>(nnz.data());
   auto filter_view =
     raft::make_device_vector_view<const BitmapT, IdxT>(filter.data(), filter.n_elements());
+  IdxT size_h    = n_queries * n_dataset;
+  auto size_view = raft::make_host_scalar_view<IdxT>(&size_h);
 
   // TODO(rhdong): Need to switch to the public API,
   // with the issue: https://github.com/rapidsai/cuvs/issues/158
-  raft::detail::popc(res, filter_view, n_queries * n_dataset, nnz_view);
+  raft::popc(res, filter_view, size_view, nnz_view);
   raft::copy(&nnz_h, nnz.data(), 1, stream);
 
   raft::resource::sync_stream(res, stream);

--- a/cpp/src/neighbors/detail/knn_brute_force.cuh
+++ b/cpp/src/neighbors/detail/knn_brute_force.cuh
@@ -595,7 +595,7 @@ void brute_force_search_filtered(
   IdxT size_h    = n_queries * n_dataset;
   auto size_view = raft::make_host_scalar_view<IdxT>(&size_h);
 
-  raft::util::popc(res, filter_view, size_view, nnz_view);
+  raft::popc(res, filter_view, size_view, nnz_view);
   raft::copy(&nnz_h, nnz.data(), 1, stream);
 
   raft::resource::sync_stream(res, stream);

--- a/cpp/src/neighbors/detail/knn_brute_force.cuh
+++ b/cpp/src/neighbors/detail/knn_brute_force.cuh
@@ -30,7 +30,6 @@
 #include <raft/core/bitmap.cuh>
 #include <raft/core/device_csr_matrix.hpp>
 #include <raft/core/host_mdspan.hpp>
-#include <raft/core/popc.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resource/cuda_stream_pool.hpp>
 #include <raft/core/resource/device_memory_resource.hpp>
@@ -47,6 +46,7 @@
 #include <raft/sparse/matrix/select_k.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+#include <raft/util/popc.cuh>
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/device_uvector.hpp>
@@ -597,7 +597,7 @@ void brute_force_search_filtered(
 
   // TODO(rhdong): Need to switch to the public API,
   // with the issue: https://github.com/rapidsai/cuvs/issues/158
-  raft::popc(res, filter_view, size_view, nnz_view);
+  raft::util::popc(res, filter_view, size_view, nnz_view);
   raft::copy(&nnz_h, nnz.data(), 1, stream);
 
   raft::resource::sync_stream(res, stream);

--- a/cpp/src/neighbors/detail/knn_brute_force.cuh
+++ b/cpp/src/neighbors/detail/knn_brute_force.cuh
@@ -595,8 +595,6 @@ void brute_force_search_filtered(
   IdxT size_h    = n_queries * n_dataset;
   auto size_view = raft::make_host_scalar_view<IdxT>(&size_h);
 
-  // TODO(rhdong): Need to switch to the public API,
-  // with the issue: https://github.com/rapidsai/cuvs/issues/158
   raft::util::popc(res, filter_view, size_view, nnz_view);
   raft::copy(&nnz_h, nnz.data(), 1, stream);
 

--- a/cpp/test/neighbors/brute_force_prefiltered.cu
+++ b/cpp/test/neighbors/brute_force_prefiltered.cu
@@ -198,8 +198,6 @@ class PrefilteredBruteForceTest
 
       set_bitmap(src, dst, bitmap, n_edges, n, stream);
 
-      // TODO(rhdong): Need to switch to the public API,
-      // with the issue: https://github.com/rapidsai/cuvs/issues/158
       raft::util::popc(handle, filter_view, size_view, nnz_view);
       raft::copy(&nnz_h, nnz.data(), 1, stream);
 

--- a/cpp/test/neighbors/brute_force_prefiltered.cu
+++ b/cpp/test/neighbors/brute_force_prefiltered.cu
@@ -21,12 +21,12 @@
 #include <cuvs/neighbors/brute_force.hpp>
 
 #include <raft/core/host_mdspan.hpp>
-#include <raft/core/popc.hpp>
 #include <raft/matrix/copy.cuh>
 #include <raft/random/make_blobs.cuh>
 #include <raft/random/rmat_rectangular_generator.cuh>
 #include <raft/random/rng.cuh>
 #include <raft/random/rng_state.hpp>
+#include <raft/util/popc.cuh>
 
 #include <gtest/gtest.h>
 
@@ -200,7 +200,7 @@ class PrefilteredBruteForceTest
 
       // TODO(rhdong): Need to switch to the public API,
       // with the issue: https://github.com/rapidsai/cuvs/issues/158
-      raft::popc(handle, filter_view, size_view, nnz_view);
+      raft::util::popc(handle, filter_view, size_view, nnz_view);
       raft::copy(&nnz_h, nnz.data(), 1, stream);
 
       raft::resource::sync_stream(handle, stream);

--- a/cpp/test/neighbors/brute_force_prefiltered.cu
+++ b/cpp/test/neighbors/brute_force_prefiltered.cu
@@ -198,7 +198,7 @@ class PrefilteredBruteForceTest
 
       set_bitmap(src, dst, bitmap, n_edges, n, stream);
 
-      raft::util::popc(handle, filter_view, size_view, nnz_view);
+      raft::popc(handle, filter_view, size_view, nnz_view);
       raft::copy(&nnz_h, nnz.data(), 1, stream);
 
       raft::resource::sync_stream(handle, stream);


### PR DESCRIPTION
https://github.com/rapidsai/raft/pull/2346 introduced a breaking change in the API. This PR fixes the API usage.