### PR TITLE
Use `rapids-pip-retry` in CI jobs that might need retries

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -38,7 +38,7 @@ rapids-logger "Building '${package_name}' wheel"
 
 sccache --zero-stats
 
-python -m pip wheel \
+rapids-pip-retry wheel \
     -w dist \
     -v \
     --no-deps \

--- a/ci/build_wheel_libcuvs.sh
+++ b/ci/build_wheel_libcuvs.sh
@@ -17,7 +17,7 @@ rapids-dependency-file-generator \
 | tee /tmp/requirements-build.txt
 
 rapids-logger "Installing build requirements"
-python -m pip install \
+rapids-pip-retry install \
     -v \
     --prefer-binary \
     -r /tmp/requirements-build.txt

--- a/ci/test_wheel_cuvs.sh
+++ b/ci/test_wheel_cuvs.sh
@@ -9,7 +9,7 @@ RAPIDS_PY_WHEEL_NAME="libcuvs_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-f
 RAPIDS_PY_WHEEL_NAME="cuvs_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./dist
 
 # echo to expand wildcard before adding `[extra]` requires for pip
-python -m pip install \
+rapids-pip-retry install \
     ./local-libcuvs-dep/libcuvs*.whl \
     "$(echo ./dist/cuvs*.whl)[test]"
 


### PR DESCRIPTION
Uses a retry wrapper for `pip` commands to try to alleviate CI failures due to hash mismatches that result from network hiccups

xref rapidsai/gha-tools#132

This will retry failures that show up in CI like:

```
   Collecting nvidia-cusolver-cu12 (from libraft-cu12==25.2.*,>=0.0.0a0)
    Downloading https://pypi.nvidia.com/nvidia-cusolver-cu12/nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_aarch64.whl (260.1 MB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━      226.5/260.1 MB 70.2 MB/s eta 0:00:01
  ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
      nvidia-cusolver-cu12 from https://pypi.nvidia.com/nvidia-cusolver-cu12/nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_aarch64.whl#sha256=0fd9e98246f43c15bee5561147ad235dfdf2d037f5d07c9d41af3f7f72feb7cc (from libraft-cu12==25.2.*,>=0.0.0a0):
          Expected sha256 0fd9e98246f43c15bee5561147ad235dfdf2d037f5d07c9d41af3f7f72feb7cc
               Got        5ab0571003be61a02d3cbf59307e987c3e18a755fa472475a7f5178e77e12012

  error: subprocess-exited-with-error
  
  × pip subprocess to install backend dependencies did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
```

ref: https://github.com/rapidsai/cuvs/actions/runs/13115119921/job/36588587993?pr=643#step:10:128