### PR TITLE
Relax max duplicates in batched NN Descent

### DIFF
--- a/cpp/tests/neighbors/ann_nn_descent.cuh
+++ b/cpp/tests/neighbors/ann_nn_descent.cuh
@@ -287,7 +287,8 @@ class AnnNNDescentBatchTest : public ::testing::TestWithParam<AnnNNDescentBatchI
                                   ps.graph_degree,
                                   0.01,
                                   min_recall,
-                                  true));
+                                  true,
+                                  static_cast<size_t>(ps.graph_degree)));
     }
   }
 


### PR DESCRIPTION
As discussed, relaxing max duplicates for batch NN Descent for now to not block other PRs.
Related issue
- https://github.com/rapidsai/cuvs/issues/771