### PR TITLE
WIP: [DO NOT MERGE] Update fmt (to 11.0.2) and spdlog (to 1.14.1).

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,91 +12,91 @@ concurrency:
 jobs:
   pr-builder:
     needs:
-      - checks
+      # - checks
       - conda-cpp-build
-      - conda-cpp-tests
-      - conda-cpp-checks
+      # - conda-cpp-tests
+      # - conda-cpp-checks
       - conda-python-build
-      - conda-python-tests
-      - docs-build
-      - rust-build
+      # - conda-python-tests
+      # - docs-build
+      # - rust-build
       - wheel-build-cuvs
-      - wheel-tests-cuvs
+      # - wheel-tests-cuvs
       - devcontainer
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
-  checks:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
-    with:
-      enable_check_generated_files: false
+  # checks:
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
+  #   with:
+  #     enable_check_generated_files: false
   conda-cpp-build:
-    needs: checks
+    # needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-24.10
     with:
       build_type: pull-request
       node_type: cpu16
-  conda-cpp-tests:
-    needs: conda-cpp-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-24.10
-    with:
-      build_type: pull-request
-  conda-cpp-checks:
-    needs: conda-cpp-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      enable_check_symbols: true
-      symbol_exclusions: (void (thrust::|cub::)|raft_cutlass)
+  # conda-cpp-tests:
+  #   needs: conda-cpp-build
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  # conda-cpp-checks:
+  #   needs: conda-cpp-build
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     enable_check_symbols: true
+  #     symbol_exclusions: (void (thrust::|cub::)|raft_cutlass)
   conda-python-build:
     needs: conda-cpp-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.10
     with:
       build_type: pull-request
-  conda-python-tests:
-    needs: conda-python-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
-    with:
-      build_type: pull-request
-  docs-build:
-    needs: conda-python-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      node_type: "gpu-v100-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_docs.sh"
-  rust-build:
-    needs: conda-cpp-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      node_type: "gpu-v100-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_rust.sh"
+  # conda-python-tests:
+  #   needs: conda-python-build
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  # docs-build:
+  #   needs: conda-python-build
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-v100-latest-1"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:latest"
+  #     run_script: "ci/build_docs.sh"
+  # rust-build:
+  #   needs: conda-cpp-build
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-v100-latest-1"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:latest"
+  #     run_script: "ci/build_rust.sh"
   wheel-build-cuvs:
-    needs: checks
+    # needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
     with:
       build_type: pull-request
       script: ci/build_wheel_cuvs.sh
-  wheel-tests-cuvs:
-    needs: wheel-build-cuvs
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      script: ci/test_wheel_cuvs.sh
+  # wheel-tests-cuvs:
+  #   needs: wheel-build-cuvs
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_wheel_cuvs.sh
   devcontainer:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-24.10

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,91 +12,91 @@ concurrency:
 jobs:
   pr-builder:
     needs:
-      # - checks
+      - checks
       - conda-cpp-build
-      # - conda-cpp-tests
-      # - conda-cpp-checks
+      - conda-cpp-tests
+      - conda-cpp-checks
       - conda-python-build
-      # - conda-python-tests
-      # - docs-build
-      # - rust-build
+      - conda-python-tests
+      - docs-build
+      - rust-build
       - wheel-build-cuvs
-      # - wheel-tests-cuvs
+      - wheel-tests-cuvs
       - devcontainer
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
-  # checks:
-  #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
-  #   with:
-  #     enable_check_generated_files: false
+  checks:
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
+    with:
+      enable_check_generated_files: false
   conda-cpp-build:
-    # needs: checks
+    needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-24.10
     with:
       build_type: pull-request
       node_type: cpu16
-  # conda-cpp-tests:
-  #   needs: conda-cpp-build
-  #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-24.10
-  #   with:
-  #     build_type: pull-request
-  # conda-cpp-checks:
-  #   needs: conda-cpp-build
-  #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@branch-24.10
-  #   with:
-  #     build_type: pull-request
-  #     enable_check_symbols: true
-  #     symbol_exclusions: (void (thrust::|cub::)|raft_cutlass)
+  conda-cpp-tests:
+    needs: conda-cpp-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-24.10
+    with:
+      build_type: pull-request
+  conda-cpp-checks:
+    needs: conda-cpp-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@branch-24.10
+    with:
+      build_type: pull-request
+      enable_check_symbols: true
+      symbol_exclusions: (void (thrust::|cub::)|raft_cutlass)
   conda-python-build:
     needs: conda-cpp-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.10
     with:
       build_type: pull-request
