### PR TITLE
call `enable_testing` in root CMakeLists.txt

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -762,6 +762,7 @@ endif()
 # * build test executable ----------------------------------------------------
 
 if(BUILD_TESTS)
+  enable_testing()
   add_subdirectory(internal)
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
Required to allow `ctest` to be called in the root of the build directory
