### PR TITLE
Remove the duplicates when the dataset contains identical vectors

### DIFF
--- a/cpp/include/cuvs/neighbors/cagra.hpp
+++ b/cpp/include/cuvs/neighbors/cagra.hpp
@@ -150,6 +150,11 @@ struct index_params : cuvs::neighbors::index_params {
    * @endcode
    */
   bool attach_dataset_on_build = true;
+
+  /**
+   * Whether to deactivate the duplicate nodes.
+   */
+  bool deactivate_duplicate_nodes = false;
 };
 
 /**

--- a/cpp/src/neighbors/detail/cagra/cagra_build.cpp
+++ b/cpp/src/neighbors/detail/cagra/cagra_build.cpp
@@ -25,10 +25,13 @@ ivf_pq_params::ivf_pq_params(raft::matrix_extent<int64_t> dataset_extents,
 {
   build_params = cuvs::neighbors::ivf_pq::index_params::from_dataset(dataset_extents, metric);
 
-  search_params                         = cuvs::neighbors::ivf_pq::search_params{};
-  search_params.n_probes                = std::max<uint32_t>(10, build_params.n_lists * 0.01);
-  search_params.lut_dtype               = CUDA_R_16F;
-  search_params.internal_distance_dtype = CUDA_R_16F;
+  search_params          = cuvs::neighbors::ivf_pq::search_params{};
+  search_params.n_probes = std::max<uint32_t>(10, build_params.n_lists * 0.01);
+  // [Note] FP16 is fast when used, but we found that overflows occur in IVF-PQ
+  // distance calculation for some datasets, such as sift. To address this problem,
+  // FP32 is used for building the initial knn graph.
+  search_params.lut_dtype               = CUDA_R_32F;
+  search_params.internal_distance_dtype = CUDA_R_32F;
 
   refinement_rate = 2;
 }

--- a/cpp/src/neighbors/detail/cagra/cagra_build.cuh
+++ b/cpp/src/neighbors/detail/cagra/cagra_build.cuh
@@ -533,21 +533,21 @@ void deactivate_duplicate_nodes(
 
 #pragma omp parallel for
   for (IdxT i = 0; i < graph.extent(0); i++) {
-    auto si = get_small_node(small_node.view(), i);
     for (uint32_t k = 0; k < graph.extent(1); k++) {
       auto j = graph(i, k);
       if (!check_if_same_vector(dataset, i, j)) { break; }
+      auto si = get_small_node(small_node.view(), i);
       auto sj = get_small_node(small_node.view(), j);
       if (si == sj) { continue; }
-      if (si > sj) {
-        auto tmp = si;
-        si       = sj;
-        sj       = tmp;
-      }
 #pragma omp critical
       {
-        cuvs::neighbors::cagra::detail::bitset_set(bitset_ptr, sj, true);
-        small_node(sj) = si;
+        if (si > sj) {
+          cuvs::neighbors::cagra::detail::bitset_set(bitset_ptr, si, true);
+          small_node(si) = sj;
+        } else {
+          cuvs::neighbors::cagra::detail::bitset_set(bitset_ptr, sj, true);
+          small_node(sj) = si;
+        }
       }
       break;
     }

--- a/cpp/src/neighbors/detail/cagra/cagra_build.cuh
+++ b/cpp/src/neighbors/detail/cagra/cagra_build.cuh
@@ -276,6 +276,45 @@ void build_knn_graph(
       // we need to ensure the copy operations are done prior using the host data
       raft::resource::sync_stream(res);
 
+      {
+        char buffer[256];
+        std::string message = "";
+        std::sprintf(buffer, "[%s, %d] Checking neighbors_host\n", __FILE__, __LINE__);
+        message += buffer;
+        uint64_t count = 0;
+        for (int64_t i = 0; i < (int64_t)batch.size(); i++) {
+          int64_t num_unique_nodes = 1;
+          for (int64_t k0 = 1; k0 < neighbors_host.extent(1); k0++) {
+            bool dup = false;
+            for (int64_t k1 = 0; k1 < k0; k1++) {
+              if (neighbors_host(i, k1) != neighbors_host(i, k0)) { continue; }
+              dup = true;
+              break;
+            }
+            if (!dup) { num_unique_nodes += 1; }
+          }
+          if (num_unique_nodes >= neighbors_host.extent(1)) { continue; }
+          count++;
+          if (count <= 5) {
+            std::sprintf(buffer,
+                         "# i:%lu (batch_offset:%lu), neighbors_graph:",
+                         (uint64_t)i + batch.offset(),
+                         batch.offset());
+            message += buffer;
+            for (int64_t k = 0; k < neighbors_host.extent(1); k++) {
+              std::sprintf(buffer, " %lu,", (uint64_t)neighbors_host(i, k));
+              message += buffer;
+            }
+            message += "\n";
+          }
+        }
+        if (count > 0) {
+          std::sprintf(buffer, "# count: %ld", count);
+          message += buffer;
+          RAFT_LOG_WARN("%s", message.c_str());
+        }
+      }
+
       // process last batch
       if (previous_batch_offset + previous_batch_size == (size_t)num_queries) {
         refine_host_and_write_graph(res,
@@ -343,6 +382,43 @@ void build_knn_graph(
     first = false;
   }
 
+  RAFT_LOG_INFO("[%s, %d] Checking knn_graph", __FILE__, __LINE__);  // **** debug ****
+  uint64_t count = 0;
+  char buffer[256];
+  std::string message = "";
+  for (int64_t i = 0; i < knn_graph.extent(0); i++) {
+    int64_t num_unique_nodes = 1;
+    for (int64_t k0 = 1; k0 < knn_graph.extent(1); k0++) {
+      bool dup = false;
+      for (int64_t k1 = 0; k1 < k0; k1++) {
+        if (knn_graph(i, k1) != knn_graph(i, k0)) { continue; }
+        dup = true;
+        break;
+      }
+      if (!dup) { num_unique_nodes += 1; }
+    }
+    if (num_unique_nodes >= knn_graph.extent(1)) { continue; }
+    if (count < 10) {
+      if (count == 0) {
+        std::sprintf(buffer, "Duplicate nodes exist in knn_graph\n");
+        message += buffer;
+      }
+      std::sprintf(buffer, "# i:%ld, knn_graph:", i);
+      message += buffer;
+      for (int64_t k = 0; k < knn_graph.extent(1); k++) {
+        std::sprintf(buffer, " %lu,", (uint64_t)knn_graph(i, k));
+        message += buffer;
+      }
+      message += "\n";
+    }
+    count++;
+  }
+  if (count > 0) {
+    std::sprintf(buffer, "# count: %ld\n", count);
+    message += buffer;
+    RAFT_LOG_WARN("%s", message.c_str());
+  }
+
   if (!first) RAFT_LOG_DEBUG("# Finished building kNN graph");
 }
 
@@ -380,7 +456,8 @@ void optimize(
   raft::resources const& res,
   raft::mdspan<IdxT, raft::matrix_extent<int64_t>, raft::row_major, g_accessor> knn_graph,
   raft::host_matrix_view<IdxT, int64_t, raft::row_major> new_graph,
-  const bool guarantee_connectivity = false)
+  const bool guarantee_connectivity        = false,
+  const uint32_t* deactivated_nodes_bitset = nullptr)
 {
   using internal_IdxT = typename std::make_unsigned<IdxT>::type;
 
@@ -399,7 +476,78 @@ void optimize(
       knn_graph.extent(1));
 
   cagra::detail::graph::optimize(
-    res, knn_graph_internal, new_graph_internal, guarantee_connectivity);
+    res, knn_graph_internal, new_graph_internal, guarantee_connectivity, deactivated_nodes_bitset);
+}
+
+template <typename T,
+          typename IdxT     = uint32_t,
+          typename Accessor = raft::host_device_accessor<std::experimental::default_accessor<T>,
+                                                         raft::memory_type::host>>
+bool check_if_same_vector(
+  raft::mdspan<const T, raft::matrix_extent<int64_t>, raft::row_major, Accessor> dataset,
+  const IdxT i,
+  const IdxT j)
+{
+  for (auto k = 0; k < dataset.extent(1); k++) {
+    if (dataset(i, k) != dataset(j, k)) { return false; }
+  }
+  return true;
+}
+
+template <typename T,
+          typename IdxT     = uint32_t,
+          typename Accessor = raft::host_device_accessor<std::experimental::default_accessor<T>,
+                                                         raft::memory_type::host>>
+void deactivate_duplicate_nodes(
+  raft::host_matrix_view<IdxT, int64_t, raft::row_major> graph,
+  raft::mdspan<const T, raft::matrix_extent<int64_t>, raft::row_major, Accessor> dataset,
+  uint32_t* bitset_ptr = nullptr)
+{
+  if (bitset_ptr == nullptr) return;
+
+  // If there are nodes with the same vector, the one with the large ID
+  // is deactivated as a duplicate node.
+  uint64_t count = 0;
+#pragma omp parallel for schedule(static, 32) reduction(+ : count)
+  for (IdxT i = 0; i < graph.extent(0); i++) {
+    if (cuvs::neighbors::cagra::detail::bitset_test(bitset_ptr, i)) {
+      count += 1;
+      continue;
+    }
+    for (uint32_t k = 0; k < graph.extent(1); k++) {
+      auto j = graph(i, k);
+      if (i <= j) { continue; }
+      if (!check_if_same_vector(dataset, i, j)) { break; }
+      // Although "omp critical" is originally required here, it is made
+      // unnecessary by setting the unit of iteration allocation to each
+      // thread to 32 by "schedule(static, 32)".
+      cuvs::neighbors::cagra::detail::bitset_set(bitset_ptr, i, true);
+      count += 1;
+      break;
+    }
+  }
+  if (count > 0) {
+    RAFT_LOG_INFO("Duplicate nodes were found (# deactivated nodes: %lu / %lu (%.2lf%%))",
+                  count,
+                  (uint64_t)graph.extent(0),
+                  100 * (double)count / graph.extent(0));
+  }
+
+#pragma omp parallel for
+  for (IdxT i = 0; i < graph.extent(0); i++) {
+    if (cuvs::neighbors::cagra::detail::bitset_test(bitset_ptr, i)) {
+      // If node-i is a duplicate node, all edges from it are directed back to itself.
+      for (int64_t k = 0; k < graph.extent(1); k++) {
+        graph(i, k) = i;
+      }
+    } else {
+      for (int64_t k = 0; k < graph.extent(1); k++) {
+        auto j = graph(i, k);
+        // If node-j is a duplicate node, an edge to it is directed back to node-i.
+        if (cuvs::neighbors::cagra::detail::bitset_test(bitset_ptr, j)) { graph(i, k) = i; }
+      }
+    }
+  }
 }
 
 template <typename T,
@@ -409,7 +557,8 @@ template <typename T,
 auto iterative_build_graph(
   raft::resources const& res,
   const index_params& params,
-  raft::mdspan<const T, raft::matrix_extent<int64_t>, raft::row_major, Accessor> dataset)
+  raft::mdspan<const T, raft::matrix_extent<int64_t>, raft::row_major, Accessor> dataset,
+  uint32_t* deactivated_nodes_bitset = nullptr)
 {
   size_t intermediate_degree = params.intermediate_graph_degree;
   size_t graph_degree        = params.graph_degree;
@@ -485,11 +634,18 @@ auto iterative_build_graph(
     }
   }
 
+  auto pre_neighbors                     = raft::make_host_matrix<IdxT, int64_t>(0, 0);
+  bool check_match_rate                  = false;
+  int32_t num_check_match_rate           = 0;
+  constexpr int32_t max_check_match_rate = 1;
+  constexpr double match_rate_threshold  = 0.9;
+
   auto curr_graph_size = initial_graph_size;
   while (true) {
-    RAFT_LOG_DEBUG("# graph_size = %lu (%.3lf)",
-                   (uint64_t)curr_graph_size,
-                   (double)curr_graph_size / final_graph_size);
+    // **** debug ****
+    RAFT_LOG_INFO("graph_size = %lu (%.3lf)",
+                  (uint64_t)curr_graph_size,
+                  (double)curr_graph_size / final_graph_size);
 
     auto curr_query_size   = std::min(2 * curr_graph_size, final_graph_size);
     auto curr_topk         = small_topk;
@@ -518,6 +674,7 @@ auto iterative_build_graph(
       dev_dataset.data_handle(), (int64_t)curr_query_size, dev_dataset.extent(1));
     auto neighbors = raft::make_host_matrix<IdxT, int64_t>(curr_query_size, curr_topk);
 
+    RAFT_LOG_INFO("Searching ...");  // **** debug ****
     // Search.
     // Since there are many queries, divide them into batches and search them.
     cuvs::spatial::knn::detail::utils::batch_load_iterator<T> query_batch(
@@ -550,14 +707,59 @@ auto iterative_build_graph(
                  raft::resource::get_cuda_stream(res));
     }
 
+    RAFT_LOG_INFO("Deactivating duplicate nodes ...");  // **** debug ****
+    // Deactivate duplicate nodes
+    deactivate_duplicate_nodes(neighbors.view(), dataset, deactivated_nodes_bitset);
+
+    bool flag_last = false;
+    if (check_match_rate) {
+      if (num_check_match_rate >= max_check_match_rate) {
+        flag_last = true;
+      } else {
+        RAFT_LOG_INFO("Checking match rate ...");  // **** debug ****
+        // Check match rate between pre_neighbors and neighbors
+        int64_t count = 0;
+#pragma omp parallel for reduction(+ : count)
+        for (int64_t i = 0; i < neighbors.extent(0); i++) {
+          for (int64_t k1 = 0; k1 < neighbors.extent(1); k1++) {
+            auto j = neighbors(i, k1);
+            for (int64_t k2 = 0; k2 < pre_neighbors.extent(1); k2++) {
+              if (j != pre_neighbors(i, k2)) { continue; }
+              count += 1;
+              break;
+            }
+          }
+        }
+        int64_t num_edges = neighbors.extent(0) * neighbors.extent(1);
+        double match_rate = (double)count / num_edges;
+        if (match_rate >= match_rate_threshold) { flag_last = true; }
+        RAFT_LOG_INFO(
+          "match_rate: %lf (%ld / %ld)", match_rate, count, num_edges);  // **** debug ****
+        num_check_match_rate += 1;
+      }
+      // delete pre_neighbors
+      pre_neighbors = raft::make_host_matrix<IdxT, int64_t>(0, 0);
+    }
+
+    RAFT_LOG_INFO("Optimizing graph ...");  // **** debug ****
     // Optimize graph
-    bool flag_last  = (curr_graph_size == final_graph_size);
+    // bool flag_last  = (curr_graph_size == final_graph_size);
     curr_graph_size = curr_query_size;
     cagra_graph     = raft::make_host_matrix<IdxT, int64_t>(0, 0);  // delete existing grahp
     cagra_graph     = raft::make_host_matrix<IdxT, int64_t>(curr_graph_size, curr_graph_degree);
-    optimize<IdxT>(
-      res, neighbors.view(), cagra_graph.view(), flag_last ? params.guarantee_connectivity : 0);
+    optimize<IdxT>(res,
+                   neighbors.view(),
+                   cagra_graph.view(),
+                   // flag_last ? params.guarantee_connectivity : 0,
+                   params.guarantee_connectivity,
+                   deactivated_nodes_bitset);
     if (flag_last) { break; }
+
+    if (curr_query_size == final_graph_size) {
+      // Keep neighbors as pre_neighbors
+      pre_neighbors    = neighbors;
+      check_match_rate = true;
+    }
   }
 
   return cagra_graph;
@@ -609,12 +811,21 @@ index<T, IdxT> build(
     "IVF_PQ and NN_DESCENT for CAGRA graph build do not support BitwiseHamming as a metric. Please "
     "use the iterative CAGRA search build.");
 
+  //
+  uint32_t* bitset_ptr = nullptr;
+  size_t bitset_size   = 0;
+  if (params.deactivate_duplicate_nodes) {
+    bitset_size = sizeof(uint32_t) * (dataset.extent(0) + 31) / 32;
+    bitset_ptr  = (uint32_t*)malloc(bitset_size);
+    memset(bitset_ptr, 0, bitset_size);
+  }
+
   auto cagra_graph = raft::make_host_matrix<IdxT, int64_t>(0, 0);
 
   // Dispatch based on graph_build_params
   if (std::holds_alternative<cagra::graph_build_params::iterative_search_params>(
         knn_build_params)) {
-    cagra_graph = iterative_build_graph<T, IdxT, Accessor>(res, params, dataset);
+    cagra_graph = iterative_build_graph<T, IdxT, Accessor>(res, params, dataset, bitset_ptr);
   } else {
     std::optional<raft::host_matrix<IdxT, int64_t>> knn_graph(
       raft::make_host_matrix<IdxT, int64_t>(dataset.extent(0), intermediate_degree));
@@ -643,14 +854,19 @@ index<T, IdxT> build(
       build_knn_graph<T, IdxT>(res, dataset, knn_graph->view(), nn_descent_params);
     }
 
+    // Deactivate duplicate nodes
+    deactivate_duplicate_nodes(knn_graph->view(), dataset, bitset_ptr);
+
     cagra_graph = raft::make_host_matrix<IdxT, int64_t>(dataset.extent(0), graph_degree);
 
     RAFT_LOG_INFO("optimizing graph");
-    optimize<IdxT>(res, knn_graph->view(), cagra_graph.view(), params.guarantee_connectivity);
+    optimize<IdxT>(
+      res, knn_graph->view(), cagra_graph.view(), params.guarantee_connectivity, bitset_ptr);
 
     // free intermediate graph before trying to create the index
     knn_graph.reset();
   }
+  if (bitset_ptr) { free(bitset_ptr); }
 
   RAFT_LOG_INFO("Graph optimized, creating index");
 

--- a/cpp/src/neighbors/detail/cagra/search_multi_cta_kernel-inl.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_multi_cta_kernel-inl.cuh
@@ -262,7 +262,9 @@ RAFT_KERNEL __launch_bounds__(1024, 1) search_kernel(
                                            local_traversed_hashmap_ptr,
                                            traversed_hash_bitlen,
                                            block_id,
-                                           num_blocks);
+                                           num_blocks,
+                                           knn_graph,
+                                           graph_degree);
   __syncthreads();
   _CLK_REC(clk_compute_1st_distance);
 

--- a/cpp/src/neighbors/detail/cagra/utils.hpp
+++ b/cpp/src/neighbors/detail/cagra/utils.hpp
@@ -309,4 +309,44 @@ void copy_with_padding(
                                     raft::resource::get_cuda_stream(res)));
   }
 }
+
+//
+template <typename IdxT>
+void bitset_set(uint32_t* array, IdxT index, bool value)
+{
+  const IdxT pos      = index / 32;
+  const uint32_t mask = (uint32_t)1 << (index % 32);
+  if (value) {
+    array[pos] |= mask;
+  } else {
+    array[pos] &= ~mask;
+  }
+}
+
+//
+template <typename IdxT>
+bool bitset_test(const uint32_t* array, IdxT index)
+{
+  const IdxT pos      = index / 32;
+  const uint32_t mask = (uint32_t)1 << (index % 32);
+  return ((array[pos] & mask) > 0);
+}
+
+//
+template <typename IdxT>
+IdxT bitset_count(const uint32_t* array, IdxT num)
+{
+  IdxT count = 0;
+  for (IdxT pos = 0; pos < (num + 31) / 32; pos++) {
+    IdxT val = array[pos];
+    val      = (val & 0x55555555) + ((val & 0xaaaaaaaa) >> 1);
+    val      = (val & 0x33333333) + ((val & 0xcccccccc) >> 2);
+    val      = (val & 0x0f0f0f0f) + ((val & 0xf0f0f0f0) >> 4);
+    val      = (val & 0x00ff00ff) + ((val & 0xff00ff00) >> 8);
+    val      = (val & 0x0000ffff) + ((val & 0xffff0000) >> 16);
+    count += val;
+  }
+  return count;
+}
+
 }  // namespace cuvs::neighbors::cagra::detail


### PR DESCRIPTION
This PR addresses the problem of duplicate search results that occur when multiple identical vectors exist in a vector dataset.

A relatively straightforward method is to obtain more search results than needed and remove duplicates from them. However, the problem is that you do not know in advance how many duplicates will be included in the search results, so you may have to perform the search multiple times in some cases.

The method implemented in this PR is to find duplicates when creating the graph index and disable duplicate nodes. The time to create the graph index is slightly longer, but in return, the search performance is not degraded compared to the above method.

You may have wondered how to disable duplicate nodes without degrading search performance. The answer is to isolate duplicate nodes. A node that is determined to be a duplicate node will have all edges starting from it as edges coming back to itself, and the graph will be created so that no other nodes will have edges going to it. When the graph is created in this way, duplicate nodes will not be traversed during the search, and therefore will naturally not be included in the search results.

By default, this feature is disabled, and we have added a `deactivate_duplicate_nodes` parameter for graph creation, which can be set to `true` to create a graph with duplicate nodes disabled.