### PR TITLE
Use NCCL wheels from PyPI for CUDA 12 builds

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -35,6 +35,14 @@ if [[ "${package_dir}" != "python/libcuvs" ]]; then
     )
 fi
 
+RAPIDS_CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
+if [[ ${RAPIDS_CUDA_MAJOR} == "12" ]]; then
+    EXCLUDE_ARGS+=(
+      --exclude "libnccl.so.*"
+    )
+    export SKBUILD_CMAKE_ARGS="-DUSE_NCCL_RUNTIME_WHEEL=ON"
+fi
+
 rapids-logger "Building '${package_name}' wheel"
 
 sccache --zero-stats

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -36,7 +36,7 @@ if [[ "${package_dir}" != "python/libcuvs" ]]; then
 fi
 
 RAPIDS_CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
-if [[ ${RAPIDS_CUDA_MAJOR} == "12" ]]; then
+if [[ ${RAPIDS_CUDA_MAJOR} != "11" ]]; then
     EXCLUDE_ARGS+=(
       --exclude "libnccl.so.*"
     )

--- a/ci/test_wheel_cuvs.sh
+++ b/ci/test_wheel_cuvs.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# Delete system libnccl.so to ensure the wheel is used
+RAPIDS_CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
+if [[ ${RAPIDS_CUDA_MAJOR} == "12" ]]; then
+  rm -rf /usr/lib64/libnccl*
+fi
+
 mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 RAPIDS_PY_WHEEL_NAME="libcuvs_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 cpp ./local-libcuvs-dep

--- a/ci/test_wheel_cuvs.sh
+++ b/ci/test_wheel_cuvs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 # Delete system libnccl.so to ensure the wheel is used
 RAPIDS_CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
-if [[ ${RAPIDS_CUDA_MAJOR} == "12" ]]; then
+if [[ ${RAPIDS_CUDA_MAJOR} != "11" ]]; then
   rm -rf /usr/lib64/libnccl*
 fi
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -17,6 +17,7 @@ files:
       - depends_on_cupy
       - depends_on_librmm
       - depends_on_pylibraft
+      - depends_on_nccl
       - docs
       - rapids_build
       - run_py_cuvs
@@ -42,6 +43,7 @@ files:
       - depends_on_pylibraft
       - depends_on_libcuvs
       - depends_on_librmm
+      - depends_on_nccl
       - rapids_build
       - rapids_build_setuptools
   test_cpp:
@@ -94,6 +96,7 @@ files:
       - rust
       - depends_on_libcuvs
       - depends_on_libraft
+      - depends_on_nccl
   go:
     output: conda
     matrix:
@@ -107,6 +110,7 @@ files:
       - go
       - depends_on_libcuvs
       - depends_on_libraft
+      - depends_on_nccl
   py_build_libcuvs:
     output: pyproject
     pyproject_dir: python/libcuvs
@@ -123,6 +127,7 @@ files:
     includes:
       - depends_on_libraft
       - depends_on_librmm
+      - depends_on_nccl
       - rapids_build
   py_run_libcuvs:
     output: pyproject
@@ -133,6 +138,7 @@ files:
       - cuda_wheels
       - depends_on_libraft
       - depends_on_librmm
+      - depends_on_nccl
   py_build_cuvs:
     output: pyproject
     pyproject_dir: python/cuvs
@@ -226,7 +232,6 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
-          - nccl>=2.19
     specific:
       - output_types: conda
         matrices:
@@ -706,3 +711,18 @@ dependencies:
             packages:
               - pylibraft-cu11==25.6.*,>=0.0.0a0
           - {matrix: null, packages: [*pylibraft_unsuffixed]}
+  depends_on_nccl:
+    common:
+      - output_types: conda
+        packages:
+          - &nccl_unsuffixed nccl>=2.19
+    specific:
+      - output_types: [pyproject, requirements]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - nvidia-nccl-cu12>=2.19
+          - matrix:
+            packages:

--- a/python/libcuvs/CMakeLists.txt
+++ b/python/libcuvs/CMakeLists.txt
@@ -25,6 +25,8 @@ project(
   LANGUAGES CXX CUDA
 )
 
+option(USE_NCCL_RUNTIME_WHEEL "Use the NCCL wheel at runtime instead of the system library" OFF)
+
 # Check if cuVS is already available. If so, it is the user's responsibility to ensure that the
 # CMake package is also available at build time of the Python cuvs package.
 find_package(cuvs "${RAPIDS_VERSION}")
@@ -57,6 +59,11 @@ set(rpaths
     "$ORIGIN/../../nvidia/cusparse/lib"
     "$ORIGIN/../../nvidia/nvjitlink/lib"
 )
+
+if(USE_NCCL_RUNTIME_WHEEL)
+  list(APPEND rpaths "$ORIGIN/../../nvidia/nccl/lib")
+endif()
+
 set_property(
   TARGET cuvs
   PROPERTY INSTALL_RPATH ${rpaths}


### PR DESCRIPTION
Reference PR in RAFT https://github.com/rapidsai/raft/pull/2629.

The size of `libcuvs-cu12` wheel goes down from about 1.2G to 854M.