### PR TITLE
Quote head_rev in conda recipes

### DIFF
--- a/conda/recipes/cuvs-bench-cpu/recipe.yaml
+++ b/conda/recipes/cuvs-bench-cpu/recipe.yaml
@@ -6,7 +6,7 @@ context:
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   py_version: ${{ env.get("RAPIDS_PY_VERSION") }}
   py_buildstring: ${{ py_version | version_to_buildstring }}
-  head_rev: ${{ git.head_rev(".")[:8] }}
+  head_rev: '${{ git.head_rev(".")[:8] }}'
   linux64: ${{ linux and x86_64 }}
 
 package:

--- a/conda/recipes/cuvs-bench/recipe.yaml
+++ b/conda/recipes/cuvs-bench/recipe.yaml
@@ -9,7 +9,7 @@ context:
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   py_version: ${{ env.get("RAPIDS_PY_VERSION") }}
   py_buildstring: ${{ py_version | version_to_buildstring }}
-  head_rev: ${{ git.head_rev(".")[:8] }}
+  head_rev: '${{ git.head_rev(".")[:8] }}'
   linux64: ${{ linux and x86_64 }}
 
 package:

--- a/conda/recipes/cuvs/recipe.yaml
+++ b/conda/recipes/cuvs/recipe.yaml
@@ -9,7 +9,7 @@ context:
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   py_version: ${{ env.get("RAPIDS_PY_VERSION") }}
   py_buildstring: ${{ py_version | version_to_buildstring }}
-  head_rev: ${{ git.head_rev(".")[:8] }}
+  head_rev: '${{ git.head_rev(".")[:8] }}'
 
 package:
   name: cuvs

--- a/conda/recipes/libcuvs/recipe.yaml
+++ b/conda/recipes/libcuvs/recipe.yaml
@@ -7,7 +7,7 @@ context:
   cuda_version: ${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[:2] | join(".") }}
   cuda_major: '${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[0] }}'
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
-  head_rev: ${{ git.head_rev(".")[:8] }}
+  head_rev: '${{ git.head_rev(".")[:8] }}'
   linux64: ${{ linux and x86_64 }}
 
 recipe:


### PR DESCRIPTION
This quotes `head_rev` to ensure that commits with leading zeros in the git SHA include those zeros in the output package name.

xref: https://github.com/rapidsai/build-planning/issues/176
