### PR TITLE
run shellcheck on all files, other small pre-commit updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
       - repo: https://github.com/pre-commit/pre-commit-hooks
         rev: v5.0.0
         hooks:
+              - id: check-json
               - id: trailing-whitespace
               - id: end-of-file-fixer
       - repo: https://github.com/PyCQA/isort
@@ -100,10 +101,6 @@ repos:
                   (?x)
                     ^CHANGELOG[.]md$|
                     ^cpp/cmake/patches/cutlass/build-export[.]patch$
-      - repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v4.5.0
-        hooks:
-              - id: check-json
       - repo: https://github.com/rapidsai/pre-commit-hooks
         rev: v0.6.0
         hooks:
@@ -122,7 +119,7 @@ repos:
           - id: verify-codeowners
             args: [--fix, --project-prefix=cuvs]
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.17.0
+        rev: v1.18.1
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]
@@ -131,7 +128,6 @@ repos:
         hooks:
           - id: shellcheck
             args: ["--severity=warning"]
-            files: ^ci/
 
 default_language_version:
       python: python3

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ ARGS=$*
 
 # NOTE: ensure all dir changes are relative to the location of this
 # scripts, and that this script resides in the repo dir!
-REPODIR=$(cd $(dirname $0); pwd)
+REPODIR=$(cd "$(dirname "$0")"; pwd)
 
 VALIDARGS="clean libcuvs python rust go java docs tests bench-ann examples --uninstall  -v -g -n --allgpuarch --no-mg --no-cpu --cpu-only --no-shared-libs --no-nvtx --show_depr_warn --incl-cache-stats --time -h"
 HELP="$0 [<target> ...] [<flag> ...] [--cmake-args=\"<args>\"] [--cache-tool=<tool>] [--limit-tests=<targets>] [--limit-bench-ann=<targets>] [--build-metrics=<filename>]
@@ -75,7 +75,6 @@ BUILD_DIRS="${LIBCUVS_BUILD_DIR} ${PYTHON_BUILD_DIR} ${RUST_BUILD_DIR} ${JAVA_BU
 # Set defaults for vars modified by flags to this script
 CMAKE_LOG_LEVEL=""
 VERBOSE_FLAG=""
-BUILD_ALL_GPU_ARCH=0
 BUILD_TESTS=ON
 BUILD_MG_ALGOS=ON
 BUILD_TYPE=Release
@@ -92,7 +91,6 @@ CACHE_ARGS=""
 NVTX=ON
 LOG_COMPILE_TIME=OFF
 CLEAN=0
-UNINSTALL=0
 DISABLE_DEPRECATION_WARNINGS=ON
 CMAKE_TARGET=""
 EXTRA_CMAKE_ARGS=""
@@ -255,7 +253,6 @@ fi
 
 # This should run before build/install
 if hasArg --uninstall; then
-    UNINSTALL=1
 
     if hasArg cuvs || hasArg libcuvs || (( ${NUMARGS} == 1 )); then
 
@@ -502,8 +499,10 @@ if (( ${NUMARGS} == 0 )) || hasArg java; then
     ./build.sh
 fi
 
-export RAPIDS_VERSION="$(sed -E -e 's/^([0-9]{2})\.([0-9]{2})\.([0-9]{2}).*$/\1.\2.\3/' "${REPODIR}/VERSION")"
-export RAPIDS_VERSION_MAJOR_MINOR="$(sed -E -e 's/^([0-9]{2})\.([0-9]{2})\.([0-9]{2}).*$/\1.\2/' "${REPODIR}/VERSION")"
+RAPIDS_VERSION="$(sed -E -e 's/^([0-9]{2})\.([0-9]{2})\.([0-9]{2}).*$/\1.\2.\3/' "${REPODIR}/VERSION")"
+export RAPIDS_VERSION
+RAPIDS_VERSION_MAJOR_MINOR="$(sed -E -e 's/^([0-9]{2})\.([0-9]{2})\.([0-9]{2}).*$/\1.\2/' "${REPODIR}/VERSION")"
+export RAPIDS_VERSION_MAJOR_MINOR
 
 if hasArg docs; then
     set -x