-  # conda-python-tests:
-  #   needs: conda-python-build
-  #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
-  #   with:
-  #     build_type: pull-request
-  # docs-build:
-  #   needs: conda-python-build
-  #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
-  #   with:
-  #     build_type: pull-request
-  #     node_type: "gpu-v100-latest-1"
-  #     arch: "amd64"
-  #     container_image: "rapidsai/ci-conda:latest"
-  #     run_script: "ci/build_docs.sh"
-  # rust-build:
-  #   needs: conda-cpp-build
-  #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
-  #   with:
-  #     build_type: pull-request
-  #     node_type: "gpu-v100-latest-1"
-  #     arch: "amd64"
-  #     container_image: "rapidsai/ci-conda:latest"
-  #     run_script: "ci/build_rust.sh"
+  conda-python-tests:
+    needs: conda-python-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
+    with:
+      build_type: pull-request
+  docs-build:
+    needs: conda-python-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+    with:
+      build_type: pull-request
+      node_type: "gpu-v100-latest-1"
+      arch: "amd64"
+      container_image: "rapidsai/ci-conda:latest"
+      run_script: "ci/build_docs.sh"
+  rust-build:
+    needs: conda-cpp-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+    with:
+      build_type: pull-request
+      node_type: "gpu-v100-latest-1"
+      arch: "amd64"
+      container_image: "rapidsai/ci-conda:latest"
+      run_script: "ci/build_rust.sh"
   wheel-build-cuvs:
-    # needs: checks
+    needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
     with:
       build_type: pull-request
       script: ci/build_wheel_cuvs.sh
-  # wheel-tests-cuvs:
-  #   needs: wheel-build-cuvs
-  #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
-  #   with:
-  #     build_type: pull-request
-  #     script: ci/test_wheel_cuvs.sh
+  wheel-tests-cuvs:
+    needs: wheel-build-cuvs
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+    with:
+      build_type: pull-request
+      script: ci/test_wheel_cuvs.sh
   devcontainer:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-24.10

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -11,6 +11,9 @@ source rapids-date-string
 
 export CMAKE_GENERATOR=Ninja
 
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
+source ./ci/use_conda_packages_from_prs.sh
+
 rapids-print-env
 
 rapids-logger "Begin cpp build"

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -11,6 +11,9 @@ source rapids-date-string
 
 export CMAKE_GENERATOR=Ninja
 
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
+source ./ci/use_conda_packages_from_prs.sh
+
 rapids-print-env
 
 rapids-logger "Begin py build"

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -12,6 +12,8 @@ source rapids-date-string
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
+source ./ci/use_wheels_from_prs.sh
+
 rapids-generate-version > ./VERSION
 
 cd "${package_dir}"

--- a/ci/build_wheel_cuvs.sh
+++ b/ci/build_wheel_cuvs.sh
@@ -12,6 +12,8 @@ case "${RAPIDS_CUDA_VERSION}" in
   ;;
 esac
 
+source ./ci/use_wheels_from_prs.sh
+
 # Set up skbuild options. Enable sccache in skbuild config options
 export SKBUILD_CMAKE_ARGS="-DDETECT_CONDA_ENV=OFF;-DFIND_CUVS_CPP=OFF${EXTRA_CMAKE_ARGS}"
 

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 . /opt/conda/etc/profile.d/conda.sh
+source ./ci/use_conda_packages_from_prs.sh
 
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 . /opt/conda/etc/profile.d/conda.sh
+source ./ci/use_conda_packages_from_prs.sh
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_wheel_cuvs.sh
+++ b/ci/test_wheel_cuvs.sh
@@ -7,6 +7,8 @@ mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 RAPIDS_PY_WHEEL_NAME="cuvs_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
 
+source ./ci/use_wheels_from_prs.sh
+
 # echo to expand wildcard before adding `[extra]` requires for pip
 python -m pip install $(echo ./dist/cuvs*.whl)[test]
 

