### PR TITLE
Fix an OOB error in device-side cuvs::neighbors::refine and CAGRA kern_prune

### DIFF
--- a/cpp/src/neighbors/detail/cagra/graph_core.cuh
+++ b/cpp/src/neighbors/detail/cagra/graph_core.cuh
@@ -156,6 +156,7 @@ __global__ void kern_prune(const IdxT* const knn_graph,  // [graph_chunk_size, g
   // count number of detours (A->D->B)
   for (uint32_t kAD = 0; kAD < graph_degree - 1; kAD++) {
     const uint64_t iD = knn_graph[kAD + (graph_degree * iA)];
+    if (iD >= graph_size) { continue; }
     for (uint32_t kDB = threadIdx.x; kDB < graph_degree; kDB += blockDim.x) {
       const uint64_t iB_candidate = knn_graph[kDB + ((uint64_t)graph_degree * iD)];
       for (uint32_t kAB = kAD + 1; kAB < graph_degree; kAB++) {

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -137,6 +137,7 @@ if(BUILD_TESTS)
     NAME
     NEIGHBORS_ANN_CAGRA_TEST
     PATH
+    neighbors/ann_cagra/bug_extreme_inputs_oob.cu
     neighbors/ann_cagra/bug_multi_cta_crash.cu
     neighbors/ann_cagra/test_float_uint32_t.cu
     neighbors/ann_cagra/test_half_uint32_t.cu

--- a/cpp/test/neighbors/ann_cagra/bug_extreme_inputs_oob.cu
+++ b/cpp/test/neighbors/ann_cagra/bug_extreme_inputs_oob.cu
@@ -16,12 +16,11 @@
 
 #include <gtest/gtest.h>
 
-#include "../../test_utils.cuh"
-
 #include <cuvs/neighbors/cagra.hpp>
 
 #include <raft/core/device_mdarray.hpp>
 #include <raft/core/device_resources.hpp>
+#include <raft/random/rng.cuh>
 
 #include <cstdint>
 

--- a/cpp/test/neighbors/ann_cagra/bug_extreme_inputs_oob.cu
+++ b/cpp/test/neighbors/ann_cagra/bug_extreme_inputs_oob.cu
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../test_utils.cuh"
+
+#include <cuvs/neighbors/cagra.hpp>
+
+#include <raft/core/device_mdarray.hpp>
+#include <raft/core/device_resources.hpp>
+
+#include <cstdint>
+
+namespace cuvs::neighbors::cagra {
+
+class cagra_extreme_inputs_oob_test : public ::testing::Test {
+ public:
+  using data_type = float;
+
+ protected:
+  void run()
+  {
+    cagra::index_params ix_ps;
+    graph_build_params::ivf_pq_params gb_params{};
+    gb_params.refinement_rate       = 2;
+    ix_ps.graph_build_params        = gb_params;
+    ix_ps.graph_degree              = 64;
+    ix_ps.intermediate_graph_degree = 128;
+
+    [[maybe_unused]] auto ix = cagra::build(res, ix_ps, raft::make_const_mdspan(dataset->view()));
+    raft::resource::sync_stream(res);
+  }
+
+  void SetUp() override
+  {
+    dataset.emplace(raft::make_device_matrix<data_type, int64_t>(res, n_samples, n_dim));
+    raft::random::RngState r(1234ULL);
+    raft::random::normal(
+      res, r, dataset->data_handle(), n_samples * n_dim, data_type(0), data_type(1e20));
+    raft::resource::sync_stream(res);
+  }
+
+  void TearDown() override
+  {
+    dataset.reset();
+    raft::resource::sync_stream(res);
+  }
+
+ private:
+  raft::resources res;
+  std::optional<raft::device_matrix<data_type, int64_t>> dataset = std::nullopt;
+
+  constexpr static int64_t n_samples                   = 100000;
+  constexpr static int64_t n_dim                       = 200;
+  constexpr static cuvs::distance::DistanceType metric = cuvs::distance::DistanceType::L2Expanded;
+};
+
+TEST_F(cagra_extreme_inputs_oob_test, cagra_extreme_inputs_oob_test) { this->run(); }
+
+}  // namespace cuvs::neighbors::cagra


### PR DESCRIPTION
IVF-Flat index expects all valid indices during build, which may not be the case in the context of refinement.
At the same time, `cagra::detail::graph::kern_prune` fails with OOB error if some indices are invalid.

This PR tweaks both kernels to avoid touching the input data with an invalid index.

Fixes https://github.com/rapidsai/cuvs/issues/337