### PR TITLE
use different wheel-size thresholds based on CUDA version

### DIFF
--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -6,12 +6,26 @@ set -euo pipefail
 package_dir=$1
 wheel_dir_relative_path=$2
 
+RAPIDS_CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
+
+# some packages are much larger on CUDA 11 than on CUDA 12
+if [[ "${RAPIDS_CUDA_MAJOR}" == "11" ]]; then
+    PYDISTCHECK_ARGS=(
+        --max-allowed-size-compressed '1.4G'
+    )
+else
+    PYDISTCHECK_ARGS=(
+        --max-allowed-size-compressed '950M'
+    )
+fi
+
 cd "${package_dir}"
 
 rapids-logger "validate packages with 'pydistcheck'"
 
 pydistcheck \
     --inspect \
+    "${PYDISTCHECK_ARGS[@]}" \
     "$(echo ${wheel_dir_relative_path}/*.whl)"
 
 rapids-logger "validate packages with 'twine'"

--- a/python/cuvs/pyproject.toml
+++ b/python/cuvs/pyproject.toml
@@ -135,11 +135,9 @@ matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 
 [tool.pydistcheck]
 select = [
+    # NOTE: size threshold is managed via CLI args in CI scripts
     "distro-too-large-compressed",
 ]
-
-# detect when package size grows significantly
-max_allowed_size_compressed = '1.4G'
 
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
`cuvs-cu11` wheels are significantly larger than `cuvs-cu12` wheels, because (among other reasons) they are not able to dynamically link to CUDA math library wheels.

In #464, I proposed a size limit for CI checks of "max CUDA 11 wheel size + a buffer".

This PR proposes using different thresholds based on CUDA major version, following these discussions:

* https://github.com/rapidsai/cugraph/pull/4754#discussion_r1842526907
* https://github.com/rapidsai/cuml/pull/6136#discussion_r1841774811