### PR TITLE
Add missing nccl_clique header

### DIFF
--- a/cpp/src/neighbors/mg/mg.cuh
+++ b/cpp/src/neighbors/mg/mg.cuh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "../detail/knn_merge_parts.cuh"
+#include <raft/comms/nccl_clique.hpp>
 #include <raft/core/resource/nccl_clique.hpp>
 #include <raft/core/serialize.hpp>
 #include <raft/linalg/add.cuh>


### PR DESCRIPTION
After a recent change in raft (https://github.com/rapidsai/raft/pull/2549) cuvs builds have been failing with a `error: namespace "raft::comms" has no member "nccl_clique"` error message. This is because the raft/comms/nccl_clique.hpp include was removed from raft/resource/nccl_clique.hpp - and we were relying on that here.

Fix by adding the required header

