### PR TITLE
Reduce the recall threshold for IVF-PQ low-precision LUT inner product  tests

### DIFF
--- a/cpp/test/neighbors/ann_ivf_pq.cuh
+++ b/cpp/test/neighbors/ann_ivf_pq.cuh
@@ -879,7 +879,7 @@ inline auto enum_variety_ip() -> test_cases_t
         // InnerProduct score is signed,
         // thus we're forced to used signed 8-bit representation,
         // thus we have one bit less precision
-        y.min_recall = y.min_recall.value() * 0.90;
+        y.min_recall = y.min_recall.value() * 0.88;
       } else {
         // In other cases it seems to perform a little bit better, still worse than L2
         y.min_recall = y.min_recall.value() * 0.94;


### PR DESCRIPTION
IVF-PQ allows to use low-precision for the lookup table during search to improve QPS. When used for the inner product distance, this has extra tall on recall. This PR reduces our expectation of the recall in this case as an answer to occasional test failures in CI.