### PR TITLE
Use random tmp names for index files in tests

### DIFF
--- a/cpp/tests/neighbors/ann_brute_force.cuh
+++ b/cpp/tests/neighbors/ann_brute_force.cuh
@@ -115,9 +115,10 @@ class AnnBruteForceTest : public ::testing::TestWithParam<AnnBruteForceInputs<Id
                                                       stream_,
                                                       true));
 
-      brute_force::serialize(handle_, std::string{"brute_force_index"}, idx, true);
+      tmp_index_file index_file;
+      brute_force::serialize(handle_, index_file.filename, idx, true);
       auto index_loaded = brute_force::index<DataT, T>(handle_);
-      brute_force::deserialize(handle_, std::string{"brute_force_index"}, &index_loaded);
+      brute_force::deserialize(handle_, index_file.filename, &index_loaded);
 
       brute_force::search(handle_,
                           index_loaded,

--- a/cpp/tests/neighbors/ann_cagra.cuh
+++ b/cpp/tests/neighbors/ann_cagra.cuh
@@ -408,6 +408,7 @@ class AnnCagraTest : public ::testing::TestWithParam<AnnCagraInputs> {
         auto database_view = raft::make_device_matrix_view<const DataT, int64_t>(
           (const DataT*)database.data(), ps.n_rows, ps.dim);
 
+        tmp_index_file index_file;
         {
           std::optional<raft::host_matrix<DataT, int64_t>> database_host{std::nullopt};
           cagra::index<DataT, IdxT> index(handle_, index_params.metric);
@@ -422,11 +423,11 @@ class AnnCagraTest : public ::testing::TestWithParam<AnnCagraInputs> {
             index = cagra::build(handle_, index_params, database_view);
           };
 
-          cagra::serialize(handle_, "cagra_index", index, ps.include_serialized_dataset);
+          cagra::serialize(handle_, index_file.filename, index, ps.include_serialized_dataset);
         }
 
         cagra::index<DataT, IdxT> index(handle_);
-        cagra::deserialize(handle_, "cagra_index", &index);
+        cagra::deserialize(handle_, index_file.filename, &index);
 
         if (!ps.include_serialized_dataset) { index.update_dataset(handle_, database_view); }
 

--- a/cpp/tests/neighbors/ann_ivf_flat.cuh
+++ b/cpp/tests/neighbors/ann_ivf_flat.cuh
@@ -197,10 +197,10 @@ class AnnIVFFlatTest : public ::testing::TestWithParam<AnnIvfFlatInputs<IdxT>> {
           indices_ivfflat_dev.data(), ps.num_queries, ps.k);
         auto dists_out_view = raft::make_device_matrix_view<T, IdxT>(
           distances_ivfflat_dev.data(), ps.num_queries, ps.k);
-        const std::string filename = "ivf_flat_index";
-        cuvs::neighbors::ivf_flat::serialize(handle_, filename, index_2);
+        tmp_index_file index_file;
+        cuvs::neighbors::ivf_flat::serialize(handle_, index_file.filename, index_2);
         cuvs::neighbors::ivf_flat::index<DataT, IdxT> index_loaded(handle_);
-        cuvs::neighbors::ivf_flat::deserialize(handle_, filename, &index_loaded);
+        cuvs::neighbors::ivf_flat::deserialize(handle_, index_file.filename, &index_loaded);
         ASSERT_EQ(index_2.size(), index_loaded.size());
 
         cuvs::neighbors::ivf_flat::search(handle_,

--- a/cpp/tests/neighbors/ann_ivf_pq.cuh
+++ b/cpp/tests/neighbors/ann_ivf_pq.cuh
@@ -267,10 +267,10 @@ class ivf_pq_test : public ::testing::TestWithParam<ivf_pq_inputs> {
 
   auto build_serialize()
   {
-    std::string filename = "ivf_pq_index";
-    cuvs::neighbors::ivf_pq::serialize(handle_, filename, build_only());
+    tmp_index_file index_file;
+    cuvs::neighbors::ivf_pq::serialize(handle_, index_file.filename, build_only());
     cuvs::neighbors::ivf_pq::index<IdxT> index(handle_);
-    cuvs::neighbors::ivf_pq::deserialize(handle_, filename, &index);
+    cuvs::neighbors::ivf_pq::deserialize(handle_, index_file.filename, &index);
     return index;
   }
 

--- a/cpp/tests/neighbors/ann_vamana.cuh
+++ b/cpp/tests/neighbors/ann_vamana.cuh
@@ -155,7 +155,8 @@ class AnnVamanaTest : public ::testing::TestWithParam<AnnVamanaInputs> {
 
     CheckGraph<DataT, IdxT>(&index, ps, stream_);
 
-    vamana::serialize(handle_, "vamana_index", index);
+    tmp_index_file index_file;
+    vamana::serialize(handle_, index_file.filename, index);
 
     // Test recall by searching with CAGRA search
     if (ps.graph_degree < 256) {  // CAGRA search result buffer cannot support larger graph degree

--- a/cpp/tests/neighbors/mg.cuh
+++ b/cpp/tests/neighbors/mg.cuh
@@ -117,13 +117,14 @@ class AnnMGTest : public ::testing::TestWithParam<AnnMGInputs> {
       auto distances = raft::make_host_matrix_view<float, int64_t, row_major>(
         distances_snmg_ann.data(), ps.num_queries, ps.k);
 
+      tmp_index_file index_file;
       {
         auto index = cuvs::neighbors::mg::build(handle_, index_params, index_dataset);
         cuvs::neighbors::mg::extend(handle_, index, index_dataset, std::nullopt);
-        cuvs::neighbors::mg::serialize(handle_, index, "mg_ivf_flat_index");
+        cuvs::neighbors::mg::serialize(handle_, index, index_file.filename);
       }
       auto new_index =
-        cuvs::neighbors::mg::deserialize_flat<DataT, int64_t>(handle_, "mg_ivf_flat_index");
+        cuvs::neighbors::mg::deserialize_flat<DataT, int64_t>(handle_, index_file.filename);
 
       if (ps.m_mode == m_mode_t::MERGE_ON_ROOT_RANK)
         search_params.merge_mode = MERGE_ON_ROOT_RANK;
@@ -176,13 +177,14 @@ class AnnMGTest : public ::testing::TestWithParam<AnnMGInputs> {
       auto distances = raft::make_host_matrix_view<float, int64_t, row_major>(
         distances_snmg_ann.data(), ps.num_queries, ps.k);
 
+      tmp_index_file index_file;
       {
         auto index = cuvs::neighbors::mg::build(handle_, index_params, index_dataset);
         cuvs::neighbors::mg::extend(handle_, index, index_dataset, std::nullopt);
-        cuvs::neighbors::mg::serialize(handle_, index, "mg_ivf_pq_index");
+        cuvs::neighbors::mg::serialize(handle_, index, index_file.filename);
       }
       auto new_index =
-        cuvs::neighbors::mg::deserialize_pq<DataT, int64_t>(handle_, "mg_ivf_pq_index");
+        cuvs::neighbors::mg::deserialize_pq<DataT, int64_t>(handle_, index_file.filename);
 
       if (ps.m_mode == m_mode_t::MERGE_ON_ROOT_RANK)
         search_params.merge_mode = MERGE_ON_ROOT_RANK;
@@ -230,12 +232,13 @@ class AnnMGTest : public ::testing::TestWithParam<AnnMGInputs> {
       auto distances = raft::make_host_matrix_view<float, uint32_t, row_major>(
         distances_snmg_ann.data(), ps.num_queries, ps.k);
 
+      tmp_index_file index_file;
       {
         auto index = cuvs::neighbors::mg::build(handle_, index_params, index_dataset);
-        cuvs::neighbors::mg::serialize(handle_, index, "mg_cagra_index");
+        cuvs::neighbors::mg::serialize(handle_, index, index_file.filename);
       }
       auto new_index =
-        cuvs::neighbors::mg::deserialize_cagra<DataT, uint32_t>(handle_, "mg_cagra_index");
+        cuvs::neighbors::mg::deserialize_cagra<DataT, uint32_t>(handle_, index_file.filename);
 
       if (ps.m_mode == m_mode_t::MERGE_ON_ROOT_RANK)
         search_params.merge_mode = MERGE_ON_ROOT_RANK;
@@ -275,7 +278,8 @@ class AnnMGTest : public ::testing::TestWithParam<AnnMGInputs> {
         auto index_dataset = raft::make_device_matrix_view<const DataT, int64_t>(
           d_index_dataset.data(), ps.num_db_vecs, ps.dim);
         auto index = cuvs::neighbors::ivf_flat::build(handle_, index_params, index_dataset);
-        ivf_flat::serialize(handle_, "local_ivf_flat_index", index);
+        tmp_index_file index_file;
+        ivf_flat::serialize(handle_, index_file.filename, index);
       }
 
       auto queries = raft::make_host_matrix_view<const DataT, int64_t, row_major>(
@@ -327,7 +331,8 @@ class AnnMGTest : public ::testing::TestWithParam<AnnMGInputs> {
         auto index_dataset = raft::make_device_matrix_view<const DataT, int64_t>(
           d_index_dataset.data(), ps.num_db_vecs, ps.dim);
         auto index = cuvs::neighbors::ivf_pq::build(handle_, index_params, index_dataset);
-        ivf_pq::serialize(handle_, "local_ivf_pq_index", index);
+        tmp_index_file index_file;
+        ivf_pq::serialize(handle_, index_file.filename, index);
       }
 
       auto queries = raft::make_host_matrix_view<const DataT, int64_t, row_major>(
@@ -374,7 +379,8 @@ class AnnMGTest : public ::testing::TestWithParam<AnnMGInputs> {
         auto index_dataset = raft::make_device_matrix_view<const DataT, int64_t>(
           d_index_dataset.data(), ps.num_db_vecs, ps.dim);
         auto index = cuvs::neighbors::cagra::build(handle_, index_params, index_dataset);
-        cuvs::neighbors::cagra::serialize(handle_, "local_cagra_index", index);
+        tmp_index_file index_file;
+        cuvs::neighbors::cagra::serialize(handle_, index_file.filename, index);
       }
 
       auto queries = raft::make_host_matrix_view<const DataT, int64_t, row_major>(


### PR DESCRIPTION
Replace all hard-coded index file names in tests with a randomly-generated unique paths in the system temporary folder and delete the files after use.

This is a slightly opinionated convenience PR to give the following benefits:
 - Temporary index files do not clutter the project folder
 - One can run multiple test instances in parallel without the danger of data corruption (e.g. for stress-testing)
 - The tests do not fail if the current folder is read-only
