### PR TITLE
Revert docs builds to CI latest tag.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -124,7 +124,7 @@ jobs:
       build_type: pull-request
       node_type: "gpu-v100-latest-1"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:cuda12.8.0-ubuntu24.04-py3.12"
+      container_image: "rapidsai/ci-conda:latest"
       run_script: "ci/build_docs.sh"
   rust-build:
     needs: conda-cpp-build


### PR DESCRIPTION
This cleans up one change from #621 that could not be reverted in #630. It is now safe to use `ci-imgs`' `latest` tag, because https://github.com/rapidsai/ci-imgs/pull/236 is merged.
