### PR TITLE
Exclude librmm.so from auditwheel

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -26,6 +26,7 @@ EXCLUDE_ARGS=(
   --exclude "libcusparse.so.*"
   --exclude "libnvJitLink.so.*"
   --exclude "librapids_logger.so"
+  --exclude "librmm.so"
 )
 
 if [[ "${package_dir}" != "python/libcuvs" ]]; then


### PR DESCRIPTION
librmm will ship a shared library component in 25.06 (xref: https://github.com/rapidsai/rmm/issues/1779). This PR updates `auditwheel` calls to exclude `librmm.so`.
