### PR TITLE
Fix duplicate indices in batch NN Descent

### DIFF
--- a/cpp/src/neighbors/detail/nn_descent.cuh
+++ b/cpp/src/neighbors/detail/nn_descent.cuh
@@ -244,6 +244,8 @@ class BloomFilter {
     }
   }
 
+  void set_nrow(size_t nrow) { nrow_ = nrow; }
+
   bool check(size_t list_id, Index_t key)
   {
     bool is_present       = true;
@@ -1265,6 +1267,8 @@ void GNND<Data_t, Index_t>::build(Data_t* data,
   cudaStream_t stream = raft::resource::get_cuda_stream(res);
   nrow_               = nrow;
   graph_.nrow         = nrow;
+  graph_.bloom_filter.set_nrow(nrow);
+  update_counter_ = 0;
   graph_.h_graph      = (InternalID_t<Index_t>*)output_graph;
 
   cudaPointerAttributes data_ptr_attr;

--- a/cpp/src/neighbors/detail/nn_descent.cuh
+++ b/cpp/src/neighbors/detail/nn_descent.cuh
@@ -1361,11 +1361,8 @@ void GNND<Data_t, Index_t>::build(Data_t* data,
     }
 
     update_and_sample_thread.join();
-    std::cout << "iter " << it + 1 << "inside the loop, before hitting update counter "
-              << update_counter_.load() << std::endl;
+
     if (update_counter_ == -1) { break; }
-    std::cout << "iter " << it + 1 << "inside the loop, after hitting update counter "
-              << update_counter_.load() << std::endl;
     raft::copy(graph_host_buffer_.data_handle(),
                graph_buffer_.data_handle(),
                nrow_ * DEGREE_ON_DEVICE,

--- a/cpp/src/neighbors/detail/nn_descent.cuh
+++ b/cpp/src/neighbors/detail/nn_descent.cuh
@@ -1361,8 +1361,11 @@ void GNND<Data_t, Index_t>::build(Data_t* data,
     }
 
     update_and_sample_thread.join();
-
+    std::cout << "iter " << it + 1 << "inside the loop, before hitting update counter "
+              << update_counter_.load() << std::endl;
     if (update_counter_ == -1) { break; }
+    std::cout << "iter " << it + 1 << "inside the loop, after hitting update counter "
+              << update_counter_.load() << std::endl;
     raft::copy(graph_host_buffer_.data_handle(),
                graph_buffer_.data_handle(),
                nrow_ * DEGREE_ON_DEVICE,

--- a/cpp/src/neighbors/detail/nn_descent.cuh
+++ b/cpp/src/neighbors/detail/nn_descent.cuh
@@ -1269,7 +1269,7 @@ void GNND<Data_t, Index_t>::build(Data_t* data,
   graph_.nrow         = nrow;
   graph_.bloom_filter.set_nrow(nrow);
   update_counter_ = 0;
-  graph_.h_graph      = (InternalID_t<Index_t>*)output_graph;
+  graph_.h_graph  = (InternalID_t<Index_t>*)output_graph;
 
   cudaPointerAttributes data_ptr_attr;
   RAFT_CUDA_TRY(cudaPointerGetAttributes(&data_ptr_attr, data));

--- a/cpp/src/neighbors/detail/nn_descent_batch.cuh
+++ b/cpp/src/neighbors/detail/nn_descent_batch.cuh
@@ -171,7 +171,7 @@ void get_global_nearest_k(
       if (i == num_batches - 1) { batch_size_ = num_rows - batch_size * i; }
       thrust::copy(raft::resource::get_thrust_policy(res),
                    nearest_clusters_idx.data_handle() + i * batch_size * k,
-                   nearest_clusters_idx.data_handle() + (i + 1) * batch_size * k,
+                   nearest_clusters_idx.data_handle() + (i * batch_size + batch_size_) * k,
                    nearest_clusters_idxt.data_handle());
       raft::copy(global_nearest_cluster.data_handle() + i * batch_size * k,
                  nearest_clusters_idxt.data_handle(),

--- a/cpp/src/neighbors/detail/nn_descent_batch.cuh
+++ b/cpp/src/neighbors/detail/nn_descent_batch.cuh
@@ -650,7 +650,8 @@ void batch_build(raft::resources const& res,
                            .internal_node_degree  = extended_intermediate_degree,
                            .max_iterations        = params.max_iterations,
                            .termination_threshold = params.termination_threshold,
-                           .output_graph_degree   = graph_degree};
+                           .output_graph_degree   = graph_degree,
+                           .metric                = params.metric};
 
   auto global_indices_h   = raft::make_managed_matrix<IdxT, int64_t>(res, num_rows, graph_degree);
   auto global_distances_h = raft::make_managed_matrix<float, int64_t>(res, num_rows, graph_degree);

--- a/cpp/src/neighbors/detail/nn_descent_batch.cuh
+++ b/cpp/src/neighbors/detail/nn_descent_batch.cuh
@@ -107,10 +107,6 @@ void get_global_nearest_k(
 
   size_t num_batches = n_clusters;
   size_t batch_size  = (num_rows + n_clusters) / n_clusters;
-  // if (n_clusters == k) {
-  //   batch_size = num_rows /
-  // }
-  printf("num batches: %lu, batch size: %lu\n", num_batches, batch_size);
   if (ptr == nullptr) {  // data on host
 
     auto d_dataset_batch =
@@ -173,7 +169,6 @@ void get_global_nearest_k(
       size_t batch_size_ = batch_size;
 
       if (i == num_batches - 1) { batch_size_ = num_rows - batch_size * i; }
-      printf("\tusing batch size %lu\n", batch_size_);
       thrust::copy(raft::resource::get_thrust_policy(res),
                    nearest_clusters_idx.data_handle() + i * batch_size * k,
                    nearest_clusters_idx.data_handle() + (i + 1) * batch_size * k,
@@ -224,14 +219,11 @@ void get_inverted_indices(raft::resources const& res,
     }
   }
 
-  raft::print_host_vector("cluster sizes", cluster_size.data_handle(), n_clusters, std::cout);
-
   offset(0) = 0;
   for (size_t i = 1; i < n_clusters; i++) {
     offset(i) = offset(i - 1) + cluster_size(i - 1);
   }
 
-  raft::print_host_vector("offsets", offset.data_handle(), n_clusters, std::cout);
   for (size_t i = 0; i < num_rows; i++) {
     for (size_t j = 0; j < k; j++) {
       IdxT cluster_id = global_nearest_cluster(i, j);
@@ -408,109 +400,6 @@ void build_and_merge(raft::resources const& res,
     }
   }
 
-  // looking for duplicates
-  auto batch_distances_h =
-    raft::make_host_matrix<float, int64_t, raft::row_major>(num_data_in_cluster, graph_degree);
-  raft::copy(batch_distances_h.data_handle(),
-             batch_distances_d,
-             num_data_in_cluster * graph_degree,
-             raft::resource::get_cuda_stream(res));
-
-  auto cluster_data_h = raft::make_host_matrix<T, int64_t, raft::row_major>(1, num_cols);
-  raft::print_host_vector("inverted indices", inverted_indices, num_data_in_cluster, std::cout);
-  for (size_t i = 0; i < num_data_in_cluster; i++) {
-    size_t global_row_idx = inverted_indices[i];
-    printf("\nbatch row %lu, global row %lu\n", i, global_row_idx);
-    raft::print_device_vector(
-      "batch distances:", batch_distances_d + i * graph_degree, graph_degree, std::cout);
-    raft::print_host_vector("global distances:",
-                            global_distances_d + global_row_idx * graph_degree,
-                            graph_degree,
-                            std::cout);
-    raft::print_host_vector(
-      "batch indices:", batch_indices_h + i * graph_degree, graph_degree, std::cout);
-    raft::print_host_vector(
-      "global indices:", global_indices_d + global_row_idx * graph_degree, graph_degree, std::cout);
-
-    if (cluster_id == 0) {
-      raft::copy(cluster_data_h.data_handle(),
-                 cluster_data + i * num_cols,
-                 num_cols,
-                 raft::resource::get_cuda_stream(res));
-      raft::print_host_vector(
-        "item1(global row)", cluster_data_h.data_handle(), num_cols, std::cout);
-      raft::print_host_vector(
-        "int graph", int_graph + i * int_graph_node_degree, graph_degree, std::cout);
-    }
-
-    for (size_t j = 0; j < graph_degree; j++) {
-      size_t batch_index_ij = batch_indices_h[i * graph_degree + j];
-
-      if (cluster_id == 0) {
-        printf("\titem2 index %lu (batch row %lu)\t", batch_index_ij, j);
-        for (size_t p = 0; p < num_data_in_cluster; p++) {
-          if (inverted_indices[p] == batch_index_ij) {
-            raft::copy(cluster_data_h.data_handle(),
-                       cluster_data + p * num_cols,
-                       num_cols,
-                       raft::resource::get_cuda_stream(res));
-            raft::print_host_vector(
-              "item2(batch)", cluster_data_h.data_handle(), num_cols, std::cout);
-            break;
-          }
-        }
-      }
-
-      for (size_t k = 0; k < graph_degree; k++) {
-        size_t global_index_ik = global_indices_d[global_row_idx * graph_degree + k];
-
-        float batch_dist_ij  = batch_distances_h(i, j);
-        float global_dist_ik = global_distances_d[global_row_idx * graph_degree + k];
-
-        if (batch_index_ij == global_index_ik) {
-          // distances should be the same for these two
-          // printf("Looking at same index for row %lu\n", global_row_idx);
-
-          if (batch_dist_ij != global_dist_ik &&
-              global_dist_ik != std::numeric_limits<float>::max()) {
-            // raft::print_device_vector("batch distances:", batch_distances_d + i * graph_degree,
-            // graph_degree, std::cout); raft::print_host_vector("global distances:",
-            // global_distances_d + global_row_idx * graph_degree, graph_degree, std::cout);
-            // raft::print_host_vector("batch indices:", batch_indices_h + i * graph_degree,
-            // graph_degree, std::cout); raft::print_host_vector("global indices:", global_indices_d
-            // + global_row_idx * graph_degree, graph_degree, std::cout);
-            printf(
-              "\tWrong dist calculation [%lu]. For row %lu, distance to item %lu differs: %f VS "
-              "%f\n",
-              i,
-              global_row_idx,
-              batch_index_ij,
-              batch_dist_ij,
-              global_dist_ik);
-
-            raft::copy(cluster_data_h.data_handle(),
-                       cluster_data + i * num_cols,
-                       num_cols,
-                       raft::resource::get_cuda_stream(res));
-            raft::print_host_vector("item1", cluster_data_h.data_handle(), num_cols, std::cout);
-
-            for (size_t p = 0; p < num_data_in_cluster; p++) {
-              if (inverted_indices[p] == batch_index_ij) {
-                raft::copy(cluster_data_h.data_handle(),
-                           cluster_data + p * num_cols,
-                           num_cols,
-                           raft::resource::get_cuda_stream(res));
-                printf("batch row %lu\t", p);
-                raft::print_host_vector("item2", cluster_data_h.data_handle(), num_cols, std::cout);
-                break;
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
   raft::copy(batch_indices_d,
              batch_indices_h,
              num_data_in_cluster * graph_degree,
@@ -602,11 +491,6 @@ void cluster_nnd(raft::resources const& res,
       "# Data on host. Running clusters: %lu / %lu", cluster_id + 1, params.n_clusters);
     size_t num_data_in_cluster = cluster_size[cluster_id];
     size_t offset              = offsets[cluster_id];
-    printf("# Data on host. Running clusters: %lu / %lu (max %lu, num data: %lu)\n",
-           cluster_id + 1,
-           params.n_clusters,
-           max_cluster_size,
-           num_data_in_cluster);
 
 #pragma omp parallel for
     for (size_t i = 0; i < num_data_in_cluster; i++) {
@@ -669,11 +553,6 @@ void cluster_nnd(raft::resources const& res,
       "# Data on device. Running clusters: %lu / %lu", cluster_id + 1, params.n_clusters);
     size_t num_data_in_cluster = cluster_size[cluster_id];
     size_t offset              = offsets[cluster_id];
-    printf("# Data on device. Running clusters: %lu / %lu (max %lu, num data: %lu)\n",
-           cluster_id + 1,
-           params.n_clusters,
-           max_cluster_size,
-           num_data_in_cluster);
 
     auto cluster_data_view = raft::make_device_matrix_view<T, IdxT>(
       cluster_data_matrix.data_handle(), num_data_in_cluster, num_cols);
@@ -719,7 +598,6 @@ void batch_build(raft::resources const& res,
 
   size_t num_rows = static_cast<size_t>(dataset.extent(0));
   size_t num_cols = static_cast<size_t>(dataset.extent(1));
-  printf("num rows: %lu, num cols: %lu\n", num_rows, num_cols);
 
   auto centroids =
     raft::make_device_matrix<T, IdxT, raft::row_major>(res, params.n_clusters, num_cols);
@@ -750,7 +628,7 @@ void batch_build(raft::resources const& res,
                        inverted_indices.view(),
                        cluster_size.view(),
                        offset.view());
-  printf("max cluster size: %lu, min cluster size: %lu]\n", max_cluster_size, min_cluster_size);
+
   if (intermediate_degree >= min_cluster_size) {
     RAFT_LOG_WARN(
       "Intermediate graph degree cannot be larger than minimum cluster size, reducing it to %lu",

--- a/cpp/src/neighbors/detail/nn_descent_batch.cuh
+++ b/cpp/src/neighbors/detail/nn_descent_batch.cuh
@@ -223,7 +223,6 @@ void get_inverted_indices(raft::resources const& res,
   for (size_t i = 1; i < n_clusters; i++) {
     offset(i) = offset(i - 1) + cluster_size(i - 1);
   }
-
   for (size_t i = 0; i < num_rows; i++) {
     for (size_t j = 0; j < k; j++) {
       IdxT cluster_id = global_nearest_cluster(i, j);
@@ -385,9 +384,7 @@ void build_and_merge(raft::resources const& res,
                      IdxT* batch_indices_h,
                      IdxT* batch_indices_d,
                      float* batch_distances_d,
-                     GNND<const T, int>& nnd,
-                     size_t cluster_id,
-                     size_t num_cols)
+                     GNND<const T, int>& nnd)
 {
   nnd.build(cluster_data, num_data_in_cluster, int_graph, true, batch_distances_d);
 
@@ -514,9 +511,7 @@ void cluster_nnd(raft::resources const& res,
                              batch_indices_h,
                              batch_indices_d,
                              batch_distances_d,
-                             nnd,
-                             cluster_id,
-                             num_cols);
+                             nnd);
     nnd.reset(res);
   }
 }
@@ -577,9 +572,7 @@ void cluster_nnd(raft::resources const& res,
                              batch_indices_h,
                              batch_indices_d,
                              batch_distances_d,
-                             nnd,
-                             cluster_id,
-                             num_cols);
+                             nnd);
     nnd.reset(res);
   }
 }
@@ -619,7 +612,6 @@ void batch_build(raft::resources const& res,
   auto offset           = raft::make_host_vector<IdxT, IdxT, raft::row_major>(params.n_clusters);
 
   size_t max_cluster_size, min_cluster_size;
-
   get_inverted_indices(res,
                        params.n_clusters,
                        max_cluster_size,

--- a/cpp/tests/neighbors/ann_nn_descent.cuh
+++ b/cpp/tests/neighbors/ann_nn_descent.cuh
@@ -327,8 +327,6 @@ const std::vector<AnnNNDescentInputs> inputs =
                                                      {false, true},
                                                      {0.90});
 
-// TODO : Investigate why this test is failing Reference issue https
-// :  // github.com/rapidsai/raft/issues/2450
 const std::vector<AnnNNDescentBatchInputs> inputsBatch =
   raft::util::itertools::product<AnnNNDescentBatchInputs>(
     {std::make_pair(0.9, 3lu), std::make_pair(0.9, 2lu)},  // min_recall, n_clusters

--- a/cpp/tests/neighbors/ann_nn_descent.cuh
+++ b/cpp/tests/neighbors/ann_nn_descent.cuh
@@ -241,7 +241,7 @@ class AnnNNDescentBatchTest : public ::testing::TestWithParam<AnnNNDescentBatchI
         index_params.metric                    = ps.metric;
         index_params.graph_degree              = ps.graph_degree;
         index_params.intermediate_graph_degree = 2 * ps.graph_degree;
-        index_params.max_iterations            = 10;
+        index_params.max_iterations            = 20;
         index_params.return_distances          = true;
         index_params.n_clusters                = ps.recall_cluster.second;
 
@@ -287,8 +287,7 @@ class AnnNNDescentBatchTest : public ::testing::TestWithParam<AnnNNDescentBatchI
                                   ps.graph_degree,
                                   0.01,
                                   min_recall,
-                                  true,
-                                  static_cast<size_t>(ps.graph_degree * 0.1)));
+                                  true));
     }
   }
 

--- a/cpp/tests/neighbors/ann_nn_descent.cuh
+++ b/cpp/tests/neighbors/ann_nn_descent.cuh
@@ -241,7 +241,7 @@ class AnnNNDescentBatchTest : public ::testing::TestWithParam<AnnNNDescentBatchI
         index_params.metric                    = ps.metric;
         index_params.graph_degree              = ps.graph_degree;
         index_params.intermediate_graph_degree = 2 * ps.graph_degree;
-        index_params.max_iterations            = 20;
+        index_params.max_iterations            = 100;
         index_params.return_distances          = true;
         index_params.n_clusters                = ps.recall_cluster.second;
 

--- a/cpp/tests/neighbors/ann_nn_descent/test_float_uint32_t.cu
+++ b/cpp/tests/neighbors/ann_nn_descent/test_float_uint32_t.cu
@@ -23,12 +23,12 @@ namespace cuvs::neighbors::nn_descent {
 typedef AnnNNDescentTest<float, float, std::uint32_t> AnnNNDescentTestF_U32;
 TEST_P(AnnNNDescentTestF_U32, AnnNNDescent) { this->testNNDescent(); }
 
-// typedef AnnNNDescentBatchTest<float, float, std::uint32_t> AnnNNDescentBatchTestF_U32;
-// TEST_P(AnnNNDescentBatchTestF_U32, AnnNNDescentBatch) { this->testNNDescentBatch(); }
+typedef AnnNNDescentBatchTest<float, float, std::uint32_t> AnnNNDescentBatchTestF_U32;
+TEST_P(AnnNNDescentBatchTestF_U32, AnnNNDescentBatch) { this->testNNDescentBatch(); }
 
 INSTANTIATE_TEST_CASE_P(AnnNNDescentTest, AnnNNDescentTestF_U32, ::testing::ValuesIn(inputs));
-// INSTANTIATE_TEST_CASE_P(AnnNNDescentBatchTest,
-//                         AnnNNDescentBatchTestF_U32,
-//                         ::testing::ValuesIn(inputsBatch));
+INSTANTIATE_TEST_CASE_P(AnnNNDescentBatchTest,
+                        AnnNNDescentBatchTestF_U32,
+                        ::testing::ValuesIn(inputsBatch));
 
 }  // namespace   cuvs::neighbors::nn_descent


### PR DESCRIPTION
### Purpose of this PR
Handling duplicate indices in batch NN Descent graph.

Resolves the following issues
- https://github.com/rapidsai/raft/issues/2450
- https://github.com/rapidsai/cuvs/issues/559
- https://github.com/rapidsai/cuvs/issues/753
### Notes
- Also fixed in RAFT [here](https://github.com/rapidsai/raft/pull/2586) for current use with cuML