--- a/cpp/scripts/run-cmake-format.sh
+++ b/cpp/scripts/run-cmake-format.sh
@@ -48,7 +48,7 @@ DEFAULT_FORMAT_FILE_LOCATIONS=(
 )
 
 if [ -z ${RAPIDS_CMAKE_FORMAT_FILE:+PLACEHOLDER} ]; then
-    for file_path in ${DEFAULT_FORMAT_FILE_LOCATIONS[@]}; do
+    for file_path in "${DEFAULT_FORMAT_FILE_LOCATIONS[@]}"; do
         if [ -f ${file_path} ]; then
             RAPIDS_CMAKE_FORMAT_FILE=${file_path}
             break
@@ -68,12 +68,12 @@ else
 fi
 
 if [[ $1 == "cmake-format" ]]; then
-  cmake-format -i --config-files cpp/cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- ${@:2}
+  cmake-format -i --config-files cpp/cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- "${@:2}"
 elif [[ $1 == "cmake-lint" ]]; then
   # Since the pre-commit hook is verbose, we have to be careful to only
   # present cmake-lint's output (which is quite verbose) if we actually
   # observe a failure.
-  OUTPUT=$(cmake-lint --config-files cpp/cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- ${@:2})
+  OUTPUT=$(cmake-lint --config-files cpp/cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- "${@:2}")
   status=$?
 
   if ! [ ${status} -eq 0 ]; then

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -59,7 +59,6 @@ function gpuArch {
 # Set up build configuration
 PARALLEL_LEVEL=${PARALLEL_LEVEL:=`nproc`}
 BUILD_TYPE=Release
-BUILD_DIR=build/
 CUVS_REPO_REL=""
 EXTRA_CMAKE_ARGS=""
 

--- a/java/build.sh
+++ b/java/build.sh
@@ -7,7 +7,8 @@ GROUP_ID="com.nvidia.cuvs"
 SO_FILE_PATH="./internal/build"
 
 if [ -z "${CMAKE_PREFIX_PATH:=}" ]; then
-  export CMAKE_PREFIX_PATH="$(pwd)/../cpp/build"
+  CMAKE_PREFIX_PATH="$(pwd)/../cpp/build"
+  export CMAKE_PREFIX_PATH
 fi
 
 cmake -B ./internal/build -S ./internal

--- a/java/panama-bindings/generate-bindings.sh
+++ b/java/panama-bindings/generate-bindings.sh
@@ -3,8 +3,8 @@
 set -e -u -o pipefail
 
 echo "Starting Panama FFM API bindings generation ..."
-REPODIR=$(cd $(dirname $0); cd ../../ ; pwd)
-CURDIR=$(cd $(dirname $0); pwd)
+REPODIR=$(cd "$(dirname $0)"; cd ../../ ; pwd)
+CURDIR=$(cd "$(dirname $0)"; pwd)
 CUDA_HOME=$(which nvcc | cut -d/ -f-4)
 TARGET_PACKAGE="com.nvidia.cuvs.internal.panama"
 
@@ -29,7 +29,8 @@ then
   echo "jextract doesn't exist. Downloading it from $JEXTRACT_DOWNLOAD_URL.";
   wget -c $JEXTRACT_DOWNLOAD_URL
   tar -xvf ./"${JEXTRACT_FILENAME}"
-  export PATH="$(pwd)/jextract-22/bin/jextract:${PATH}"
+  PATH="$(pwd)/jextract-22/bin/jextract:${PATH}"
+  export PATH
   echo "jextract downloaded to $(pwd)/jextract-22"
 fi
 


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/135

Follow-up to #662

While reviewing #805 and #831, I found myself suggesting things manually that I know `shellcheck` would have caught automatically. To prevent that for reviewers in the future, this proposes running `shellcheck` on **all** shell scripts in the repo, not just those in the `ci/` directory.

Other changes:

* updates `rapids-dependency-file-generator` to its latest version (1.18.1)
* consolidates duplicate entries for https://github.com/pre-commit/pre-commit-hooks in `.pre-commit-config.yaml`