### PR TITLE
fix style checks on Python 3.12

### DIFF
--- a/python/cuvs/cuvs/test/test_doctests.py
+++ b/python/cuvs/cuvs/test/test_doctests.py
@@ -100,7 +100,7 @@ DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.distance))
 
 def _test_name_from_docstring(docstring):
     filename = Path(docstring.filename).name.split(".")[0]
-    return f"{filename}:{docstring.name}"
+    return f"{filename}:{docstring.name}"  # noqa: E231
 
 
 @pytest.mark.parametrize(
@@ -121,5 +121,5 @@ def test_docstring(docstring):
         results = runner.summarize()
     assert not results.failed, (
         f"{results.failed} of {results.attempted} doctests failed for "
-        f"{docstring.name}:\n{doctest_stdout.getvalue()}"
+        f"{docstring.name}:\n{doctest_stdout.getvalue()}"  # noqa: E231
     )


### PR DESCRIPTION
After merging https://github.com/rapidsai/ci-imgs/pull/188, style checks here started breaking like this:

```text
python/cuvs/cuvs/test/test_doctests.py:103:24: E231 missing whitespace after ':'
python/cuvs/cuvs/test/test_doctests.py:124:27: E231 missing whitespace after ':'
```

([build link](https://github.com/rapidsai/cuvs/actions/runs/10905609739/job/30264867507?pr=325))

Looks like both of those are false positives (we really do intend to not have a space after the `:` on those lines). This proposes ignoring them with `#noqa` comments.