### PR TITLE
Revert "Temporarily skip CUDA 11 wheel CI"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -150,9 +150,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_cuvs.sh
-      # CUDA 11 wheel CI is disabled until
-      # https://github.com/rapidsai/build-planning/issues/137 is resolved.
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   devcontainer:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-25.02

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,3 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_cuvs.sh
-      # CUDA 11 wheel CI is disabled until
-      # https://github.com/rapidsai/build-planning/issues/137 is resolved.
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))


### PR DESCRIPTION
Reverts rapidsai/cuvs#599 now that https://github.com/rapidsai/raft/pull/2548 has landed.