### PR TITLE
cuvs-bench-cpu: avoid 'mkl' dependency on aarch64

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -48,7 +48,6 @@ sccache --zero-stats
 RAPIDS_CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
 if [[ ${RAPIDS_CUDA_MAJOR} == "12" ]]; then
   rapids-conda-retry build \
-  --no-test \
   --channel "${CPP_CHANNEL}" \
   --channel "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" \
   conda/recipes/cuvs-bench-cpu

--- a/conda/recipes/cuvs-bench-cpu/meta.yaml
+++ b/conda/recipes/cuvs-bench-cpu/meta.yaml
@@ -67,6 +67,17 @@ requirements:
     - python
     - requests
     - scikit-learn>=1.5
+
+test:
+  # test that the package is installable and these modules are importable
+  imports:
+    - cuvs_bench
+    - cuvs_bench.data_export
+    - cuvs_bench.get_dataset
+    - cuvs_bench.plot
+    - cuvs_bench.run
+    - cuvs_bench.split_groundtruth
+
 about:
   home: https://rapids.ai/
   license: Apache-2.0

--- a/conda/recipes/cuvs-bench-cpu/meta.yaml
+++ b/conda/recipes/cuvs-bench-cpu/meta.yaml
@@ -72,10 +72,11 @@ test:
   # test that the package is installable and these modules are importable
   imports:
     - cuvs_bench
-    - cuvs_bench.data_export
+    - cuvs_bench.generate_groundtruth
     - cuvs_bench.get_dataset
     - cuvs_bench.plot
     - cuvs_bench.run
+    - cuvs_bench.run.data_export
     - cuvs_bench.split_groundtruth
 
 about:

--- a/conda/recipes/cuvs-bench-cpu/meta.yaml
+++ b/conda/recipes/cuvs-bench-cpu/meta.yaml
@@ -76,7 +76,6 @@ test:
     - cuvs_bench.get_dataset
     - cuvs_bench.plot
     - cuvs_bench.run
-    - cuvs_bench.run.data_export
     - cuvs_bench.split_groundtruth
 
 about:

--- a/conda/recipes/cuvs-bench-cpu/meta.yaml
+++ b/conda/recipes/cuvs-bench-cpu/meta.yaml
@@ -60,7 +60,7 @@ requirements:
     - glog {{ glog_version }}
     - h5py {{ h5py_version }}
     - matplotlib-base
-    - mkl =2023
+    - mkl =2023  # [linux64]
     - numpy >=1.23,<3.0a0
     - pandas
     - pyyaml

--- a/docs/source/cuvs_bench/index.rst
+++ b/docs/source/cuvs_bench/index.rst
@@ -120,7 +120,7 @@ The steps below demonstrate how to download, install, and run benchmarks on a su
     python -m cuvs_bench.run --dataset deep-image-96-inner --algorithms cuvs_cagra --batch-size 10 -k 10
 
     # (3) export data
-    python -m cuvs_bench.data_export --dataset deep-image-96-inner
+    python -m cuvs_bench.run.data_export --dataset deep-image-96-inner
 
     # (4) plot results
     python -m cuvs_bench.plot --dataset deep-image-96-inner
@@ -204,7 +204,7 @@ The steps below demonstrate how to download, install, and run benchmarks on a su
     python -m cuvs_bench.run --dataset deep-1B --algorithms cuvs_cagra --batch-size 10 -k 10
 
     # (3) export data
-    python -m cuvs_bench.data_export --dataset deep-1B
+    python -m cuvs_bench.run.data_export --dataset deep-1B
 
     # (4) plot results
     python -m cuvs_bench.plot --dataset deep-1B

--- a/docs/source/cuvs_bench/index.rst
+++ b/docs/source/cuvs_bench/index.rst
@@ -120,7 +120,7 @@ The steps below demonstrate how to download, install, and run benchmarks on a su
     python -m cuvs_bench.run --dataset deep-image-96-inner --algorithms cuvs_cagra --batch-size 10 -k 10
 
     # (3) export data
-    python -m cuvs_bench.run.data_export --dataset deep-image-96-inner
+    python -m cuvs_bench.run --data-export --dataset deep-image-96-inner
 
     # (4) plot results
     python -m cuvs_bench.plot --dataset deep-image-96-inner
@@ -204,7 +204,7 @@ The steps below demonstrate how to download, install, and run benchmarks on a su
     python -m cuvs_bench.run --dataset deep-1B --algorithms cuvs_cagra --batch-size 10 -k 10
 
     # (3) export data
-    python -m cuvs_bench.run.data_export --dataset deep-1B
+    python -m cuvs_bench.run --data-export --dataset deep-1B
 
     # (4) plot results
     python -m cuvs_bench.plot --dataset deep-1B


### PR DESCRIPTION
Fixes https://github.com/rapidsai/docker/issues/739

#260 introduced a runtime dependency on `mkl` for the `cuvs-bench-cpu` conda package. There are not aarch64 packages for `mkl` on conda-forge, so this makes `cuvs-bench-cpu` impossible to install on aarch64.

This fixes that, by applying the same "only add on x86_64" guard used for `mkl` everywhere else in this project, e.g. like this:

https://github.com/rapidsai/cuvs/blob/89b03493b487910d2125fde6680590adde8e2a95/conda/recipes/cuvs-bench-cpu/meta.yaml#L51

It also proposes adding import tests to the `cuvs-bench-cpu` conda recipe, so issues like this can be caught in CI in the future.

## Notes for Reviewers

I searched for references like this

```shell
git grep -i mkl
```

### How I tested this

Saw lines like this in `conda-python-build` logs:

```text
BUILD START: ['cuvs-bench-cpu-25.04.00a96-py312_250305_g94340bc_96.conda']
...
TEST START: /tmp/conda-bld-output/linux-aarch64/cuvs-bench-cpu-25.04.00a96-py312_250305_g94340bc_96.conda
...
import: 'cuvs_bench'
import: 'cuvs_bench.generate_groundtruth'
import: 'cuvs_bench.get_dataset'
import: 'cuvs_bench.plot'
import: 'cuvs_bench.run'
import: 'cuvs_bench.run.data_export'
import: 'cuvs_bench.split_groundtruth'
import: 'cuvs_bench'
import: 'cuvs_bench.generate_groundtruth'
import: 'cuvs_bench.get_dataset'
import: 'cuvs_bench.plot'
import: 'cuvs_bench.run'
import: 'cuvs_bench.run.data_export'
import: 'cuvs_bench.split_groundtruth'
...
TEST END: /tmp/conda-bld-output/linux-aarch64/cuvs-bench-cpu-25.04.00a96-py312_250305_g94340bc_96.conda
```

([build link](https://github.com/rapidsai/cuvs/actions/runs/13687659537/job/38276160494?pr=750#step:9:5961))