### PR TITLE
refactor(rattler): enable strict channel priority for builds

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -21,16 +21,14 @@ sccache --zero-stats
 RAPIDS_PACKAGE_VERSION=$(rapids-generate-version)
 export RAPIDS_PACKAGE_VERSION
 
+# populates `RATTLER_CHANNELS` array and `RATTLER_ARGS` array
 source rapids-rattler-channel-string
 
 # --no-build-id allows for caching with `sccache`
 # more info is available at
 # https://rattler.build/latest/tips_and_tricks/#using-sccache-or-ccache-with-rattler-build
 rattler-build build --recipe conda/recipes/libcuvs \
-                    --experimental \
-                    --no-build-id \
-                    --channel-priority disabled \
-                    --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
+                    "${RATTLER_ARGS[@]}" \
                     "${RATTLER_CHANNELS[@]}"
 
 sccache --show-adv-stats

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -24,7 +24,7 @@ echo "${version}" > VERSION
 sccache --zero-stats
 
 
-# populates `RATTLER_CHANNELS` array
+# populates `RATTLER_CHANNELS` array and `RATTLER_ARGS` array
 source rapids-rattler-channel-string
 
 rapids-logger "Prepending channel ${CPP_CHANNEL} to RATTLER_CHANNELS"
@@ -39,22 +39,15 @@ rapids-logger "Building cuvs"
 # more info is available at
 # https://rattler.build/latest/tips_and_tricks/#using-sccache-or-ccache-with-rattler-build
 rattler-build build --recipe conda/recipes/cuvs \
-                    --experimental \
-                    --no-build-id \
-                    --channel-priority disabled \
-                    --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
-                    --test skip \
+                    "${RATTLER_ARGS[@]}" \
                     "${RATTLER_CHANNELS[@]}"
 
 sccache --show-adv-stats
 sccache --zero-stats
 
 rattler-build build --recipe conda/recipes/cuvs-bench \
-                    --experimental \
-                    --no-build-id \
-                    --channel-priority disabled \
-                    --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
                     --test skip \
+                    "${RATTLER_ARGS[@]}" \
                     "${RATTLER_CHANNELS[@]}"
 
 sccache --show-adv-stats
@@ -65,10 +58,7 @@ sccache --zero-stats
 RAPIDS_CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
 if [[ ${RAPIDS_CUDA_MAJOR} == "12" ]]; then
   rattler-build build --recipe conda/recipes/cuvs-bench-cpu \
-                      --experimental \
-                      --no-build-id \
-                      --channel-priority disabled \
-                      --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
+                      "${RATTLER_ARGS[@]}" \
                       "${RATTLER_CHANNELS[@]}"
   sccache --show-adv-stats
 fi


### PR DESCRIPTION
This PR enables strict channel priority for building conda packages with `rattler-build`.

xref rapidsai/build-planning#84
