### PR TITLE
Use cuda.bindings layout.

### DIFF
--- a/python/cuvs/cuvs/common/c_api.pxd
+++ b/python/cuvs/cuvs/common/c_api.pxd
@@ -16,7 +16,7 @@
 # cython: language_level=3
 
 
-from cuda.ccudart cimport cudaStream_t
+from cuda.bindings.cyruntime cimport cudaStream_t
 from libc.stdint cimport uintptr_t
 
 

--- a/python/cuvs/cuvs/common/resources.pyx
+++ b/python/cuvs/cuvs/common/resources.pyx
@@ -17,7 +17,7 @@
 
 import functools
 
-from cuda.ccudart cimport cudaStream_t
+from cuda.bindings.cyruntime cimport cudaStream_t
 
 from cuvs.common.c_api cimport (
     cuvsResources_t,


### PR DESCRIPTION
This PR updates cuVS to use the new cuda-python `cuda.bindings` layout. See https://github.com/rapidsai/build-planning/issues/117.
