### PR TITLE
Expose configuration singleton as a global context for ann-bench algos

### DIFF
--- a/cpp/bench/ann/src/common/benchmark.hpp
+++ b/cpp/bench/ann/src/common/benchmark.hpp
@@ -523,8 +523,6 @@ void dispatch_benchmark(std::string cmdline,
                         bool force_overwrite,
                         bool build_mode,
                         bool search_mode,
-                        std::string data_prefix,
-                        std::string index_prefix,
                         kv_series override_kv,
                         Mode metric_objective,
                         const std::vector<int>& threads,
@@ -540,12 +538,9 @@ void dispatch_benchmark(std::string cmdline,
     }
   }
   auto& dataset_conf = conf.get_dataset_conf();
-  auto& base_file    = dataset_conf.base_file;
-  auto& query_file   = dataset_conf.query_file;
-  auto& gt_file      = dataset_conf.groundtruth_neighbors_file;
-  base_file          = combine_path(data_prefix, base_file);
-  query_file         = combine_path(data_prefix, query_file);
-  if (gt_file.has_value()) { gt_file.emplace(combine_path(data_prefix, gt_file.value())); }
+  auto base_file     = dataset_conf.base_file;
+  auto query_file    = dataset_conf.query_file;
+  auto gt_file       = dataset_conf.groundtruth_neighbors_file;
   auto dataset =
     std::make_shared<bench::dataset<T>>(dataset_conf.name,
                                         base_file,
@@ -572,7 +567,6 @@ void dispatch_benchmark(std::string cmdline,
       for (auto param : apply_overrides(index.build_param, override_kv)) {
         auto modified_index        = index;
         modified_index.build_param = param;
-        modified_index.file        = combine_path(index_prefix, modified_index.file);
         more_indices.push_back(modified_index);
       }
     }
@@ -604,7 +598,6 @@ void dispatch_benchmark(std::string cmdline,
     }
     for (auto& index : indices) {
       index.search_params = apply_overrides(index.search_params, override_kv);
-      index.file          = combine_path(index_prefix, index.file);
     }
     register_search<T>(dataset, indices, metric_objective, threads, no_lap_sync);
   }
@@ -729,7 +722,7 @@ inline auto run_main(int argc, char** argv) -> int
     log_warn("cudart library is not found, GPU-based indices won't work.");
   }
 
-  auto& conf        = bench::configuration::initialize(conf_stream);
+  auto& conf        = bench::configuration::initialize(conf_stream, data_prefix, index_prefix);
   std::string dtype = conf.get_dataset_conf().dtype;
 
   if (dtype == "float") {
@@ -738,8 +731,6 @@ inline auto run_main(int argc, char** argv) -> int
                               force_overwrite,
                               build_mode,
                               search_mode,
-                              data_prefix,
-                              index_prefix,
                               override_kv,
                               metric_objective,
                               threads,
@@ -750,8 +741,6 @@ inline auto run_main(int argc, char** argv) -> int
                              force_overwrite,
                              build_mode,
                              search_mode,
-                             data_prefix,
-                             index_prefix,
                              override_kv,
                              metric_objective,
                              threads,
@@ -762,8 +751,6 @@ inline auto run_main(int argc, char** argv) -> int
                                      force_overwrite,
                                      build_mode,
                                      search_mode,
-                                     data_prefix,
-                                     index_prefix,
                                      override_kv,
                                      metric_objective,
                                      threads,
@@ -774,8 +761,6 @@ inline auto run_main(int argc, char** argv) -> int
                                     force_overwrite,
                                     build_mode,
                                     search_mode,
-                                    data_prefix,
-                                    index_prefix,
                                     override_kv,
                                     metric_objective,
                                     threads,

--- a/cpp/bench/ann/src/common/conf.hpp
+++ b/cpp/bench/ann/src/common/conf.hpp
@@ -57,6 +57,26 @@ class configuration {
     std::optional<double> filtering_rate{std::nullopt};
   };
 
+  [[nodiscard]] inline auto get_dataset_conf() const -> const dataset_conf&
+  {
+    return dataset_conf_;
+  }
+  [[nodiscard]] inline auto get_dataset_conf() -> dataset_conf& { return dataset_conf_; }
+  [[nodiscard]] inline auto get_indices() const -> const std::vector<index>& { return indices_; };
+  [[nodiscard]] inline auto get_indices() -> std::vector<index>& { return indices_; };
+
+  /** The benchmark initializes the configuration once and has a chance to modify it during the
+   * setup. */
+  static inline auto initialize(std::istream& conf_stream) -> configuration&
+  {
+    singleton_ = std::unique_ptr<configuration>(new configuration{conf_stream});
+    return *singleton_;
+  }
+
+  /** Any algorithm can access the benchmark configuration as an immutable context. */
+  [[nodiscard]] static inline auto singleton() -> const configuration& { return *singleton_; }
+
+ private:
   explicit inline configuration(std::istream& conf_stream)
   {
     // to enable comments in json
@@ -66,10 +86,6 @@ class configuration {
     parse_index(conf.at("index"), conf.at("search_basic_param"));
   }
 
-  [[nodiscard]] inline auto get_dataset_conf() const -> dataset_conf { return dataset_conf_; }
-  [[nodiscard]] inline auto get_indices() const -> std::vector<index> { return indices_; };
-
- private:
   inline void parse_dataset(const nlohmann::json& conf)
   {
     dataset_conf_.name       = conf.at("name");
@@ -147,6 +163,8 @@ class configuration {
 
   dataset_conf dataset_conf_;
   std::vector<index> indices_;
+
+  static inline std::unique_ptr<configuration> singleton_ = nullptr;
 };
 
 }  // namespace cuvs::bench


### PR DESCRIPTION
Expose the `bench::configuration` as a global context (singleton), so that algorithms can inspect it during setup if the need arises.

This is a proposal for https://github.com/rapidsai/cuvs/pull/260 to avoid mixing algorithm-specific logic into the common benchmarking infrastructure.