### PR TITLE
add a README for wheels

### DIFF
--- a/python/cuvs/README.md
+++ b/python/cuvs/README.md
@@ -1,0 +1,3 @@
+# cuVS
+
+cuVS contains state-of-the-art implementations of several algorithms for running approximate nearest neighbors and clustering on the GPU. It can be used directly or through the various databases and other libraries that have integrated it. The primary goal of cuVS is to simplify the use of GPUs for vector similarity search and clustering.


### PR DESCRIPTION
Wheel-building CI jobs are failing like this:

> Checking final_dist/cuvs_cu12-25.2.0a26-cp310-cp310-manylinux_2_28_aarch64.whl: FAILED due to warnings
> WARNING  `long_description` missing.                                            
> Error: Process completed with exit code 1.

([build link](https://github.com/rapidsai/cuvs/actions/runs/12133882036))

Looks like the root cause is a combination of the following:

* there was a new `twine` release (6.x) 3 days ago: https://pypi.org/project/twine/#history
* it contains https://github.com/pypa/twine/pull/1168, which makes `twine check --strict` fail if the wheel's `long_description` is empty
* the `cuvs` wheel README (used as the wheel `long_description`) is empty

This proposes adding a small README, with just 2 sentences copied from the project's root-level README, to get past that check.

## Notes for Reviewers

The `long_description` becomes the project homepage when a project is hosted on PyPI. The wheels produced from this repo aren't currently being published to pypi.org so this change won't be seen there, but a more user-friendly README should be added if/when we decide to publish `cuvs-cu{11,12}` to pypi.org.

ref: https://github.com/rapidsai/build-planning/issues/70