### PR TITLE
Fix broken examples link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cagra::index_params index_params;
 auto index = cagra::build(res, index_params, dataset);
 ```
 
-For more example of the C++ APIs, refer to [cpp/examples](https://github.com/rapidsai/cuvs/tree/HEAD/cpp/examples) directory in the codebase.
+For more examples of the C++ APIs, refer to the [examples](https://github.com/rapidsai/cuvs/tree/HEAD/examples) directory in the codebase.
 
 ### C API
 


### PR DESCRIPTION
Fixes a broken link to the examples in the README.
