### PR TITLE
Enable NVTX in cuvs-cagra-search component

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -603,6 +603,9 @@ SECTIONS
     # This enables NVTX within the project with no option to disable it downstream.
     target_link_libraries(cuvs PUBLIC CUDA::nvtx3)
     target_compile_definitions(cuvs PUBLIC NVTX_ENABLED)
+
+    target_link_libraries(cuvs-cagra-search PUBLIC CUDA::nvtx3)
+    target_compile_definitions(cuvs-cagra-search PUBLIC NVTX_ENABLED)
   else()
     # Allow enable NVTX downstream if not set here. This creates a new option at build/install time,
     # which is set by default to OFF, but can be enabled in the dependent project.


### PR DESCRIPTION
Since parts of CAGRA code have been separated into a static library component `cuvs-cagra-search` (to selectively enable CUDA separable compilation on them), the NVTX flags are not passed to the affected sources anymore. This PR fixes that.