### PR TITLE
Java: Fixing the broken pre-filtering for Brute Force

### DIFF
--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/BruteForceQuery.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/BruteForceQuery.java
@@ -30,6 +30,7 @@ public class BruteForceQuery {
   private List<Integer> mapping;
   private float[][] queryVectors;
   private BitSet[] prefilters;
+  private int numDocs = -1;
   private int topK;
 
   /**
@@ -41,12 +42,15 @@ public class BruteForceQuery {
    * @param topK         the top k results to return
    * @param prefilter    the prefilter data to use while searching the BRUTEFORCE
    *                     index
+   * @param numDocs      Maximum of bits in each prefilter, representing number of documents in this index.
+   *                     Used only when prefilter(s) is/are passed.
    */
-  public BruteForceQuery(float[][] queryVectors, List<Integer> mapping, int topK, BitSet[] prefilters) {
+  public BruteForceQuery(float[][] queryVectors, List<Integer> mapping, int topK, BitSet[] prefilters, int numDocs) {
     this.queryVectors = queryVectors;
     this.mapping = mapping;
     this.topK = topK;
     this.prefilters = prefilters;
+    this.numDocs = numDocs;
   }
 
   /**
@@ -85,6 +89,15 @@ public class BruteForceQuery {
     return prefilters;
   }
 
+  /**
+   * Gets the number of documents supposed to be in this index, as used for prefilters
+   *
+   * @return number of documents as an integer
+   */
+  public int getNumDocs() {
+    return numDocs;
+  }
+
   @Override
   public String toString() {
     return "BruteForceQuery [mapping=" + mapping + ", queryVectors=" + Arrays.toString(queryVectors) + ", prefilter="
@@ -98,6 +111,7 @@ public class BruteForceQuery {
 
     private float[][] queryVectors;
     private BitSet[] prefilters;
+    private int numDocs;
     private List<Integer> mapping;
     private int topK = 2;
 
@@ -141,8 +155,9 @@ public class BruteForceQuery {
      *        many bits as there are vectors in the index
      * @return an instance of this Builder
      */
-    public Builder withPrefilter(BitSet[] prefilters) {
+    public Builder withPrefilter(BitSet[] prefilters, int numDocs) {
       this.prefilters = prefilters;
+      this.numDocs = numDocs;
       return this;
     }
 
@@ -152,7 +167,7 @@ public class BruteForceQuery {
      * @return an instance of {@link BruteForceQuery}
      */
     public BruteForceQuery build() {
-      return new BruteForceQuery(queryVectors, mapping, topK, prefilters);
+      return new BruteForceQuery(queryVectors, mapping, topK, prefilters, numDocs);
     }
   }
 }

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/BruteForceQuery.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/BruteForceQuery.java
@@ -17,6 +17,7 @@
 package com.nvidia.cuvs;
 
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.List;
 
 /**
@@ -28,7 +29,7 @@ public class BruteForceQuery {
 
   private List<Integer> mapping;
   private float[][] queryVectors;
-  private long[] prefilter;
+  private BitSet[] prefilters;
   private int topK;
 
   /**
@@ -41,11 +42,11 @@ public class BruteForceQuery {
    * @param prefilter    the prefilter data to use while searching the BRUTEFORCE
    *                     index
    */
-  public BruteForceQuery(float[][] queryVectors, List<Integer> mapping, int topK, long[] prefilter) {
+  public BruteForceQuery(float[][] queryVectors, List<Integer> mapping, int topK, BitSet[] prefilters) {
     this.queryVectors = queryVectors;
     this.mapping = mapping;
     this.topK = topK;
-    this.prefilter = prefilter;
+    this.prefilters = prefilters;
   }
 
   /**
@@ -78,16 +79,16 @@ public class BruteForceQuery {
   /**
    * Gets the prefilter long array
    *
-   * @return a long array
+   * @return an array of bitsets
    */
-  public long[] getPrefilter() {
-    return prefilter;
+  public BitSet[] getPrefilters() {
+    return prefilters;
   }
 
   @Override
   public String toString() {
     return "BruteForceQuery [mapping=" + mapping + ", queryVectors=" + Arrays.toString(queryVectors) + ", prefilter="
-        + Arrays.toString(prefilter) + ", topK=" + topK + "]";
+        + Arrays.toString(prefilters) + ", topK=" + topK + "]";
   }
 
   /**
@@ -96,7 +97,7 @@ public class BruteForceQuery {
   public static class Builder {
 
     private float[][] queryVectors;
-    private long[] prefilter;
+    private BitSet[] prefilters;
     private List<Integer> mapping;
     private int topK = 2;
 
@@ -134,13 +135,14 @@ public class BruteForceQuery {
     }
 
     /**
-     * Sets the prefilter data for building the {@link BruteForceQuery}.
+     * Sets the prefilters data for building the {@link BruteForceQuery}.
      *
-     * @param prefilter a one-dimensional long array
+     * @param prefilters array of bitsets, as many as queries, each containing as
+     *        many bits as there are vectors in the index
      * @return an instance of this Builder
      */
-    public Builder withPrefilter(long[] prefilter) {
-      this.prefilter = prefilter;
+    public Builder withPrefilter(BitSet[] prefilters) {
+      this.prefilters = prefilters;
       return this;
     }
 
@@ -150,7 +152,7 @@ public class BruteForceQuery {
      * @return an instance of {@link BruteForceQuery}
      */
     public BruteForceQuery build() {
-      return new BruteForceQuery(queryVectors, mapping, topK, prefilter);
+      return new BruteForceQuery(queryVectors, mapping, topK, prefilters);
     }
   }
 }

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/BruteForceIndexImpl.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/BruteForceIndexImpl.java
@@ -28,6 +28,8 @@ import java.lang.foreign.SequenceLayout;
 import java.lang.invoke.MethodHandle;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -59,7 +61,7 @@ public class BruteForceIndexImpl implements BruteForceIndex{
       FunctionDescriptor.of(ADDRESS, ADDRESS, C_LONG, C_LONG, ADDRESS, ADDRESS, C_INT));
 
   private static final MethodHandle searchMethodHandle = downcallHandle("search_brute_force_index",
-      FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, C_INT, C_LONG, C_INT, ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS, C_LONG, C_LONG));
+      FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, C_INT, C_LONG, C_INT, ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS, C_LONG));
 
   private static final MethodHandle destroyIndexMethodHandle = downcallHandle("destroy_brute_force_index",
       FunctionDescriptor.ofVoid(ADDRESS, ADDRESS));
@@ -169,16 +171,29 @@ public class BruteForceIndexImpl implements BruteForceIndex{
     long numQueries = cuvsQuery.getQueryVectors().length;
     long numBlocks = cuvsQuery.getTopK() * numQueries;
     int vectorDimension = numQueries > 0 ? cuvsQuery.getQueryVectors()[0].length : 0;
-    long prefilterDataLength = cuvsQuery.getPrefilter() != null ? cuvsQuery.getPrefilter().length : 0;
     long numRows = dataset != null ? dataset.length : 0;
 
     SequenceLayout neighborsSequenceLayout = MemoryLayout.sequenceLayout(numBlocks, C_LONG);
     SequenceLayout distancesSequenceLayout = MemoryLayout.sequenceLayout(numBlocks, C_FLOAT);
     MemorySegment neighborsMemorySegment = resources.getArena().allocate(neighborsSequenceLayout);
     MemorySegment distancesMemorySegment = resources.getArena().allocate(distancesSequenceLayout);
-    MemorySegment prefilterDataMemorySegment = cuvsQuery.getPrefilter() != null
-            ? Util.buildMemorySegment(resources.getArena(), cuvsQuery.getPrefilter())
-            : MemorySegment.NULL;
+
+    // prepare the prefiltering data
+    long prefilterDataLength = 0;
+    MemorySegment prefilterDataMemorySegment = MemorySegment.NULL;
+    BitSet[] prefilters = cuvsQuery.getPrefilters();
+    if (prefilters != null && prefilters.length > 0) {
+      BitSet concatenatedFilters = Util.concatenate(prefilters);
+      byte[] paddedFilterBytes = new byte[Util.roundUp(concatenatedFilters.toByteArray().length, 4)];
+      int pad = paddedFilterBytes.length - concatenatedFilters.toByteArray().length;
+      for (int i=0; i<concatenatedFilters.toByteArray().length; i++) {
+        paddedFilterBytes[pad+i] = concatenatedFilters.toByteArray()[i];
+      }
+      for (int i=0; i<pad; i++) paddedFilterBytes[i] = 0;
+      prefilterDataMemorySegment = Util.buildMemorySegment(resources.getArena(), paddedFilterBytes);
+      prefilterDataLength = paddedFilterBytes.length;
+    }
+
     MemorySegment querySeg = Util.buildMemorySegment(resources.getArena(), cuvsQuery.getQueryVectors());
     try (var localArena = Arena.ofConfined()) {
       MemorySegment returnValue = localArena.allocate(C_INT);
@@ -193,7 +208,7 @@ public class BruteForceIndexImpl implements BruteForceIndex{
         distancesMemorySegment,
         returnValue,
         prefilterDataMemorySegment,
-        prefilterDataLength, numRows
+        prefilterDataLength
       );
       checkError(returnValue.get(C_INT, 0L), "searchMethodHandle");
     }

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/Util.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/Util.java
@@ -25,6 +25,8 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
 import java.util.List;
 
 import com.nvidia.cuvs.GPUInfo;
@@ -184,6 +186,14 @@ public class Util {
     return dataMemorySegment;
   }
 
+  public static MemorySegment buildMemorySegment(Arena arena, byte[] data) {
+	int cells = data.length;
+	MemoryLayout dataMemoryLayout = MemoryLayout.sequenceLayout(cells, C_CHAR);
+	MemorySegment dataMemorySegment = arena.allocate(dataMemoryLayout);
+	MemorySegment.copy(data, 0, dataMemorySegment, C_CHAR, 0, cells);
+	return dataMemorySegment;
+  }
+
   /**
    * A utility method for building a {@link MemorySegment} for a 2D float array.
    *
@@ -201,4 +211,31 @@ public class Util {
     }
     return dataMemorySegment;
   }
+
+  public static BitSet concatenate(BitSet[] arr) {
+	// compute the size of the largest bitset
+	int size = -1;
+	for (BitSet b: arr) {
+	  if (b == null) continue;
+	  if (size == -1) size = Math.max(size, b.length());
+	}
+	if (size == -1) throw new RuntimeException("No valid bitset present in the array");
+	BitSet ret = new BitSet(size * arr.length);
+	for (int i=0; i<arr.length; i++) {
+		BitSet b = arr[i];
+		if (b == null || b.length() == 0) {
+			ret.set(i*size, (i+1)*size);
+		} else {
+			for (int j=0; j<size; j++) {
+				ret.set(i*size + j, b.get(j));
+			}
+		}
+	}
+	return ret;
+  }
+
+  public static int roundUp(int value, int multiplier) {
+    return (value + multiplier - 1) / multiplier * multiplier;
+  }
+
 }

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/Util.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/Util.java
@@ -187,11 +187,11 @@ public class Util {
   }
 
   public static MemorySegment buildMemorySegment(Arena arena, byte[] data) {
-	int cells = data.length;
-	MemoryLayout dataMemoryLayout = MemoryLayout.sequenceLayout(cells, C_CHAR);
-	MemorySegment dataMemorySegment = arena.allocate(dataMemoryLayout);
-	MemorySegment.copy(data, 0, dataMemorySegment, C_CHAR, 0, cells);
-	return dataMemorySegment;
+    int cells = data.length;
+    MemoryLayout dataMemoryLayout = MemoryLayout.sequenceLayout(cells, C_CHAR);
+    MemorySegment dataMemorySegment = arena.allocate(dataMemoryLayout);
+    MemorySegment.copy(data, 0, dataMemorySegment, C_CHAR, 0, cells);
+    return dataMemorySegment;
   }
 
   /**
@@ -213,25 +213,25 @@ public class Util {
   }
 
   public static BitSet concatenate(BitSet[] arr) {
-	// compute the size of the largest bitset
-	int size = -1;
-	for (BitSet b: arr) {
-	  if (b == null) continue;
-	  if (size == -1) size = Math.max(size, b.length());
-	}
-	if (size == -1) throw new RuntimeException("No valid bitset present in the array");
-	BitSet ret = new BitSet(size * arr.length);
-	for (int i=0; i<arr.length; i++) {
-		BitSet b = arr[i];
-		if (b == null || b.length() == 0) {
-			ret.set(i*size, (i+1)*size);
-		} else {
-			for (int j=0; j<size; j++) {
-				ret.set(i*size + j, b.get(j));
-			}
-		}
-	}
-	return ret;
+    // compute the size of the largest bitset
+    int size = -1;
+    for (BitSet b: arr) {
+      if (b == null) continue;
+      if (size == -1) size = Math.max(size, b.length());
+    }
+    if (size == -1) throw new RuntimeException("No valid bitset present in the array");
+    BitSet ret = new BitSet(size * arr.length);
+    for (int i=0; i<arr.length; i++) {
+      BitSet b = arr[i];
+      if (b == null || b.length() == 0) {
+        ret.set(i*size, (i+1)*size);
+      } else {
+        for (int j=0; j<size; j++) {
+          ret.set(i*size + j, b.get(j));
+        }
+      }
+    }
+    return ret;
   }
 
   public static int roundUp(int value, int multiplier) {

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/Util.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/Util.java
@@ -212,30 +212,19 @@ public class Util {
     return dataMemorySegment;
   }
 
-  public static BitSet concatenate(BitSet[] arr) {
-    // compute the size of the largest bitset
-    int size = -1;
-    for (BitSet b: arr) {
-      if (b == null) continue;
-      if (size == -1) size = Math.max(size, b.length());
-    }
-    if (size == -1) throw new RuntimeException("No valid bitset present in the array");
-    BitSet ret = new BitSet(size * arr.length);
+  public static BitSet concatenate(BitSet[] arr, int maxSizeOfEachBitSet) {
+    BitSet ret = new BitSet(maxSizeOfEachBitSet * arr.length);
     for (int i=0; i<arr.length; i++) {
       BitSet b = arr[i];
       if (b == null || b.length() == 0) {
-        ret.set(i*size, (i+1)*size);
+        ret.set(i*maxSizeOfEachBitSet, (i+1)*maxSizeOfEachBitSet);
       } else {
-        for (int j=0; j<size; j++) {
-          ret.set(i*size + j, b.get(j));
+        for (int j=0; j<maxSizeOfEachBitSet; j++) {
+          ret.set(i*maxSizeOfEachBitSet + j, b.get(j));
         }
       }
     }
     return ret;
-  }
-
-  public static int roundUp(int value, int multiplier) {
-    return (value + multiplier - 1) / multiplier * multiplier;
   }
 
 }

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/Util.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/Util.java
@@ -214,13 +214,13 @@ public class Util {
 
   public static BitSet concatenate(BitSet[] arr, int maxSizeOfEachBitSet) {
     BitSet ret = new BitSet(maxSizeOfEachBitSet * arr.length);
-    for (int i=0; i<arr.length; i++) {
+    for (int i = 0; i < arr.length; i++) {
       BitSet b = arr[i];
       if (b == null || b.length() == 0) {
-        ret.set(i*maxSizeOfEachBitSet, (i+1)*maxSizeOfEachBitSet);
+        ret.set(i * maxSizeOfEachBitSet, (i + 1) * maxSizeOfEachBitSet);
       } else {
-        for (int j=0; j<maxSizeOfEachBitSet; j++) {
-          ret.set(i*maxSizeOfEachBitSet + j, b.get(j));
+        for (int j = 0; j < maxSizeOfEachBitSet; j++) {
+          ret.set(i * maxSizeOfEachBitSet + j, b.get(j));
         }
       }
     }

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceAndSearchIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceAndSearchIT.java
@@ -16,12 +16,15 @@
 
 package com.nvidia.cuvs;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeTrue;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -30,9 +33,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeTrue;
-import static org.junit.Assert.assertEquals;
 
 public class BruteForceAndSearchIT extends CuVSTestCase{
 
@@ -57,33 +57,40 @@ public class BruteForceAndSearchIT extends CuVSTestCase{
         { 0.03902049f, 0.9689629f },
         { 0.92514056f, 0.4463501f },
         { 0.6673192f, 0.10993068f }
-      };
+    };
     List<Integer> map = List.of(0, 1, 2, 3);
     float[][] queries = {
         { 0.48216683f, 0.0428398f },
         { 0.5084142f, 0.6545497f },
         { 0.51260436f, 0.2643005f },
         { 0.05198065f, 0.5789965f }
-      };
+    };
 
     // Expected search results
-    List<Map<Integer, Float>> expectedResults = Arrays.asList(
+    final List<Map<Integer, Float>> expectedResults = Arrays.asList(
         Map.of(3, 0.038782537f, 2, 0.35904616f, 0, 0.83774555f),
         Map.of(0, 0.12472606f, 2, 0.21700788f, 1, 0.3191862f),
         Map.of(3, 0.047766685f, 2, 0.20332813f, 0, 0.48305476f),
         Map.of(1, 0.15224183f, 0, 0.5906347f, 3, 0.5986643f)
-      );
+        );
+
+    // pre-filtering
+    BitSet prefilter = new BitSet();
+    prefilter.set(0);
+    prefilter.set(1);
+    prefilter.clear(2);
+    prefilter.set(3);
+
+    final List<Map<Integer, Float>> expectedResultsWithFiltering = Arrays.asList(
+        Map.of(0, 0.83774555f, 1, 1.0540828f, 3, 0.038782537f),
+        Map.of(0, 0.12472606f, 1, 0.3191862f, 3, 0.32186073f),
+        Map.of(0, 0.48305476f, 1, 0.7208309f, 3, 0.047766685f),
+        Map.of(0, 0.5906347f, 1, 0.15224195f, 3, 0.5986643f)
+        );
 
     for (int j = 0; j < 10; j++) {
 
       try (CuVSResources resources = CuVSResources.create()) {
-
-        // Create a query object with the query vectors
-        BruteForceQuery cuvsQuery = new BruteForceQuery.Builder()
-            .withTopK(3)
-            .withQueryVectors(queries)
-            .withMapping(map)
-            .build();
 
         // Set index parameters
         BruteForceIndexParams indexParams = new BruteForceIndexParams.Builder()
@@ -108,19 +115,30 @@ public class BruteForceAndSearchIT extends CuVSTestCase{
             .build();
 
         // Perform the search
-        SearchResults resultsFromLoadedIndex = loadedIndex.search(cuvsQuery);
+        BruteForceQuery cuvsQuery = new BruteForceQuery.Builder()
+            .withTopK(3)
+            .withQueryVectors(queries)
+            .withMapping(map)
+            .build();
+        BruteForceQuery cuvsQueryWithFiltering = new BruteForceQuery.Builder()
+            .withTopK(3)
+            .withQueryVectors(queries)
+            .withPrefilter(new BitSet[] {prefilter, prefilter, prefilter, prefilter})
+            .withMapping(map)
+            .build();
 
-        // Check results
-        log.info(resultsFromLoadedIndex.getResults().toString());
-        assertEquals(expectedResults, resultsFromLoadedIndex.getResults());
+        // search the loaded index
+        SearchResults results = loadedIndex.search(cuvsQuery);
+        checkResults(expectedResults, results.getResults());
+        
+        // search the first index
+        results = index.search(cuvsQuery);
+        checkResults(expectedResults, results.getResults());
 
-        // Perform the search
-        SearchResults results = index.search(cuvsQuery);
-
-        // Check results
-        log.info(results.getResults().toString());
-        assertEquals(expectedResults, results.getResults());
-
+        // search with pre-filtering
+        results = index.search(cuvsQueryWithFiltering);
+        checkResults(expectedResultsWithFiltering, results.getResults());
+        
         // Cleanup
         index.destroyIndex();
         loadedIndex.destroyIndex();

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceAndSearchIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceAndSearchIT.java
@@ -67,7 +67,7 @@ public class BruteForceAndSearchIT extends CuVSTestCase{
     };
 
     // Expected search results
-    final List<Map<Integer, Float>> expectedResults = Arrays.asList(
+    List<Map<Integer, Float>> expectedResults = Arrays.asList(
         Map.of(3, 0.038782537f, 2, 0.35904616f, 0, 0.83774555f),
         Map.of(0, 0.12472606f, 2, 0.21700788f, 1, 0.3191862f),
         Map.of(3, 0.047766685f, 2, 0.20332813f, 0, 0.48305476f),

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceAndSearchIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceAndSearchIT.java
@@ -130,7 +130,7 @@ public class BruteForceAndSearchIT extends CuVSTestCase{
         // search the loaded index
         SearchResults results = loadedIndex.search(cuvsQuery);
         checkResults(expectedResults, results.getResults());
-        
+
         // search the first index
         results = index.search(cuvsQuery);
         checkResults(expectedResults, results.getResults());
@@ -138,7 +138,7 @@ public class BruteForceAndSearchIT extends CuVSTestCase{
         // search with pre-filtering
         results = index.search(cuvsQueryWithFiltering);
         checkResults(expectedResultsWithFiltering, results.getResults());
-        
+
         // Cleanup
         index.destroyIndex();
         loadedIndex.destroyIndex();

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceAndSearchIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceAndSearchIT.java
@@ -123,7 +123,7 @@ public class BruteForceAndSearchIT extends CuVSTestCase{
         BruteForceQuery cuvsQueryWithFiltering = new BruteForceQuery.Builder()
             .withTopK(3)
             .withQueryVectors(queries)
-            .withPrefilter(new BitSet[] {prefilter, prefilter, prefilter, prefilter})
+            .withPrefilter(new BitSet[] {prefilter, prefilter, prefilter, prefilter}, dataset.length)
             .withMapping(map)
             .build();
 

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceRandomizedIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceRandomizedIT.java
@@ -67,15 +67,14 @@ public class BruteForceRandomizedIT extends CuVSTestCase {
     BitSet[] prefilters = null;
     if (usePrefilter) {
       prefilters = new BitSet[numQueries];
-      for (int i=0; i<numQueries; i++) {
+      for (int i = 0; i < numQueries; i++) {
         BitSet randomFilter = new BitSet(datasetSize);
-        for (int j=0; j<datasetSize; j++) {
+        for (int j = 0; j < datasetSize; j++) {
           randomFilter.set(j, random.nextBoolean());
         }
         prefilters[i] = randomFilter;
       }
     }
-
 
     // Generate a random dataset
     float[][] dataset = generateData(random, datasetSize, dimensions);

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraRandomizedIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraRandomizedIT.java
@@ -91,7 +91,7 @@ public class CagraRandomizedIT extends CuVSTestCase {
     assert topK > 0 && topK <= datasetSize : "Invalid topK value.";
 
     // Generate expected results using brute force
-    List<List<Integer>> expected = generateExpectedResults(topK, dataset, queries, log);
+    List<List<Integer>> expected = generateExpectedResults(topK, dataset, queries, null, log);
 
     // Create CuVS index and query
     try (CuVSResources resources = CuVSResources.create()) {

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/CuVSTestCase.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/CuVSTestCase.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -50,16 +51,21 @@ public abstract class CuVSTestCase {
     return data;
   }
 
-  protected List<List<Integer>> generateExpectedResults(int topK, float[][] dataset, float[][] queries, Logger log) {
+  protected List<List<Integer>> generateExpectedResults(int topK, float[][] dataset, float[][] queries, BitSet[] prefilters, Logger log) {
     List<List<Integer>> neighborsResult = new ArrayList<>();
     int dimensions = dataset[0].length;
 
-    for (float[] query : queries) {
+    for (int q=0; q<queries.length; q++) {
+      float[] query = queries[q];
       Map<Integer, Double> distances = new TreeMap<>();
       for (int j = 0; j < dataset.length; j++) {
         double distance = 0;
-        for (int k = 0; k < dimensions; k++) {
-          distance += (query[k] - dataset[j][k]) * (query[k] - dataset[j][k]);
+        if (prefilters != null && prefilters[q].get(j) == false) {
+          distance = Double.POSITIVE_INFINITY;
+        } else {
+          for (int k = 0; k < dimensions; k++) {
+            distance += (query[k] - dataset[j][k]) * (query[k] - dataset[j][k]);
+          }
         }
         distances.put(j, Math.sqrt(distance));
       }
@@ -85,7 +91,6 @@ public abstract class CuVSTestCase {
     // actual vs. expected results
     for (int i = 0; i < results.getResults().size(); i++) {
       Map<Integer, Float> result = results.getResults().get(i);
-      assertEquals("TopK mismatch for query.", Math.min(topK, datasetSize), result.size());
 
       // Sort result by values (distances) and extract keys
       List<Integer> sortedResultKeys = result.entrySet().stream().sorted(Map.Entry.comparingByValue())

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/CuVSTestCase.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/CuVSTestCase.java
@@ -55,7 +55,7 @@ public abstract class CuVSTestCase {
     List<List<Integer>> neighborsResult = new ArrayList<>();
     int dimensions = dataset[0].length;
 
-    for (int q=0; q<queries.length; q++) {
+    for (int q = 0; q < queries.length; q++) {
       float[] query = queries[q];
       Map<Integer, Double> distances = new TreeMap<>();
       for (int j = 0; j < dataset.length; j++) {

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/CuVSTestCase.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/CuVSTestCase.java
@@ -101,6 +101,34 @@ public abstract class CuVSTestCase {
     }
   }
 
+  protected static void checkResults(List<Map<Integer, Float>> expected, List<Map<Integer, Float>> actual) {
+    List<Map<Integer, Float>> sortedExpected = new ArrayList<Map<Integer,Float>>();
+    List<Map<Integer, Float>> sortedActual   = new ArrayList<Map<Integer,Float>>();
+    for (Map<Integer, Float> map: expected) {
+      sortedExpected.add(new TreeMap<Integer, Float>(map) {
+        @Override
+        public boolean equals(Object o) {
+          Map<Integer, Float> map = (Map<Integer, Float>) o;
+          if (this.size() != map.size()) return false;
+          for (Integer key: map.keySet()) {
+            try {
+              if (Math.abs((float)map.get(key) - ((float)get(key))) < 0.0001f == false) {
+                return false;
+              }
+            } catch (Exception ex) {
+              return false;
+            }
+          }
+          return true;
+        }
+      });
+    }
+    for (Map<Integer, Float> map: actual) {
+      sortedActual.add(new TreeMap<Integer, Float>(map));
+    }
+    assertEquals(sortedExpected, sortedActual);
+  }
+
   protected static boolean isLinuxAmd64() {
     String name = System.getProperty("os.name");
     return (name.startsWith("Linux")) && System.getProperty("os.arch").equals("amd64");

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/HnswRandomizedIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/HnswRandomizedIT.java
@@ -97,7 +97,7 @@ public class HnswRandomizedIT extends CuVSTestCase {
     assert topK > 0 && topK <= datasetSize : "Invalid topK value.";
 
     // Generate expected results using brute force
-    List<List<Integer>> expected = generateExpectedResults(topK, dataset, queries, log);
+    List<List<Integer>> expected = generateExpectedResults(topK, dataset, queries, null, log);
 
     // Create CuVS index and query
     try (CuVSResources resources = CuVSResources.create()) {

--- a/java/internal/src/cuvs_java.c
+++ b/java/internal/src/cuvs_java.c
@@ -266,26 +266,20 @@ cuvsBruteForceIndex_t build_brute_force_index(float *dataset, long rows, long di
  * @param[in] n_rows number of rows in the dataset
  */
 void search_brute_force_index(cuvsBruteForceIndex_t index, float *queries, int topk, long n_queries, int dimensions,
-    cuvsResources_t cuvs_resources, int64_t *neighbors_h, float *distances_h, int *return_value, long *prefilter_data,
-    long prefilter_data_length, long n_rows) {
+    cuvsResources_t cuvs_resources, int64_t *neighbors_h, float *distances_h, int *return_value, unsigned char *prefilter_data,
+    long prefilter_data_length) {
 
   cudaStream_t stream;
   cuvsStreamGet(cuvs_resources, &stream);
 
   int64_t *neighbors;
   float *distances, *queries_d;
-  long *prefilter_data_d;
-
-  long prefilter_data_32_size = sizeof(uint32_t) * prefilter_data_length * 2;
-  uint32_t *prefilter_data_32 = (uint32_t *)malloc(prefilter_data_32_size);
 
   cuvsRMMAlloc(cuvs_resources, (void**) &queries_d, sizeof(float) * n_queries * dimensions);
   cuvsRMMAlloc(cuvs_resources, (void**) &neighbors, sizeof(int64_t) * n_queries * topk);
   cuvsRMMAlloc(cuvs_resources, (void**) &distances, sizeof(float) * n_queries * topk);
-  cuvsRMMAlloc(cuvs_resources, (void**) &prefilter_data_d, prefilter_data_32_size);
 
   cudaMemcpy(queries_d, queries, sizeof(float) * n_queries * dimensions, cudaMemcpyDefault);
-  cudaMemcpy(prefilter_data_d, prefilter_data_32, prefilter_data_32_size, cudaMemcpyDefault);
 
   int64_t queries_shape[2] = {n_queries, dimensions};
   DLManagedTensor queries_tensor = prepare_tensor(queries_d, queries_shape, kDLFloat, 32, 2, kDLCUDA);
@@ -296,20 +290,22 @@ void search_brute_force_index(cuvsBruteForceIndex_t index, float *queries, int t
   int64_t distances_shape[2] = {n_queries, topk};
   DLManagedTensor distances_tensor = prepare_tensor(distances, distances_shape, kDLFloat, 32, 2, kDLCUDA);
 
-  // unpack the incoming long into two 32bit ints
-  for (long i = 0; i < prefilter_data_length; i++) {
-    *(prefilter_data_32 + (2 * i)) = (int)(*(prefilter_data + i) >> 32);
-    *(prefilter_data_32 + ((2 * i) + 1)) = (int)*(prefilter_data + i);
-    //long l = (((long)*(prefilter_data_32 + (2 * i))) << 32) | (*(prefilter_data_32 + ((2 * i) + 1)) & 0xffffffffL);
-  }
-
   cuvsFilter prefilter;
   if (prefilter_data == NULL) {
     prefilter.type = NO_FILTER;
     prefilter.addr = (uintptr_t)NULL;
   } else {
-    int64_t prefilter_shape[1] = {(n_queries * n_rows + 31) / 32};
-    DLManagedTensor prefilter_tensor = prepare_tensor(prefilter_data_d, prefilter_shape, kDLUInt, 32, 1, kDLCUDA);
+    // Parse the filters data
+    uint32_t *prefilters = (uint32_t*) malloc(prefilter_data_length);
+    int num_integers = prefilter_data_length / sizeof(uint32_t);
+    for (int i=0; i<num_integers; i++) {
+      *(prefilters + i) = (uint32_t)prefilter_data[4*i + 1] << 24 |
+            (uint32_t)prefilter_data[4*i + 0] << 16 |
+            (uint32_t)prefilter_data[4*i + 3] << 8  |
+            (uint32_t)prefilter_data[4*i + 2];
+    }
+    int64_t prefilter_shape[1] = {prefilter_data_length};
+    DLManagedTensor prefilter_tensor = prepare_tensor(prefilters, prefilter_shape, kDLUInt, 32, 1, kDLCUDA);
     prefilter.type = BITMAP;
     prefilter.addr = (uintptr_t)&prefilter_tensor;
   }


### PR DESCRIPTION
Changed the signature from `long[] prefilter` to `BitSet[] prefilters`.
Added a very simple test.