--- a/ci/use_conda_packages_from_prs.sh
+++ b/ci/use_conda_packages_from_prs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+LIBRMM_CHANNEL=$(rapids-get-pr-conda-artifact rmm 1678 cpp)
+RMM_CHANNEL=$(rapids-get-pr-conda-artifact rmm 1678 python)
+
+CUDF_CPP_CHANNEL=$(rapids-get-pr-conda-artifact cudf 16806 cpp)
+CUDF_PYTHON_CHANNEL=$(rapids-get-pr-conda-artifact cudf 16806 python)
+
+UCXX_CHANNEL=$(rapids-get-pr-conda-artifact ucxx 278 cpp)
+
+LIBRAFT_CHANNEL=$(rapids-get-pr-conda-artifact raft 2433 cpp)
+RAFT_CHANNEL=$(rapids-get-pr-conda-artifact raft 2433 python)
+
+conda config --system --add channels "${LIBRMM_CHANNEL}"
+conda config --system --add channels "${RMM_CHANNEL}"
+conda config --system --add channels "${CUDF_CPP_CHANNEL}"
+conda config --system --add channels "${CUDF_PYTHON_CHANNEL}"
+conda config --system --add channels "${UCXX_CHANNEL}"
+conda config --system --add channels "${LIBRAFT_CHANNEL}"
+conda config --system --add channels "${RAFT_CHANNEL}"

--- a/ci/use_wheels_from_prs.sh
+++ b/ci/use_wheels_from_prs.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+
+LIBRMM_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=rmm_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact rmm 1678 cpp
+)
+RMM_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=rmm_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact rmm 1678 python
+)
+
+UCXX_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=ucxx_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact ucxx 278 python
+)
+LIBUCXX_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=libucxx_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact ucxx 278 cpp
+)
+DISTRIBUTED_UCXX_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=distributed_ucxx_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact ucxx 278 python
+)
+
+CUDF_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=cudf_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact cudf 16806 python
+)
+LIBCUDF_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=libcudf_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact cudf 16806 cpp
+)
+PYLIBCUDF_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=pylibcudf_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact cudf 16806 python
+)
+DASK_CUDF_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=dask_cudf_${RAPIDS_PY_CUDA_SUFFIX} \
+  RAPIDS_PY_WHEEL_PURE=1 \
+    rapids-get-pr-wheel-artifact cudf 16806 python
+)
+
+RAFT_DASK_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=raft_dask_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact raft 2433 python
+)
+PYLIBRAFT_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=pylibraft_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact raft 2433 python
+)
+
+cat > /tmp/constraints.txt <<EOF
+librmm-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${LIBRMM_CHANNEL}/librmm_*.whl)
+rmm-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${RMM_CHANNEL}/rmm_*.whl)
+cudf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${CUDF_CHANNEL}/cudf_*.whl)
+libcudf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${LIBCUDF_CHANNEL}/libcudf_*.whl)
+pylibcudf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${PYLIBCUDF_CHANNEL}/pylibcudf_*.whl)
+dask-cudf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${DASK_CUDF_CHANNEL}/dask_cudf_*.whl)
+ucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${UCXX_CHANNEL}/ucxx_*.whl)
+libucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${LIBUCXX_CHANNEL}/libucxx_*.whl)
+distributed-ucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${DISTRIBUTED_UCXX_CHANNEL}/distributed_ucxx_*.whl)
+raft-dask-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${RAFT_DASK_CHANNEL}/raft_dask_*.whl)
+pylibraft-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${PYLIBRAFT_CHANNEL}/pylibraft_*.whl)
+EOF
+
+export PIP_CONSTRAINT=/tmp/constraints.txt

--- a/rapids_config.cmake
+++ b/rapids_config.cmake
@@ -26,6 +26,8 @@ else()
   )
 endif()
 
+set(rapids-cmake-repo jameslamb/rapids-cmake)
+set(rapids-cmake-branch fmt-and-spdlog)
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/CUVS_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")
   file(
     DOWNLOAD


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/56

Now that most of `conda-forge` has been updated to `fmt >=11.0.1,<12` and `spdlog>=1.14.1,<1.15` (https://github.com/rapidsai/build-planning/issues/56#issuecomment-2334281452), we're attempting to upgrade RAPIDS to similar versions of those libraries.

This improves the likelihood that RAPIDS will be installable alongside newer versions of its
dependencies and complementary packages on conda-forge.

## Notes for Reviewers

**THIS SHOULD NOT BE MERGED**

This PR is testing changes made in https://github.com/rapidsai/rapids-cmake/pull/689.
