### PR TITLE
`L2SqrtExpanded` metric support for NN Descent

### DIFF
--- a/cpp/tests/neighbors/ann_nn_descent.cuh
+++ b/cpp/tests/neighbors/ann_nn_descent.cuh
@@ -323,6 +323,7 @@ const std::vector<AnnNNDescentInputs> inputs =
                                                      {4, 16, 64, 256, 1024},  // dim
                                                      {32, 64},                // graph_degree
                                                      {cuvs::distance::DistanceType::L2Expanded,
+                                                      cuvs::distance::DistanceType::L2SqrtExpanded,
                                                       cuvs::distance::DistanceType::InnerProduct,
                                                       cuvs::distance::DistanceType::CosineExpanded},
                                                      {false, true},


### PR DESCRIPTION
Adding `L2SqrtExpanded` support for NN Descent.
This is for better usages with cuML UMAP (since UMAP's default metric is `L2SqrtExpanded`)