### PR TITLE
Add `click` package to `cuvs-bench` conda recipe

### DIFF
--- a/conda/recipes/cuvs_bench/meta.yaml
+++ b/conda/recipes/cuvs_bench/meta.yaml
@@ -82,6 +82,7 @@ requirements:
 
   run:
     - benchmark
+    - click
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
     {% if cuda_major == "11" %}
     - cudatoolkit

--- a/conda/recipes/cuvs_bench_cpu/meta.yaml
+++ b/conda/recipes/cuvs_bench_cpu/meta.yaml
@@ -55,6 +55,7 @@ requirements:
 
   run:
     - benchmark
+    - click
     - glog {{ glog_version }}
     - h5py {{ h5py_version }}
     - matplotlib


### PR DESCRIPTION
This package is available in `dependencies.yaml`, but due to an oversight was not added to conda metas.