### PR TITLE
Use rapids-version-major-minor for libraft pinnings.

### DIFF
--- a/ci/build_go.sh
+++ b/ci/build_go.sh
@@ -34,6 +34,6 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   "libcuvs=${RAPIDS_VERSION}" \
-  "libraft=${RAPIDS_VERSION}"
+  "libraft=$(rapids-version-major-minor)"
 
 bash ./build.sh go

--- a/ci/build_rust.sh
+++ b/ci/build_rust.sh
@@ -35,6 +35,6 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   "libcuvs=${RAPIDS_VERSION}" \
-  "libraft=${RAPIDS_VERSION}"
+  "libraft=$(rapids-version-major-minor)"
 
 bash ./build.sh rust


### PR DESCRIPTION
This fixes libraft version issues blocking Go and Rust builds.
