### PR TITLE
Fix python ivf-pq for int8/uint8 dtypes

### DIFF
--- a/cpp/src/neighbors/ivf_pq_c.cpp
+++ b/cpp/src/neighbors/ivf_pq_c.cpp
@@ -30,7 +30,7 @@
 
 namespace {
 
-template <typename IdxT>
+template <typename T, typename IdxT>
 void* _build(cuvsResources_t res, cuvsIvfPqIndexParams params, DLManagedTensor* dataset_tensor)
 {
   auto res_ptr = reinterpret_cast<raft::resources*>(res);
@@ -54,7 +54,7 @@ void* _build(cuvsResources_t res, cuvsIvfPqIndexParams params, DLManagedTensor* 
 
   auto index = new cuvs::neighbors::ivf_pq::index<IdxT>(*res_ptr, build_params, dim);
 
-  using mdspan_type = raft::device_matrix_view<float const, IdxT, raft::row_major>;
+  using mdspan_type = raft::device_matrix_view<const T, IdxT, raft::row_major>;
   auto mds          = cuvs::core::from_dlpack<mdspan_type>(dataset_tensor);
 
   cuvs::neighbors::ivf_pq::build(*res_ptr, build_params, mds, index);
@@ -62,7 +62,7 @@ void* _build(cuvsResources_t res, cuvsIvfPqIndexParams params, DLManagedTensor* 
   return index;
 }
 
-template <typename IdxT>
+template <typename T, typename IdxT>
 void _search(cuvsResources_t res,
              cuvsIvfPqSearchParams params,
              cuvsIvfPqIndex index,
@@ -79,7 +79,7 @@ void _search(cuvsResources_t res,
   search_params.internal_distance_dtype  = params.internal_distance_dtype;
   search_params.preferred_shmem_carveout = params.preferred_shmem_carveout;
 
-  using queries_mdspan_type   = raft::device_matrix_view<float const, IdxT, raft::row_major>;
+  using queries_mdspan_type   = raft::device_matrix_view<const T, IdxT, raft::row_major>;
   using neighbors_mdspan_type = raft::device_matrix_view<IdxT, IdxT, raft::row_major>;
   using distances_mdspan_type = raft::device_matrix_view<float, IdxT, raft::row_major>;
   auto queries_mds            = cuvs::core::from_dlpack<queries_mdspan_type>(queries_tensor);
@@ -107,7 +107,7 @@ void* _deserialize(cuvsResources_t res, const char* filename)
   return index;
 }
 
-template <typename IdxT>
+template <typename T, typename IdxT>
 void _extend(cuvsResources_t res,
              DLManagedTensor* new_vectors,
              DLManagedTensor* new_indices,
@@ -115,7 +115,7 @@ void _extend(cuvsResources_t res,
 {
   auto res_ptr              = reinterpret_cast<raft::resources*>(res);
   auto index_ptr            = reinterpret_cast<cuvs::neighbors::ivf_pq::index<IdxT>*>(index.addr);
-  using vectors_mdspan_type = raft::device_matrix_view<float const, IdxT, raft::row_major>;
+  using vectors_mdspan_type = raft::device_matrix_view<const T, IdxT, raft::row_major>;
   using indices_mdspan_type = raft::device_vector_view<IdxT, IdxT>;
 
   auto vectors_mds = cuvs::core::from_dlpack<vectors_mdspan_type>(new_vectors);
@@ -147,14 +147,19 @@ extern "C" cuvsError_t cuvsIvfPqBuild(cuvsResources_t res,
                                       cuvsIvfPqIndex_t index)
 {
   return cuvs::core::translate_exceptions([=] {
-    auto dataset = dataset_tensor->dl_tensor;
+    auto dataset      = dataset_tensor->dl_tensor;
+    index->dtype.code = dataset.dtype.code;
+    index->dtype.bits = dataset.dtype.bits;
 
-    if ((dataset.dtype.code == kDLFloat && dataset.dtype.bits == 32) ||
-        (dataset.dtype.code == kDLInt && dataset.dtype.bits == 8) ||
-        (dataset.dtype.code == kDLUInt && dataset.dtype.bits == 8)) {
-      index->addr = reinterpret_cast<uintptr_t>(_build<int64_t>(res, *params, dataset_tensor));
-      index->dtype.code = dataset.dtype.code;
-      index->dtype.bits = dataset.dtype.bits;
+    if (dataset.dtype.code == kDLFloat && dataset.dtype.bits == 32) {
+      index->addr =
+        reinterpret_cast<uintptr_t>(_build<float, int64_t>(res, *params, dataset_tensor));
+    } else if (dataset.dtype.code == kDLInt && dataset.dtype.bits == 8) {
+      index->addr =
+        reinterpret_cast<uintptr_t>(_build<int8_t, int64_t>(res, *params, dataset_tensor));
+    } else if (dataset.dtype.code == kDLUInt && dataset.dtype.bits == 8) {
+      index->addr =
+        reinterpret_cast<uintptr_t>(_build<uint8_t, int64_t>(res, *params, dataset_tensor));
     } else {
       RAFT_FAIL("Unsupported dataset DLtensor dtype: %d and bits: %d",
                 dataset.dtype.code,
@@ -188,11 +193,15 @@ extern "C" cuvsError_t cuvsIvfPqSearch(cuvsResources_t res,
                  "distances should be of type float32");
 
     auto index = *index_c_ptr;
-
-    if ((queries.dtype.code == kDLFloat && queries.dtype.bits == 32) ||
-        (queries.dtype.code == kDLInt && queries.dtype.bits == 8) ||
-        (queries.dtype.code == kDLUInt && queries.dtype.bits == 8)) {
-      _search<int64_t>(res, *params, index, queries_tensor, neighbors_tensor, distances_tensor);
+    if (queries.dtype.code == kDLFloat && queries.dtype.bits == 32) {
+      _search<float, int64_t>(
+        res, *params, index, queries_tensor, neighbors_tensor, distances_tensor);
+    } else if (queries.dtype.code == kDLInt && queries.dtype.bits == 8) {
+      _search<int8_t, int64_t>(
+        res, *params, index, queries_tensor, neighbors_tensor, distances_tensor);
+    } else if (queries.dtype.code == kDLUInt && queries.dtype.bits == 8) {
+      _search<uint8_t, int64_t>(
+        res, *params, index, queries_tensor, neighbors_tensor, distances_tensor);
     } else {
       RAFT_FAIL("Unsupported queries DLtensor dtype: %d and bits: %d",
                 queries.dtype.code,
@@ -260,10 +269,13 @@ extern "C" cuvsError_t cuvsIvfPqExtend(cuvsResources_t res,
 {
   return cuvs::core::translate_exceptions([=] {
     auto vectors = new_vectors->dl_tensor;
-    if ((vectors.dtype.code == kDLFloat && vectors.dtype.bits == 32) ||
-        (vectors.dtype.code == kDLInt && vectors.dtype.bits == 8) ||
-        (vectors.dtype.code == kDLUInt && vectors.dtype.bits == 8)) {
-      _extend<int64_t>(res, new_vectors, new_indices, *index);
+
+    if (vectors.dtype.code == kDLFloat && vectors.dtype.bits == 32) {
+      _extend<float, int64_t>(res, new_vectors, new_indices, *index);
+    } else if (vectors.dtype.code == kDLInt && vectors.dtype.bits == 8) {
+      _extend<int8_t, int64_t>(res, new_vectors, new_indices, *index);
+    } else if (vectors.dtype.code == kDLUInt && vectors.dtype.bits == 8) {
+      _extend<uint8_t, int64_t>(res, new_vectors, new_indices, *index);
     } else {
       RAFT_FAIL("Unsupported index dtype: %d and bits: %d", vectors.dtype.code, vectors.dtype.bits);
     }

--- a/python/cuvs/cuvs/test/test_ivf_pq.py
+++ b/python/cuvs/cuvs/test/test_ivf_pq.py
@@ -192,3 +192,12 @@ def test_extend(dtype):
         dtype=dtype,
         add_data_on_build=False,
     )
+
+
+@pytest.mark.parametrize("inplace", [True, False])
+@pytest.mark.parametrize("dtype", [np.float32, np.int8, np.uint8])
+def test_ivf_pq_dtype(inplace, dtype):
+    run_ivf_pq_build_search_test(
+        dtype=dtype,
+        inplace=inplace,
+    )


### PR DESCRIPTION
The ivf-pq python bindings weren't working appropriately for int8/uint8 dtypes. Fix.
