### PR TITLE
get Java artifacts from GitHub Actions artifact store

### DIFF
--- a/ci/build_java.sh
+++ b/ci/build_java.sh
@@ -14,7 +14,7 @@ fi
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 
 rapids-logger "Generate Java testing dependencies"
 


### PR DESCRIPTION
Follow-up to #834

Contributes to https://github.com/rapidsai/build-infra/issues/237

Uses GitHub Actions artifact store, instead of `downloads.rapids.ai`, to download `libcuvs` conda artifacts in CI.