### PR TITLE
Expand NVTX annotations in CAGRA build and HNSW

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -636,6 +636,7 @@ SECTIONS
   if(CUVS_NVTX)
     # This enables NVTX within the project with no option to disable it downstream.
     target_link_libraries(cuvs PUBLIC CUDA::nvtx3)
+    target_compile_definitions(cuvs_objs PUBLIC NVTX_ENABLED)
     target_compile_definitions(cuvs PUBLIC NVTX_ENABLED)
 
     target_link_libraries(cuvs-cagra-search PUBLIC CUDA::nvtx3)

--- a/cpp/src/neighbors/hnsw.cpp
+++ b/cpp/src/neighbors/hnsw.cpp
@@ -15,20 +15,22 @@
  */
 
 #include "detail/hnsw.hpp"
+#include "../core/nvtx.hpp"
 #include <cstdint>
 #include <cuvs/neighbors/hnsw.hpp>
 #include <sys/types.h>
 
 namespace cuvs::neighbors::hnsw {
 
-#define CUVS_INST_HNSW_FROM_CAGRA(T)                                                  \
-  std::unique_ptr<index<T>> from_cagra(                                               \
-    raft::resources const& res,                                                       \
-    const index_params& params,                                                       \
-    const cuvs::neighbors::cagra::index<T, uint32_t>& cagra_index,                    \
-    std::optional<raft::host_matrix_view<const T, int64_t, raft::row_major>> dataset) \
-  {                                                                                   \
-    return detail::from_cagra<T>(res, params, cagra_index, dataset);                  \
+#define CUVS_INST_HNSW_FROM_CAGRA(T)                                                           \
+  std::unique_ptr<index<T>> from_cagra(                                                        \
+    raft::resources const& res,                                                                \
+    const index_params& params,                                                                \
+    const cuvs::neighbors::cagra::index<T, uint32_t>& cagra_index,                             \
+    std::optional<raft::host_matrix_view<const T, int64_t, raft::row_major>> dataset)          \
+  {                                                                                            \
+    raft::common::nvtx::range<cuvs::common::nvtx::domain::cuvs> fun_scope("hnsw::from_cagra"); \
+    return detail::from_cagra<T>(res, params, cagra_index, dataset);                           \
   }
 
 CUVS_INST_HNSW_FROM_CAGRA(float);


### PR DESCRIPTION
Add a few more NVTX annotations in CAGRA and HNSW routines to make it easier to analyze index build times.
Add the missing `NVTX_ENABLED` definition to `cuvs_objs` (without this, only CAGRA-search-related annotations are enabled as they are a part of a different component).