### PR TITLE
Temporarily skip CUDA 11 wheel CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -150,6 +150,9 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_cuvs.sh
+      # CUDA 11 wheel CI is disabled until
+      # https://github.com/rapidsai/build-planning/issues/137 is resolved.
+      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   devcontainer:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-25.02

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,3 +49,6 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_cuvs.sh
+      # CUDA 11 wheel CI is disabled until
+      # https://github.com/rapidsai/build-planning/issues/137 is resolved.
+      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))


### PR DESCRIPTION
Due to some failures coming from libraft C++ wheels, CUDA 11 wheel CI will not pass. This PR temporarily disables CUDA 11 wheel tests until those issues can be resolved.

See https://github.com/rapidsai/build-planning/issues/137.
