### PR TITLE
Use L4 instead of V100

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
       arch: "amd64"
       date: ${{ inputs.date }}
       container_image: "rapidsai/ci-conda:latest"
-      node_type: "gpu-v100-latest-1"
+      node_type: "gpu-l4-latest-1"
       run_script: "ci/build_go.sh"
       sha: ${{ inputs.sha }}
   python-build:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -160,7 +160,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.04
     with:
       build_type: pull-request
-      node_type: "gpu-v100-latest-1"
+      node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
       run_script: "ci/build_go.sh"


### PR DESCRIPTION
We migrated all our V100 jobs to use L4 GPUs earlier in #627, but some new jobs were added that still reference the old runners. This fixes that.
