### PR TITLE
Remove fp16 kernels that have no public entry point

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -448,11 +448,11 @@ add_library(
   src/neighbors/nn_descent_int8.cu
   src/neighbors/nn_descent_uint8.cu
   src/neighbors/refine/detail/refine_device_float_float.cu
-  # src/neighbors/refine/detail/refine_device_half_float.cu
+  src/neighbors/refine/detail/refine_device_half_float.cu
   src/neighbors/refine/detail/refine_device_int8_t_float.cu
   src/neighbors/refine/detail/refine_device_uint8_t_float.cu
   src/neighbors/refine/detail/refine_host_float_float.cpp
-  # src/neighbors/refine/detail/refine_host_half_float.cpp
+  src/neighbors/refine/detail/refine_host_half_float.cpp
   src/neighbors/refine/detail/refine_host_int8_t_float.cpp
   src/neighbors/refine/detail/refine_host_uint8_t_float.cpp
   src/neighbors/sample_filter.cu

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -458,7 +458,7 @@ add_library(
   src/neighbors/sample_filter.cu
   src/selection/select_k_float_int64_t.cu
   src/selection/select_k_float_uint32_t.cu
-  # src/selection/select_k_half_uint32_t.cu
+  src/selection/select_k_half_uint32_t.cu
 )
 
 target_compile_options(

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -268,14 +268,6 @@ add_library(
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint32_dim512_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint32_dim1024_t32_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint32_dim1024_t32_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim128_t8_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim128_t8_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim256_t16_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim256_t16_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim512_t32_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim512_t32_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim1024_t32_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim1024_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_int8_uint32_dim128_t8_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_int8_uint32_dim128_t8_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_int8_uint32_dim256_t16_8pq_2subd_half.cu
@@ -300,14 +292,6 @@ add_library(
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint64_dim512_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint64_dim1024_t32_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint64_dim1024_t32_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim128_t8_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim128_t8_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim256_t16_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim256_t16_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim512_t32_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim512_t32_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim1024_t32_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim1024_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim128_t8_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim128_t8_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim256_t16_8pq_2subd_half.cu
@@ -316,14 +300,6 @@ add_library(
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim512_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim1024_t32_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim1024_t32_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim128_t8_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim128_t8_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim256_t16_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim256_t16_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim512_t32_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim512_t32_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim1024_t32_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim1024_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_int8_uint32_dim128_t8_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_int8_uint32_dim128_t8_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_int8_uint32_dim256_t16_8pq_2subd_half.cu
@@ -348,22 +324,10 @@ add_library(
   src/neighbors/detail/cagra/q_search_single_cta_float_uint64_dim512_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint64_dim1024_t32_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint64_dim1024_t32_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim128_t8_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim128_t8_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim256_t16_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim256_t16_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim512_t32_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim512_t32_8pq_4subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim1024_t32_8pq_2subd_half.cu
-  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim1024_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint32_dim128_t8.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint32_dim256_t16.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint32_dim512_t32.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint32_dim1024_t32.cu
-  # src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim128_t8.cu
-  # src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim256_t16.cu
-  # src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim512_t32.cu
-  # src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim1024_t32.cu
   src/neighbors/detail/cagra/search_multi_cta_int8_uint32_dim128_t8.cu
   src/neighbors/detail/cagra/search_multi_cta_int8_uint32_dim256_t16.cu
   src/neighbors/detail/cagra/search_multi_cta_int8_uint32_dim512_t32.cu
@@ -376,18 +340,10 @@ add_library(
   src/neighbors/detail/cagra/search_multi_cta_float_uint64_dim256_t16.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint64_dim512_t32.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint64_dim1024_t32.cu
-  # src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim128_t8.cu
-  # src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim256_t16.cu
-  # src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim512_t32.cu
-  # src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim1024_t32.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint32_dim128_t8.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint32_dim256_t16.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint32_dim512_t32.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint32_dim1024_t32.cu
-  # src/neighbors/detail/cagra/search_single_cta_half_uint32_dim128_t8.cu
-  # src/neighbors/detail/cagra/search_single_cta_half_uint32_dim256_t16.cu
-  # src/neighbors/detail/cagra/search_single_cta_half_uint32_dim512_t32.cu
-  # src/neighbors/detail/cagra/search_single_cta_half_uint32_dim1024_t32.cu
   src/neighbors/detail/cagra/search_single_cta_int8_uint32_dim128_t8.cu
   src/neighbors/detail/cagra/search_single_cta_int8_uint32_dim256_t16.cu
   src/neighbors/detail/cagra/search_single_cta_int8_uint32_dim512_t32.cu
@@ -400,10 +356,6 @@ add_library(
   src/neighbors/detail/cagra/search_single_cta_float_uint64_dim256_t16.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint64_dim512_t32.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint64_dim1024_t32.cu
-  # src/neighbors/detail/cagra/search_single_cta_half_uint64_dim128_t8.cu
-  # src/neighbors/detail/cagra/search_single_cta_half_uint64_dim256_t16.cu
-  # src/neighbors/detail/cagra/search_single_cta_half_uint64_dim512_t32.cu
-  # src/neighbors/detail/cagra/search_single_cta_half_uint64_dim1024_t32.cu
   $<$<BOOL:${BUILD_CAGRA_HNSWLIB}>:src/neighbors/hnsw.cpp>
   src/neighbors/ivf_flat_index.cpp
   src/neighbors/ivf_flat/ivf_flat_build_extend_float_int64_t.cu

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -268,14 +268,14 @@ add_library(
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint32_dim512_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint32_dim1024_t32_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint32_dim1024_t32_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim128_t8_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim128_t8_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim256_t16_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim256_t16_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim512_t32_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim512_t32_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim1024_t32_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim1024_t32_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim128_t8_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim128_t8_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim256_t16_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim256_t16_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim512_t32_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim512_t32_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim1024_t32_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint32_dim1024_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_int8_uint32_dim128_t8_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_int8_uint32_dim128_t8_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_int8_uint32_dim256_t16_8pq_2subd_half.cu
@@ -300,14 +300,14 @@ add_library(
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint64_dim512_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint64_dim1024_t32_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_multi_cta_float_uint64_dim1024_t32_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim128_t8_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim128_t8_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim256_t16_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim256_t16_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim512_t32_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim512_t32_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim1024_t32_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim1024_t32_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim128_t8_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim128_t8_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim256_t16_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim256_t16_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim512_t32_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim512_t32_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim1024_t32_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_multi_cta_half_uint64_dim1024_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim128_t8_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim128_t8_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim256_t16_8pq_2subd_half.cu
@@ -316,14 +316,14 @@ add_library(
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim512_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim1024_t32_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint32_dim1024_t32_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim128_t8_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim128_t8_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim256_t16_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim256_t16_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim512_t32_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim512_t32_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim1024_t32_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim1024_t32_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim128_t8_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim128_t8_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim256_t16_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim256_t16_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim512_t32_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim512_t32_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim1024_t32_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint32_dim1024_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_int8_uint32_dim128_t8_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_int8_uint32_dim128_t8_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_int8_uint32_dim256_t16_8pq_2subd_half.cu
@@ -348,22 +348,22 @@ add_library(
   src/neighbors/detail/cagra/q_search_single_cta_float_uint64_dim512_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint64_dim1024_t32_8pq_2subd_half.cu
   src/neighbors/detail/cagra/q_search_single_cta_float_uint64_dim1024_t32_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim128_t8_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim128_t8_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim256_t16_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim256_t16_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim512_t32_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim512_t32_8pq_4subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim1024_t32_8pq_2subd_half.cu
-  src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim1024_t32_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim128_t8_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim128_t8_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim256_t16_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim256_t16_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim512_t32_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim512_t32_8pq_4subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim1024_t32_8pq_2subd_half.cu
+  # src/neighbors/detail/cagra/q_search_single_cta_half_uint64_dim1024_t32_8pq_4subd_half.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint32_dim128_t8.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint32_dim256_t16.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint32_dim512_t32.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint32_dim1024_t32.cu
-  src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim128_t8.cu
-  src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim256_t16.cu
-  src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim512_t32.cu
-  src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim1024_t32.cu
+  # src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim128_t8.cu
+  # src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim256_t16.cu
+  # src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim512_t32.cu
+  # src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim1024_t32.cu
   src/neighbors/detail/cagra/search_multi_cta_int8_uint32_dim128_t8.cu
   src/neighbors/detail/cagra/search_multi_cta_int8_uint32_dim256_t16.cu
   src/neighbors/detail/cagra/search_multi_cta_int8_uint32_dim512_t32.cu
@@ -376,18 +376,18 @@ add_library(
   src/neighbors/detail/cagra/search_multi_cta_float_uint64_dim256_t16.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint64_dim512_t32.cu
   src/neighbors/detail/cagra/search_multi_cta_float_uint64_dim1024_t32.cu
-  src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim128_t8.cu
-  src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim256_t16.cu
-  src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim512_t32.cu
-  src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim1024_t32.cu
+  # src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim128_t8.cu
+  # src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim256_t16.cu
+  # src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim512_t32.cu
+  # src/neighbors/detail/cagra/search_multi_cta_half_uint64_dim1024_t32.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint32_dim128_t8.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint32_dim256_t16.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint32_dim512_t32.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint32_dim1024_t32.cu
-  src/neighbors/detail/cagra/search_single_cta_half_uint32_dim128_t8.cu
-  src/neighbors/detail/cagra/search_single_cta_half_uint32_dim256_t16.cu
-  src/neighbors/detail/cagra/search_single_cta_half_uint32_dim512_t32.cu
-  src/neighbors/detail/cagra/search_single_cta_half_uint32_dim1024_t32.cu
+  # src/neighbors/detail/cagra/search_single_cta_half_uint32_dim128_t8.cu
+  # src/neighbors/detail/cagra/search_single_cta_half_uint32_dim256_t16.cu
+  # src/neighbors/detail/cagra/search_single_cta_half_uint32_dim512_t32.cu
+  # src/neighbors/detail/cagra/search_single_cta_half_uint32_dim1024_t32.cu
   src/neighbors/detail/cagra/search_single_cta_int8_uint32_dim128_t8.cu
   src/neighbors/detail/cagra/search_single_cta_int8_uint32_dim256_t16.cu
   src/neighbors/detail/cagra/search_single_cta_int8_uint32_dim512_t32.cu
@@ -400,10 +400,10 @@ add_library(
   src/neighbors/detail/cagra/search_single_cta_float_uint64_dim256_t16.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint64_dim512_t32.cu
   src/neighbors/detail/cagra/search_single_cta_float_uint64_dim1024_t32.cu
-  src/neighbors/detail/cagra/search_single_cta_half_uint64_dim128_t8.cu
-  src/neighbors/detail/cagra/search_single_cta_half_uint64_dim256_t16.cu
-  src/neighbors/detail/cagra/search_single_cta_half_uint64_dim512_t32.cu
-  src/neighbors/detail/cagra/search_single_cta_half_uint64_dim1024_t32.cu
+  # src/neighbors/detail/cagra/search_single_cta_half_uint64_dim128_t8.cu
+  # src/neighbors/detail/cagra/search_single_cta_half_uint64_dim256_t16.cu
+  # src/neighbors/detail/cagra/search_single_cta_half_uint64_dim512_t32.cu
+  # src/neighbors/detail/cagra/search_single_cta_half_uint64_dim1024_t32.cu
   $<$<BOOL:${BUILD_CAGRA_HNSWLIB}>:src/neighbors/hnsw.cpp>
   src/neighbors/ivf_flat_index.cpp
   src/neighbors/ivf_flat/ivf_flat_build_extend_float_int64_t.cu
@@ -448,17 +448,17 @@ add_library(
   src/neighbors/nn_descent_int8.cu
   src/neighbors/nn_descent_uint8.cu
   src/neighbors/refine/detail/refine_device_float_float.cu
-  src/neighbors/refine/detail/refine_device_half_float.cu
+  # src/neighbors/refine/detail/refine_device_half_float.cu
   src/neighbors/refine/detail/refine_device_int8_t_float.cu
   src/neighbors/refine/detail/refine_device_uint8_t_float.cu
   src/neighbors/refine/detail/refine_host_float_float.cpp
-  src/neighbors/refine/detail/refine_host_half_float.cpp
+  # src/neighbors/refine/detail/refine_host_half_float.cpp
   src/neighbors/refine/detail/refine_host_int8_t_float.cpp
   src/neighbors/refine/detail/refine_host_uint8_t_float.cpp
   src/neighbors/sample_filter.cu
   src/selection/select_k_float_int64_t.cu
   src/selection/select_k_float_uint32_t.cu
-  src/selection/select_k_half_uint32_t.cu
+  # src/selection/select_k_half_uint32_t.cu
 )
 
 target_compile_options(


### PR DESCRIPTION
`libcuvs.so` contains fp16 kernels that are not accessible (missing headers and missing public entry points). This PR removes the unused kernel.