### PR TITLE
BUG: CAGRA multi-cta illegal access with bad queries

### DIFF
--- a/cpp/src/neighbors/detail/cagra/device_common.hpp
+++ b/cpp/src/neighbors/detail/cagra/device_common.hpp
@@ -181,8 +181,8 @@ RAFT_DEVICE_INLINE_FUNCTION void compute_distance_to_child_nodes(
     const IndexT smem_parent_id = parent_indices[i / knn_k];
     IndexT child_id             = invalid_index;
     if (smem_parent_id != invalid_index) {
-      // NOTE: BUG internal_topk_list contains out-of-range values (but not `invalid_index`) in rare
-      // cases this doesn't fail, indicating that parent_indices buffer is OK
+      // NOTE: BUG internal_topk_list contains out-of-range values (but not `invalid_index`)
+      // The following assert doesn't fail, indicating that parent_indices buffer is OK
       // assert(smem_parent_id < IndexT(result_child_indices_ptr - internal_topk_list));
       const auto parent_id = internal_topk_list[smem_parent_id] & ~index_msb_1_mask;
       // NOTE: Find the root cause for the incorrect value?

--- a/cpp/src/neighbors/detail/cagra/device_common.hpp
+++ b/cpp/src/neighbors/detail/cagra/device_common.hpp
@@ -120,7 +120,7 @@ RAFT_DEVICE_INLINE_FUNCTION void compute_distance_to_random_nodes(
   for (uint32_t i = threadIdx.x >> team_size_bits; i < max_i; i += (blockDim.x >> team_size_bits)) {
     const bool valid_i = (i < num_pickup);
 
-    IndexT best_index_team_local;
+    IndexT best_index_team_local    = raft::upper_bound<IndexT>();
     DistanceT best_norm2_team_local = raft::upper_bound<DistanceT>();
     for (uint32_t j = 0; j < num_distilation; j++) {
       // Select a node randomly and compute the distance to it
@@ -145,7 +145,8 @@ RAFT_DEVICE_INLINE_FUNCTION void compute_distance_to_random_nodes(
 
     const unsigned lane_id = threadIdx.x & ((1u << team_size_bits) - 1u);
     if (valid_i && lane_id == 0) {
-      if (hashmap::insert(visited_hash_ptr, hash_bitlen, best_index_team_local)) {
+      if (best_index_team_local != raft::upper_bound<IndexT>() &&
+          hashmap::insert(visited_hash_ptr, hash_bitlen, best_index_team_local)) {
         result_distances_ptr[i] = best_norm2_team_local;
         result_indices_ptr[i]   = best_index_team_local;
       } else {
@@ -181,20 +182,8 @@ RAFT_DEVICE_INLINE_FUNCTION void compute_distance_to_child_nodes(
     const IndexT smem_parent_id = parent_indices[i / knn_k];
     IndexT child_id             = invalid_index;
     if (smem_parent_id != invalid_index) {
-      // NOTE: BUG internal_topk_list contains out-of-range values (but not `invalid_index`)
-      // The following assert doesn't fail, indicating that parent_indices buffer is OK
-      // assert(smem_parent_id < IndexT(result_child_indices_ptr - internal_topk_list));
       const auto parent_id = internal_topk_list[smem_parent_id] & ~index_msb_1_mask;
-      // NOTE: Find the root cause for the incorrect value?
-      // This condition fails, indicating the internal_topk_list content is NOT OK
-      // if (parent_id < dataset_desc.size) {
-      child_id = knn_graph[(i % knn_k) + (static_cast<int64_t>(knn_k) * parent_id)];
-      // } else {
-      //   printf("parent_id = %u / in hex = %p / as fp32 = %f\n",
-      //          uint32_t(parent_id),
-      //          (void*)(parent_id),
-      //          reinterpret_cast<const float&>(parent_id));
-      // }
+      child_id             = knn_graph[(i % knn_k) + (static_cast<int64_t>(knn_k) * parent_id)];
     }
     if (child_id != invalid_index) {
       if (hashmap::insert(visited_hashmap_ptr, hash_bitlen, child_id) == 0) {

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -137,6 +137,7 @@ if(BUILD_TESTS)
     NAME
     NEIGHBORS_ANN_CAGRA_TEST
     PATH
+    neighbors/ann_cagra/bug_multi_cta_crash.cu
     neighbors/ann_cagra/test_float_uint32_t.cu
     neighbors/ann_cagra/test_half_uint32_t.cu
     neighbors/ann_cagra/test_int8_t_uint32_t.cu
@@ -241,7 +242,6 @@ if(TARGET cuvs::c_api)
     target_link_libraries(NEIGHBORS_HNSW_TEST PRIVATE hnswlib::hnswlib)
     target_compile_definitions(NEIGHBORS_HNSW_TEST PUBLIC CUVS_BUILD_CAGRA_HNSWLIB)
   endif()
-
 
   add_executable(cuvs_c_test core/c_api.c)
   target_link_libraries(cuvs_c_test PUBLIC cuvs::c_api)

--- a/cpp/test/neighbors/ann_cagra/bug_multi_cta_crash.cu
+++ b/cpp/test/neighbors/ann_cagra/bug_multi_cta_crash.cu
@@ -22,7 +22,6 @@
 
 #include <raft/core/device_mdarray.hpp>
 #include <raft/core/device_resources.hpp>
-#include <raft/random/make_blobs.cuh>
 
 #include <cstdint>
 
@@ -73,7 +72,7 @@ class AnnCagraBugMultiCTACrash : public ::testing::TestWithParam<cagra::search_a
     // NOTE: when initializing queries with "normal" data, the bug is NOT reproducible
     raft::linalg::map(
       res, queries->view(), raft::const_op<data_type>{raft::upper_bound<data_type>()});
-    // InitDataset(res, queries->data_handle(), n_samples, n_dim, metric, r);
+    // InitDataset(res, queries->data_handle(), n_queries, n_dim, metric, r);
     raft::resource::sync_stream(res);
   }
 

--- a/cpp/test/neighbors/ann_cagra/bug_multi_cta_crash.cu
+++ b/cpp/test/neighbors/ann_cagra/bug_multi_cta_crash.cu
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../ann_cagra.cuh"
+
+#include <cuvs/neighbors/cagra.hpp>
+
+#include <raft/core/device_mdarray.hpp>
+#include <raft/core/device_resources.hpp>
+#include <raft/random/make_blobs.cuh>
+
+#include <cstdint>
+
+namespace cuvs::neighbors::cagra {
+
+class AnnCagraBugMultiCTACrash : public ::testing::TestWithParam<cagra::search_algo> {
+ public:
+  using data_type = half;
+
+ protected:
+  void run()
+  {
+    cagra::index_params cagra_index_params;
+    cagra_index_params.graph_degree              = 32;
+    cagra_index_params.intermediate_graph_degree = 48;
+
+    auto cagra_index =
+      cagra::build(res, cagra_index_params, raft::make_const_mdspan(dataset->view()));
+    raft::resource::sync_stream(res);
+
+    cagra::search_params cagra_search_params;
+    cagra_search_params.itopk_size        = 32;
+    cagra_search_params.thread_block_size = 256;
+    cagra_search_params.search_width      = 1;
+    cagra_search_params.max_iterations    = 0;
+    cagra_search_params.algo = ::testing::TestWithParam<cagra::search_algo>::GetParam();
+
+    // NOTE: when using one resource/stream for everything, the bug is NOT reproducible
+    raft::resources res_search;
+    cagra::search(res_search,
+                  cagra_search_params,
+                  cagra_index,
+                  raft::make_const_mdspan(queries->view()),
+                  neighbors->view(),
+                  distances->view());
+
+    raft::resource::sync_stream(res_search);
+  }
+
+  void SetUp() override
+  {
+    dataset.emplace(raft::make_device_matrix<data_type, int64_t>(res, n_samples, n_dim));
+    queries.emplace(raft::make_device_matrix<data_type, int64_t>(res, n_queries, n_dim));
+    neighbors.emplace(raft::make_device_matrix<uint32_t, int64_t>(res, n_queries, k));
+    distances.emplace(raft::make_device_matrix<float, int64_t>(res, n_queries, k));
+    raft::random::RngState r(1234ULL);
+    InitDataset(res, dataset->data_handle(), n_samples, n_dim, metric, r);
+    // NOTE: when initializing queries with "normal" data, the bug is NOT reproducible
+    raft::linalg::map(
+      res, queries->view(), raft::const_op<data_type>{raft::upper_bound<data_type>()});
+    // InitDataset(res, queries->data_handle(), n_samples, n_dim, metric, r);
+    raft::resource::sync_stream(res);
+  }
+
+  void TearDown() override
+  {
+    dataset.reset();
+    queries.reset();
+    neighbors.reset();
+    distances.reset();
+    raft::resource::sync_stream(res);
+  }
+
+ private:
+  raft::resources res;
+  std::optional<raft::device_matrix<data_type, int64_t>> dataset  = std::nullopt;
+  std::optional<raft::device_matrix<data_type, int64_t>> queries  = std::nullopt;
+  std::optional<raft::device_matrix<uint32_t, int64_t>> neighbors = std::nullopt;
+  std::optional<raft::device_matrix<float, int64_t>> distances    = std::nullopt;
+
+  constexpr static int64_t n_samples                   = 1183514;
+  constexpr static int64_t n_dim                       = 100;
+  constexpr static int64_t n_queries                   = 30;
+  constexpr static int64_t k                           = 10;
+  constexpr static cuvs::distance::DistanceType metric = cuvs::distance::DistanceType::L2Expanded;
+};
+
+TEST_P(AnnCagraBugMultiCTACrash, AnnCagraBugMultiCTACrash) { this->run(); }
+
+INSTANTIATE_TEST_CASE_P(AnnCagraBugMultiCTACrashReproducer,
+                        AnnCagraBugMultiCTACrash,
+                        ::testing::Values(cagra::search_algo::MULTI_CTA));
+
+}  // namespace cuvs::neighbors::cagra


### PR DESCRIPTION
CAGRA search kernel errors with `cudaErrorIllegalAddress` in some conditions, specified in the new test case.

According to compute-sanitizer, the illegal access happens in [compute_distance_to_child_nodes(...) function](https://github.com/rapidsai/cuvs/blob/b422cbeec92fe925ee59f5f966ac9834440200e2/cpp/src/neighbors/detail/cagra/device_common.hpp#L185) accessing the graph.
The `parent_id` variable in that function sometimes appears to be out-of-bounds (larger than the graph size / number of records); it's invalid and seems to be the same reported by multiple threads, yet it's not an `invalid_index`, neither `index_msb_1_mask`, neither any derivative of the two.
Further observations:
  - I've checked the graph just before calling the search kernel; it does not contain any invalid indices.
  - One should disable any fancy pool memory resources to make it easier to reproduce the error (so that `parent_id` does not hit other user allocations in the pool)
  - It seems important that the query yields infinite distance to the dataset.
  - Running the search with a newly created `raft::resources` seems to increase the chance to hit the error
  - Even with all conditions satisfied, the error does not reproduce every time...

### Reproducer
```
./build.sh -n tests --limit-tests=NEIGHBORS_ANN_CAGRA_TEST && ./cpp/build/gtests/NEIGHBORS_ANN_CAGRA_TEST --gtest_filter=AnnCagraBugMultiCTACrash*
```