### PR TITLE
Fix cagra::extend error message

### DIFF
--- a/cpp/src/neighbors/detail/cagra/add_nodes.cuh
+++ b/cpp/src/neighbors/detail/cagra/add_nodes.cuh
@@ -432,8 +432,14 @@ void extend_core(
     } else {
       index.update_graph(handle, raft::make_const_mdspan(updated_graph.view()));
     }
+  } else if (dynamic_cast<const cuvs::neighbors::empty_dataset<int64_t>*>(&index.data()) !=
+             nullptr) {
+    RAFT_FAIL(
+      "cagra::extend only supports an index to which the dataset is attached. Please check if the "
+      "index was built with index_param.attach_dataset_on_build = true, or if a dataset was "
+      "attached after the build.");
   } else {
-    RAFT_FAIL("Only uncompressed dataset is supported");
+    RAFT_FAIL("cagra::extend only supports uncompressed dataset");
   }
 }
 }  // namespace cuvs::neighbors::cagra

--- a/cpp/src/neighbors/detail/cagra/add_nodes.cuh
+++ b/cpp/src/neighbors/detail/cagra/add_nodes.cuh
@@ -439,7 +439,7 @@ void extend_core(
       "index was built with index_param.attach_dataset_on_build = true, or if a dataset was "
       "attached after the build.");
   } else {
-    RAFT_FAIL("cagra::extend only supports uncompressed dataset");
+    RAFT_FAIL("cagra::extend only supports an uncompressed dataset index");
   }
 }
 }  // namespace cuvs::neighbors::cagra


### PR DESCRIPTION
When extending a CAGRA index that is built with `index_param.attach_dataset_on_build = false`, an error message "Only uncompressed dataset is supported" is displayed even if the dataset used to build the graph is not compressed. This problem occurs since the extend function does not check whether the dataset is empty. This PR fixes it.