### PR TITLE
Fix use of `rapids_cpm_generate_patch_command`

### DIFF
--- a/cpp/cmake/thirdparty/get_cutlass.cmake
+++ b/cpp/cmake/thirdparty/get_cutlass.cmake
@@ -42,10 +42,10 @@ function(find_and_configure_cutlass)
   rapids_cpm_package_details(cutlass version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(cutlass ${version} patch_command)
+  rapids_cpm_generate_patch_command(cutlass ${version} patch_command build_patch_only)
 
   rapids_cpm_find(
-    NvidiaCutlass ${version}
+    NvidiaCutlass ${version} ${build_patch_only}
     GLOBAL_TARGETS nvidia::cutlass::cutlass
     CPM_ARGS
     GIT_REPOSITORY ${repository}

--- a/cpp/cmake/thirdparty/get_diskann.cmake
+++ b/cpp/cmake/thirdparty/get_diskann.cmake
@@ -27,9 +27,9 @@ function(find_and_configure_diskann)
   rapids_cpm_package_details(diskann version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(diskann ${version} patch_command)
+  rapids_cpm_generate_patch_command(diskann ${version} patch_command build_patch_only)
 
-  rapids_cpm_find(diskann ${version}
+  rapids_cpm_find(diskann ${version} ${build_patch_only}
           GLOBAL_TARGETS diskann
           CPM_ARGS
           OPTIONS

--- a/cpp/cmake/thirdparty/get_faiss.cmake
+++ b/cpp/cmake/thirdparty/get_faiss.cmake
@@ -31,7 +31,7 @@ function(find_and_configure_faiss)
   rapids_cpm_package_details(faiss version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(faiss ${version} patch_command)
+  rapids_cpm_generate_patch_command(faiss ${version} patch_command build_patch_only)
 
   set(BUILD_SHARED_LIBS ON)
   if (PKG_BUILD_STATIC_LIBS)
@@ -46,7 +46,7 @@ function(find_and_configure_faiss)
     set(CUVS_FAISS_OPT_LEVEL "avx2")
   endif()
 
-  rapids_cpm_find(faiss ${version}
+  rapids_cpm_find(faiss ${version} ${build_patch_only}
     GLOBAL_TARGETS faiss faiss_avx2 faiss_gpu_objs faiss::faiss faiss::faiss_avx2
     CPM_ARGS
     GIT_REPOSITORY ${repository}

--- a/cpp/cmake/thirdparty/get_ggnn.cmake
+++ b/cpp/cmake/thirdparty/get_ggnn.cmake
@@ -24,10 +24,10 @@ function(find_and_configure_ggnn)
   rapids_cpm_package_details(ggnn version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(ggnn ${version} patch_command)
+  rapids_cpm_generate_patch_command(ggnn ${version} patch_command build_patch_only)
 
   rapids_cpm_find(
-    ggnn ${version}
+    ggnn ${version} ${build_patch_only}
     GLOBAL_TARGETS ggnn::ggnn
     CPM_ARGS
     GIT_REPOSITORY ${repository}

--- a/cpp/cmake/thirdparty/get_hnswlib.cmake
+++ b/cpp/cmake/thirdparty/get_hnswlib.cmake
@@ -26,10 +26,10 @@ function(find_and_configure_hnswlib)
   rapids_cpm_package_details(hnswlib version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(hnswlib ${version} patch_command)
+  rapids_cpm_generate_patch_command(hnswlib ${version} patch_command build_patch_only)
 
   rapids_cpm_find(
-    hnswlib ${version}
+    hnswlib ${version} ${build_patch_only}
     GLOBAL_TARGETS hnswlib hnswlib::hnswlib
     CPM_ARGS
     GIT_REPOSITORY ${repository}


### PR DESCRIPTION
Adopt to recent changes in rapids-cmake