### PR TITLE
Optimize hnsw::from_cagra<GPU>

### DIFF
--- a/cpp/src/neighbors/detail/cagra/cagra_build.cuh
+++ b/cpp/src/neighbors/detail/cagra/cagra_build.cuh
@@ -574,6 +574,13 @@ index<T, IdxT> build(
 {
   size_t intermediate_degree = params.intermediate_graph_degree;
   size_t graph_degree        = params.graph_degree;
+  common::nvtx::range<common::nvtx::domain::cuvs> function_scope(
+    "cagra::build<%s>(%zu, %zu)",
+    Accessor::is_managed_type::value ? "managed"
+    : Accessor::is_host_type::value  ? "host"
+                              : "device",
+    intermediate_degree,
+    graph_degree);
   if (intermediate_degree >= static_cast<size_t>(dataset.extent(0))) {
     RAFT_LOG_WARN(
       "Intermediate graph degree cannot be larger than dataset size, reducing it to %lu",

--- a/cpp/src/neighbors/hnsw.cpp
+++ b/cpp/src/neighbors/hnsw.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,20 @@
  */
 
 #include "detail/hnsw.hpp"
-#include "../core/nvtx.hpp"
 #include <cstdint>
 #include <cuvs/neighbors/hnsw.hpp>
 #include <sys/types.h>
 
 namespace cuvs::neighbors::hnsw {
 
-#define CUVS_INST_HNSW_FROM_CAGRA(T)                                                           \
-  std::unique_ptr<index<T>> from_cagra(                                                        \
-    raft::resources const& res,                                                                \
-    const index_params& params,                                                                \
-    const cuvs::neighbors::cagra::index<T, uint32_t>& cagra_index,                             \
-    std::optional<raft::host_matrix_view<const T, int64_t, raft::row_major>> dataset)          \
-  {                                                                                            \
-    raft::common::nvtx::range<cuvs::common::nvtx::domain::cuvs> fun_scope("hnsw::from_cagra"); \
-    return detail::from_cagra<T>(res, params, cagra_index, dataset);                           \
+#define CUVS_INST_HNSW_FROM_CAGRA(T)                                                  \
+  std::unique_ptr<index<T>> from_cagra(                                               \
+    raft::resources const& res,                                                       \
+    const index_params& params,                                                       \
+    const cuvs::neighbors::cagra::index<T, uint32_t>& cagra_index,                    \
+    std::optional<raft::host_matrix_view<const T, int64_t, raft::row_major>> dataset) \
+  {                                                                                   \
+    return detail::from_cagra<T>(res, params, cagra_index, dataset);                  \
   }
 
 CUVS_INST_HNSW_FROM_CAGRA(float);


### PR DESCRIPTION
Reduce the CAGRA-for-HNSW build times by:
 - avoiding unnecessary copies of the data between cagra::build and hnsw::from_cagra in the benchmarks
 - avoiding unnecessary temporary data buffers in hnsw::from_cagra<GPU>
 - reducing random reads via forcing 1-1 mapping between the internal indices and external labels during HNSW import

As a result the HNSW import time in the benchmark is slashed roughly by half.

In addition, this PR adds a bit more verbose NVTX reporting of different stages during the CAGRA/HNSW index build.