### PR TITLE
Add ci run_ scripts needed for build infra

### DIFF
--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+# Support customizing the ctests' install location
+cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/gtests/libcuvs/"
+
+ctest --output-on-failure --no-tests=error "$@"

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+# Support invoking run_pytests.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuvs/cuvs
+
+pytest --cache-clear --verbose "$@" tests


### PR DESCRIPTION
These `run_*` scripts are needed by the build infra team and bring the cuvs project in line with the rest of RAPIDS