### PR TITLE
Unify use of OpenMP for HNSW threading models

### DIFF
--- a/cpp/src/neighbors/detail/hnsw.hpp
+++ b/cpp/src/neighbors/detail/hnsw.hpp
@@ -489,26 +489,15 @@ void search(raft::resources const& res,
   auto const* hnswlib_index =
     reinterpret_cast<hnswlib::HierarchicalNSW<typename hnsw_dist_t<T>::type> const*>(
       idx.get_index());
+  auto num_threads = params.num_threads == 0 ? omp_get_max_threads() : params.num_threads;
 
-  // when num_threads == 0, automatically maximize parallelism
-  if (params.num_threads) {
 #pragma omp parallel for num_threads(params.num_threads)
-    for (int64_t i = 0; i < queries.extent(0); ++i) {
-      get_search_knn_results(hnswlib_index,
-                             queries.data_handle() + i * queries.extent(1),
-                             neighbors.extent(1),
-                             neighbors.data_handle() + i * neighbors.extent(1),
-                             distances.data_handle() + i * distances.extent(1));
-    }
-  } else {
-#pragma omp parallel for
-    for (int64_t i = 0; i < queries.extent(0); ++i) {
-      get_search_knn_results(hnswlib_index,
-                             queries.data_handle() + i * queries.extent(1),
-                             neighbors.extent(1),
-                             neighbors.data_handle() + i * neighbors.extent(1),
-                             distances.data_handle() + i * distances.extent(1));
-    }
+  for (int64_t i = 0; i < queries.extent(0); ++i) {
+    get_search_knn_results(hnswlib_index,
+                           queries.data_handle() + i * queries.extent(1),
+                           neighbors.extent(1),
+                           neighbors.data_handle() + i * neighbors.extent(1),
+                           distances.data_handle() + i * distances.extent(1));
   }
 }
 

--- a/python/cuvs_bench/cuvs_bench/config/algos/cuvs_cagra_hnswlib.yaml
+++ b/python/cuvs_bench/cuvs_bench/config/algos/cuvs_cagra_hnswlib.yaml
@@ -8,7 +8,7 @@ groups:
       graph_degree: [32, 64, 96, 128]
       intermediate_graph_degree: [32, 64, 96, 128]
       graph_build_algo: ["NN_DESCENT"]
-      hierarchy: ["none", "cpu"]
+      hierarchy: ["none", "cpu", "gpu"]
       ef_construction: [64, 128, 256, 512]
     search:
       ef: [10, 20, 40, 60, 80, 120, 200, 400, 600, 800]


### PR DESCRIPTION
`cuvs_bench` hnswlib wrapper was using a custom threading pool while `cuvs` hnsw wrapper was using OpenMP for parallelism. This was causing unexpected deviations in measured timings.