### PR TITLE
Remove RAFT BUILD_ANN_BENCH option

### DIFF
--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -50,7 +50,6 @@ function(find_and_configure_raft)
               OPTIONS
               "BUILD_TESTS OFF"
               "BUILD_PRIMS_BENCH OFF"
-              "BUILD_ANN_BENCH OFF"
               "RAFT_NVTX ${PKG_ENABLE_NVTX}"
               "RAFT_COMPILE_LIBRARY OFF"
             )


### PR DESCRIPTION
This cleans up a reference to RAFT's `BUILD_ANN_BENCH` CMake option which no longer exists.
