### PR TITLE
[Java] New off-heap Dataset support for CAGRA and Bruteforce

### DIFF
--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/BruteForceIndex.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/BruteForceIndex.java
@@ -102,12 +102,20 @@ public interface BruteForceIndex {
     Builder from(InputStream inputStream);
 
     /**
-     * Sets the dataset for building the {@link BruteForceIndex}.
+     * Sets the dataset vectors for building the {@link BruteForceIndex}.
      *
-     * @param dataset a two-dimensional float array
+     * @param vectors a two-dimensional float array
      * @return an instance of this Builder
      */
-    Builder withDataset(float[][] dataset);
+    Builder withDataset(float[][] vectors);
+
+    /**
+     * Sets the dataset for building the {@link BruteForceIndex}.
+     *
+     * @param dataset a {@link Dataset} object containing the vectors
+     * @return an instance of this Builder
+     */
+    Builder withDataset(Dataset dataset);
 
     /**
      * Builds and returns an instance of {@link BruteForceIndex}.

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraIndex.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraIndex.java
@@ -21,6 +21,7 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.Objects;
 
+import com.nvidia.cuvs.BruteForceIndex.Builder;
 import com.nvidia.cuvs.spi.CuVSProvider;
 
 /**
@@ -184,12 +185,20 @@ public interface CagraIndex {
         Builder from(InputStream inputStream);
 
         /**
-         * Sets the dataset for building the {@link CagraIndex}.
+         * Sets the dataset vectors for building the {@link CagraIndex}.
          *
-         * @param dataset a two-dimensional float array
+         * @param vectors a two-dimensional float array
          * @return an instance of this Builder
          */
-        Builder withDataset(float[][] dataset);
+        Builder withDataset(float[][] vectors);
+
+        /**
+         * Sets the dataset for building the {@link CagraIndex}.
+         *
+         * @param dataset a {@link Dataset} object containing the vectors
+         * @return an instance of this Builder
+         */
+        Builder withDataset(Dataset dataset);
 
         /**
          * Registers an instance of configured {@link CagraIndexParams} with this

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/Dataset.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/Dataset.java
@@ -18,6 +18,12 @@ package com.nvidia.cuvs;
 
 import com.nvidia.cuvs.spi.CuVSProvider;
 
+/**
+ * This represents a wrapper for a dataset to be used for index construction.
+ * The purpose is to allow a caller to place the vectors into native memory
+ * directly, instead of requiring the caller to load all the vectors into the heap
+ * (e.g. with a float[][]).
+ */
 public interface Dataset extends AutoCloseable {
 
   /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/Dataset.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/Dataset.java
@@ -1,0 +1,18 @@
+package com.nvidia.cuvs;
+
+import java.util.Objects;
+
+import com.nvidia.cuvs.spi.CuVSProvider;
+
+public interface Dataset extends AutoCloseable {
+
+	public void addVector(float[] vector);
+	
+	static Dataset create(int size, int dimensions) {
+		return CuVSProvider.provider().newDataset(size, dimensions);
+	}
+
+	public int getSize();
+	
+	public int getDimensions();
+}

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/Dataset.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/Dataset.java
@@ -20,31 +20,35 @@ import com.nvidia.cuvs.spi.CuVSProvider;
 
 public interface Dataset extends AutoCloseable {
 
-	/**
-	 * Add a single vector to the dataset.
-	 * @param vector A float array of as many elements as the dimensions
-	 */
-	public void addVector(float[] vector);
-	
-	/**
-	 * Create a new instance of a dataset
-	 * @param size Number of vectors in the dataset
-	 * @param dimensions Size of each vector in the dataset 
-	 * @return new instance of {@link Dataset}
-	 */
-	static Dataset create(int size, int dimensions) {
-		return CuVSProvider.provider().newDataset(size, dimensions);
-	}
+  /**
+   * Add a single vector to the dataset.
+   *
+   * @param vector A float array of as many elements as the dimensions
+   */
+  public void addVector(float[] vector);
 
-	/**
-	 * Gets the size of the dataset
-	 * @return Size of the dataset
-	 */
-	public int size();
-	
-	/**
-	 * Gets the dimensions of the vectors in this dataset
-	 * @return Dimensions of the vectors in the dataset
-	 */
-	public int dimensions();
+  /**
+   * Create a new instance of a dataset
+   *
+   * @param size       Number of vectors in the dataset
+   * @param dimensions Size of each vector in the dataset
+   * @return new instance of {@link Dataset}
+   */
+  static Dataset create(int size, int dimensions) {
+    return CuVSProvider.provider().newDataset(size, dimensions);
+  }
+
+  /**
+   * Gets the size of the dataset
+   *
+   * @return Size of the dataset
+   */
+  public int size();
+
+  /**
+   * Gets the dimensions of the vectors in this dataset
+   *
+   * @return Dimensions of the vectors in the dataset
+   */
+  public int dimensions();
 }

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/Dataset.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/Dataset.java
@@ -1,18 +1,50 @@
-package com.nvidia.cuvs;
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import java.util.Objects;
+package com.nvidia.cuvs;
 
 import com.nvidia.cuvs.spi.CuVSProvider;
 
 public interface Dataset extends AutoCloseable {
 
+	/**
+	 * Add a single vector to the dataset.
+	 * @param vector A float array of as many elements as the dimensions
+	 */
 	public void addVector(float[] vector);
 	
+	/**
+	 * Create a new instance of a dataset
+	 * @param size Number of vectors in the dataset
+	 * @param dimensions Size of each vector in the dataset 
+	 * @return new instance of {@link Dataset}
+	 */
 	static Dataset create(int size, int dimensions) {
 		return CuVSProvider.provider().newDataset(size, dimensions);
 	}
 
-	public int getSize();
+	/**
+	 * Gets the size of the dataset
+	 * @return Size of the dataset
+	 */
+	public int size();
 	
-	public int getDimensions();
+	/**
+	 * Gets the dimensions of the vectors in this dataset
+	 * @return Dimensions of the vectors in the dataset
+	 */
+	public int dimensions();
 }

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/Dataset.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/Dataset.java
@@ -23,6 +23,8 @@ import com.nvidia.cuvs.spi.CuVSProvider;
  * The purpose is to allow a caller to place the vectors into native memory
  * directly, instead of requiring the caller to load all the vectors into the heap
  * (e.g. with a float[][]).
+ *
+ * @since 25.06
  */
 public interface Dataset extends AutoCloseable {
 

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/spi/CuVSProvider.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/spi/CuVSProvider.java
@@ -52,7 +52,7 @@ public interface CuVSProvider {
       throws Throwable;
 
   Dataset newDataset(int size, int dimensions) throws UnsupportedOperationException;
-  
+
   /** Creates a new BruteForceIndex Builder. */
   BruteForceIndex.Builder newBruteForceIndexBuilder(CuVSResources cuVSResources)
       throws UnsupportedOperationException;

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/spi/CuVSProvider.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/spi/CuVSProvider.java
@@ -51,6 +51,7 @@ public interface CuVSProvider {
   CuVSResources newCuVSResources(Path tempDirectory)
       throws Throwable;
 
+  /** Create a {@link Dataset} instance **/
   Dataset newDataset(int size, int dimensions) throws UnsupportedOperationException;
 
   /** Creates a new BruteForceIndex Builder. */

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/spi/CuVSProvider.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/spi/CuVSProvider.java
@@ -19,6 +19,7 @@ package com.nvidia.cuvs.spi;
 import com.nvidia.cuvs.BruteForceIndex;
 import com.nvidia.cuvs.CagraIndex;
 import com.nvidia.cuvs.CuVSResources;
+import com.nvidia.cuvs.Dataset;
 import com.nvidia.cuvs.HnswIndex;
 
 import java.nio.file.Path;
@@ -50,6 +51,8 @@ public interface CuVSProvider {
   CuVSResources newCuVSResources(Path tempDirectory)
       throws Throwable;
 
+  Dataset newDataset(int size, int dimensions) throws UnsupportedOperationException;
+  
   /** Creates a new BruteForceIndex Builder. */
   BruteForceIndex.Builder newBruteForceIndexBuilder(CuVSResources cuVSResources)
       throws UnsupportedOperationException;

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/spi/UnsupportedProvider.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/spi/UnsupportedProvider.java
@@ -19,6 +19,7 @@ package com.nvidia.cuvs.spi;
 import com.nvidia.cuvs.BruteForceIndex;
 import com.nvidia.cuvs.CagraIndex;
 import com.nvidia.cuvs.CuVSResources;
+import com.nvidia.cuvs.Dataset;
 import com.nvidia.cuvs.HnswIndex;
 
 import java.nio.file.Path;
@@ -45,6 +46,11 @@ final class UnsupportedProvider implements CuVSProvider {
 
   @Override
   public HnswIndex.Builder newHnswIndexBuilder(CuVSResources cuVSResources) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Dataset newDataset(int size, int dimensions) throws UnsupportedOperationException {
     throw new UnsupportedOperationException();
   }
 }

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/BruteForceIndexImpl.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/BruteForceIndexImpl.java
@@ -43,6 +43,7 @@ import com.nvidia.cuvs.BruteForceIndex;
 import com.nvidia.cuvs.BruteForceIndexParams;
 import com.nvidia.cuvs.BruteForceQuery;
 import com.nvidia.cuvs.CuVSResources;
+import com.nvidia.cuvs.Dataset;
 import com.nvidia.cuvs.SearchResults;
 import com.nvidia.cuvs.internal.common.Util;
 import com.nvidia.cuvs.internal.panama.cuvsBruteForceIndex;
@@ -71,7 +72,8 @@ public class BruteForceIndexImpl implements BruteForceIndex{
   private static final MethodHandle deserializeMethodHandle = downcallHandle("deserialize_brute_force_index",
       FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS));
 
-  private final float[][] dataset;
+  private final float[][] vectors;
+  private final Dataset dataset;
   private final CuVSResourcesImpl resources;
   private final IndexReference bruteForceIndexReference;
   private final BruteForceIndexParams bruteForceIndexParams;
@@ -86,8 +88,10 @@ public class BruteForceIndexImpl implements BruteForceIndex{
    * @param bruteForceIndexParams an instance of {@link BruteForceIndexParams}
    *                              holding the index parameters
    */
-  private BruteForceIndexImpl(float[][] dataset, CuVSResourcesImpl resources, BruteForceIndexParams bruteForceIndexParams)
+  private BruteForceIndexImpl(float[][] vectors, Dataset dataset, CuVSResourcesImpl resources,
+		  BruteForceIndexParams bruteForceIndexParams)
       throws Throwable {
+    this.vectors = vectors;
     this.dataset = dataset;
     this.resources = resources;
     this.bruteForceIndexParams = bruteForceIndexParams;
@@ -102,6 +106,7 @@ public class BruteForceIndexImpl implements BruteForceIndex{
    */
   private BruteForceIndexImpl(InputStream inputStream, CuVSResourcesImpl resources) throws Throwable {
     this.bruteForceIndexParams = null;
+    this.vectors = null;
     this.dataset = null;
     this.resources = resources;
     this.bruteForceIndexReference = deserialize(inputStream);
@@ -127,6 +132,7 @@ public class BruteForceIndexImpl implements BruteForceIndex{
     } finally {
       destroyed = true;
     }
+    if (dataset != null) dataset.close();
   }
 
   /**
@@ -137,10 +143,11 @@ public class BruteForceIndexImpl implements BruteForceIndex{
    *         index
    */
   private IndexReference build() throws Throwable {
-    long rows = dataset.length;
-    long cols = rows > 0 ? dataset[0].length : 0;
+    long rows = dataset != null? dataset.getSize(): vectors.length;
+    long cols = dataset != null? dataset.getDimensions(): (rows > 0 ? vectors[0].length : 0);
 
-    MemorySegment dataSeg = Util.buildMemorySegment(resources.getArena(), dataset);
+    MemorySegment dataSeg = dataset != null? ((DatasetImpl) dataset).seg: 
+    	Util.buildMemorySegment(resources.getArena(), vectors);
     try (var localArena = Arena.ofConfined()) {
       MemorySegment returnValue = localArena.allocate(C_INT);
       MemorySegment indexSeg = (MemorySegment) indexMethodHandle.invokeExact(
@@ -284,7 +291,8 @@ public class BruteForceIndexImpl implements BruteForceIndex{
    */
   public static class Builder implements BruteForceIndex.Builder {
 
-    private float[][] dataset;
+    private float[][] vectors;
+    private Dataset dataset;
     private final CuVSResourcesImpl cuvsResources;
     private BruteForceIndexParams bruteForceIndexParams;
     private InputStream inputStream;
@@ -327,11 +335,23 @@ public class BruteForceIndexImpl implements BruteForceIndex{
     /**
      * Sets the dataset for building the {@link BruteForceIndex}.
      *
-     * @param dataset a two-dimensional float array
+     * @param vectors a two-dimensional float array
      * @return an instance of this Builder
      */
     @Override
-    public Builder withDataset(float[][] dataset) {
+    public Builder withDataset(float[][] vectors) {
+      this.vectors = vectors;
+      return this;
+    }
+
+    /**
+     * Sets the dataset for building the {@link BruteForceIndex}.
+     *
+     * @param dataset a {@link Dataset} object containing the vectors
+     * @return an instance of this Builder
+     */
+    @Override
+    public Builder withDataset(Dataset dataset) {
       this.dataset = dataset;
       return this;
     }
@@ -346,7 +366,7 @@ public class BruteForceIndexImpl implements BruteForceIndex{
       if (inputStream != null) {
         return new BruteForceIndexImpl(inputStream, cuvsResources);
       } else {
-        return new BruteForceIndexImpl(dataset, cuvsResources, bruteForceIndexParams);
+        return new BruteForceIndexImpl(vectors, dataset, cuvsResources, bruteForceIndexParams);
       }
     }
   }

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/BruteForceIndexImpl.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/BruteForceIndexImpl.java
@@ -143,8 +143,8 @@ public class BruteForceIndexImpl implements BruteForceIndex{
    *         index
    */
   private IndexReference build() throws Throwable {
-    long rows = dataset != null? dataset.getSize(): vectors.length;
-    long cols = dataset != null? dataset.getDimensions(): (rows > 0 ? vectors[0].length : 0);
+    long rows = dataset != null? dataset.size(): vectors.length;
+    long cols = dataset != null? dataset.dimensions(): (rows > 0 ? vectors[0].length : 0);
 
     MemorySegment dataSeg = dataset != null? ((DatasetImpl) dataset).seg: 
     	Util.buildMemorySegment(resources.getArena(), vectors);

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/BruteForceIndexImpl.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/BruteForceIndexImpl.java
@@ -89,7 +89,7 @@ public class BruteForceIndexImpl implements BruteForceIndex{
    *                              holding the index parameters
    */
   private BruteForceIndexImpl(float[][] vectors, Dataset dataset, CuVSResourcesImpl resources,
-		  BruteForceIndexParams bruteForceIndexParams)
+      BruteForceIndexParams bruteForceIndexParams)
       throws Throwable {
     this.vectors = vectors;
     this.dataset = dataset;
@@ -146,8 +146,8 @@ public class BruteForceIndexImpl implements BruteForceIndex{
     long rows = dataset != null? dataset.size(): vectors.length;
     long cols = dataset != null? dataset.dimensions(): (rows > 0 ? vectors[0].length : 0);
 
-    MemorySegment dataSeg = dataset != null? ((DatasetImpl) dataset).seg: 
-    	Util.buildMemorySegment(resources.getArena(), vectors);
+    MemorySegment dataSeg = dataset != null? ((DatasetImpl) dataset).seg:
+      Util.buildMemorySegment(resources.getArena(), vectors);
     try (var localArena = Arena.ofConfined()) {
       MemorySegment returnValue = localArena.allocate(C_INT);
       MemorySegment indexSeg = (MemorySegment) indexMethodHandle.invokeExact(

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/CagraIndexImpl.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/CagraIndexImpl.java
@@ -161,8 +161,8 @@ public class CagraIndexImpl implements CagraIndex {
    *         index
    */
   private IndexReference build() throws Throwable {
-    long rows = dataset != null? dataset.getSize(): vectors.length;
-    long cols = dataset != null? dataset.getDimensions(): (rows > 0 ? vectors[0].length : 0);
+    long rows = dataset != null? dataset.size(): vectors.length;
+    long cols = dataset != null? dataset.dimensions(): (rows > 0 ? vectors[0].length : 0);
 
     MemorySegment indexParamsMemorySegment = cagraIndexParameters != null
         ? segmentFromIndexParams(cagraIndexParameters)
@@ -522,6 +522,9 @@ public class CagraIndexImpl implements CagraIndex {
       if (inputStream != null) {
         return new CagraIndexImpl(inputStream, cuvsResources);
       } else {
+    	if (vectors != null && dataset != null) {
+    		throw new IllegalArgumentException("Please specify only one type of dataset (a float[] or a Dataset instance)");
+    	}
         return new CagraIndexImpl(cagraIndexParams, cagraCompressionParams, vectors, dataset, cuvsResources);
       }
     }

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/DatasetImpl.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/DatasetImpl.java
@@ -21,7 +21,6 @@ import static com.nvidia.cuvs.internal.common.LinkerHelper.C_FLOAT;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.nvidia.cuvs.Dataset;
 
@@ -31,7 +30,6 @@ public class DatasetImpl implements Dataset {
   private final int size;
   private final int dimensions;
   private int current = 0;
-  private AtomicBoolean isAlive = new AtomicBoolean(true);
 
   public DatasetImpl(int size, int dimensions) {
     this.size = size;
@@ -52,7 +50,7 @@ public class DatasetImpl implements Dataset {
 
   @Override
   public void close() {
-    if (isAlive.getAndSet(false)) {
+    if (!arena.scope().isAlive()) {
       arena.close();
     }
   }

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/DatasetImpl.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/DatasetImpl.java
@@ -1,0 +1,50 @@
+package com.nvidia.cuvs.internal;
+
+import static com.nvidia.cuvs.internal.common.LinkerHelper.C_FLOAT;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+
+import com.nvidia.cuvs.Dataset;
+
+public class DatasetImpl implements Dataset {
+	private final Arena arena;
+	protected final MemorySegment seg;
+	private final int size;
+	private final int dimensions;
+	private int current = 0;
+	
+	public DatasetImpl(int size, int dimensions) {
+		this.size = size;
+		this.dimensions = dimensions;
+		
+	    MemoryLayout dataMemoryLayout = MemoryLayout.sequenceLayout(size * dimensions, C_FLOAT);
+	    //seg = this.cuVSResources.getArena().allocate(dataMemoryLayout);
+	    
+	    this.arena = Arena.ofShared();
+	    seg = arena.allocate(dataMemoryLayout);
+	}
+
+	@Override
+	public void addVector(float[] vector) {
+	   if (current >= size) throw new ArrayIndexOutOfBoundsException();
+       MemorySegment.copy(vector, 0, seg, C_FLOAT, ((current++) * dimensions * C_FLOAT.byteSize()), (int) dimensions);
+	}
+
+	@Override
+	public void close() {
+		arena.close();
+	}
+
+	@Override
+	public int getSize() {
+		return size;
+	}
+
+	@Override
+	public int getDimensions() {
+		return dimensions;
+	}
+
+}

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/DatasetImpl.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/DatasetImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.nvidia.cuvs.internal;
 
 import static com.nvidia.cuvs.internal.common.LinkerHelper.C_FLOAT;
@@ -5,6 +21,7 @@ import static com.nvidia.cuvs.internal.common.LinkerHelper.C_FLOAT;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.nvidia.cuvs.Dataset;
 
@@ -14,13 +31,13 @@ public class DatasetImpl implements Dataset {
 	private final int size;
 	private final int dimensions;
 	private int current = 0;
+	private AtomicBoolean isAlive = new AtomicBoolean(true);
 	
 	public DatasetImpl(int size, int dimensions) {
 		this.size = size;
 		this.dimensions = dimensions;
 		
 	    MemoryLayout dataMemoryLayout = MemoryLayout.sequenceLayout(size * dimensions, C_FLOAT);
-	    //seg = this.cuVSResources.getArena().allocate(dataMemoryLayout);
 	    
 	    this.arena = Arena.ofShared();
 	    seg = arena.allocate(dataMemoryLayout);
@@ -34,16 +51,18 @@ public class DatasetImpl implements Dataset {
 
 	@Override
 	public void close() {
-		arena.close();
+		if (isAlive.getAndSet(false)) {
+			arena.close();
+		}
 	}
 
 	@Override
-	public int getSize() {
+	public int size() {
 		return size;
 	}
 
 	@Override
-	public int getDimensions() {
+	public int dimensions() {
 		return dimensions;
 	}
 

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/DatasetImpl.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/DatasetImpl.java
@@ -26,44 +26,45 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import com.nvidia.cuvs.Dataset;
 
 public class DatasetImpl implements Dataset {
-	private final Arena arena;
-	protected final MemorySegment seg;
-	private final int size;
-	private final int dimensions;
-	private int current = 0;
-	private AtomicBoolean isAlive = new AtomicBoolean(true);
-	
-	public DatasetImpl(int size, int dimensions) {
-		this.size = size;
-		this.dimensions = dimensions;
-		
-	    MemoryLayout dataMemoryLayout = MemoryLayout.sequenceLayout(size * dimensions, C_FLOAT);
-	    
-	    this.arena = Arena.ofShared();
-	    seg = arena.allocate(dataMemoryLayout);
-	}
+  private final Arena arena;
+  protected final MemorySegment seg;
+  private final int size;
+  private final int dimensions;
+  private int current = 0;
+  private AtomicBoolean isAlive = new AtomicBoolean(true);
 
-	@Override
-	public void addVector(float[] vector) {
-	   if (current >= size) throw new ArrayIndexOutOfBoundsException();
-       MemorySegment.copy(vector, 0, seg, C_FLOAT, ((current++) * dimensions * C_FLOAT.byteSize()), (int) dimensions);
-	}
+  public DatasetImpl(int size, int dimensions) {
+    this.size = size;
+    this.dimensions = dimensions;
 
-	@Override
-	public void close() {
-		if (isAlive.getAndSet(false)) {
-			arena.close();
-		}
-	}
+    MemoryLayout dataMemoryLayout = MemoryLayout.sequenceLayout(size * dimensions, C_FLOAT);
 
-	@Override
-	public int size() {
-		return size;
-	}
+    this.arena = Arena.ofShared();
+    seg = arena.allocate(dataMemoryLayout);
+  }
 
-	@Override
-	public int dimensions() {
-		return dimensions;
-	}
+  @Override
+  public void addVector(float[] vector) {
+    if (current >= size)
+      throw new ArrayIndexOutOfBoundsException();
+    MemorySegment.copy(vector, 0, seg, C_FLOAT, ((current++) * dimensions * C_FLOAT.byteSize()), (int) dimensions);
+  }
+
+  @Override
+  public void close() {
+    if (isAlive.getAndSet(false)) {
+      arena.close();
+    }
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public int dimensions() {
+    return dimensions;
+  }
 
 }

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/spi/JDKProvider.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/spi/JDKProvider.java
@@ -19,10 +19,12 @@ package com.nvidia.cuvs.spi;
 import com.nvidia.cuvs.BruteForceIndex;
 import com.nvidia.cuvs.CagraIndex;
 import com.nvidia.cuvs.CuVSResources;
+import com.nvidia.cuvs.Dataset;
 import com.nvidia.cuvs.HnswIndex;
 import com.nvidia.cuvs.internal.BruteForceIndexImpl;
 import com.nvidia.cuvs.internal.CagraIndexImpl;
 import com.nvidia.cuvs.internal.CuVSResourcesImpl;
+import com.nvidia.cuvs.internal.DatasetImpl;
 import com.nvidia.cuvs.internal.HnswIndexImpl;
 
 import java.nio.file.Files;
@@ -56,5 +58,10 @@ final class JDKProvider implements CuVSProvider {
   @Override
   public HnswIndex.Builder newHnswIndexBuilder(CuVSResources cuVSResources) {
     return HnswIndexImpl.newBuilder(Objects.requireNonNull(cuVSResources));
+  }
+
+  @Override
+  public Dataset newDataset(int size, int dimensions) throws UnsupportedOperationException {
+	  return new DatasetImpl(size, dimensions);
   }
 }

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/spi/JDKProvider.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/spi/JDKProvider.java
@@ -62,6 +62,6 @@ final class JDKProvider implements CuVSProvider {
 
   @Override
   public Dataset newDataset(int size, int dimensions) throws UnsupportedOperationException {
-	  return new DatasetImpl(size, dimensions);
+      return new DatasetImpl(size, dimensions);
   }
 }

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceRandomizedIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceRandomizedIT.java
@@ -124,18 +124,18 @@ public class BruteForceRandomizedIT extends CuVSTestCase {
           log.info("Using " + Dataset.class + " for input data");
           Dataset dataset = Dataset.create(vectors.length, vectors[0].length);
           for (float[] v: vectors) dataset.addVector(v);
-    	  index = BruteForceIndex.newBuilder(resources)
-    	          .withDataset(dataset)
-    	          .withIndexParams(indexParams)
-    	          .build();
+        index = BruteForceIndex.newBuilder(resources)
+                .withDataset(dataset)
+                .withIndexParams(indexParams)
+                .build();
       } else {
-    	  log.info("Using float[][] for input data");
-    	  index = BruteForceIndex.newBuilder(resources)
-    	          .withDataset(vectors)
-    	          .withIndexParams(indexParams)
-    	          .build();
+        log.info("Using float[][] for input data");
+        index = BruteForceIndex.newBuilder(resources)
+                .withDataset(vectors)
+                .withIndexParams(indexParams)
+                .build();
       }
-      
+
       log.info("Index built successfully. Executing search...");
       SearchResults results = index.search(query);
 

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceRandomizedIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/BruteForceRandomizedIT.java
@@ -44,12 +44,15 @@ public class BruteForceRandomizedIT extends CuVSTestCase {
 
   @Test
   public void testResultsTopKWithRandomValues() throws Throwable {
-    for (int i = 0; i < 10; i++) {
-      tmpResultsTopKWithRandomValues();
+	boolean useNativeMemoryDatasets[] = {true, false};
+	for (int i = 0; i < 10; i++) {
+      for (boolean use: useNativeMemoryDatasets) {
+        tmpResultsTopKWithRandomValues(use);
+      }
     }
   }
 
-  private void tmpResultsTopKWithRandomValues() throws Throwable {
+  private void tmpResultsTopKWithRandomValues(boolean useNativeMemoryDataset) throws Throwable {
     int DATASET_SIZE_LIMIT = 10_000;
     int DIMENSIONS_LIMIT = 2048;
     int NUM_QUERIES_LIMIT = 10;
@@ -84,6 +87,7 @@ public class BruteForceRandomizedIT extends CuVSTestCase {
     log.info("Dataset size: {}x{}", datasetSize, dimensions);
     log.info("Query size: {}x{}", numQueries, dimensions);
     log.info("TopK: {}", topK);
+    log.info("Use native memory dataset? " + useNativeMemoryDataset);
 
     // Debugging: Log dataset and queries
     if (log.isDebugEnabled()) {
@@ -119,17 +123,14 @@ public class BruteForceRandomizedIT extends CuVSTestCase {
           .build();
 
       BruteForceIndex index;
-      boolean useNativeMemoryDataset = random.nextBoolean();
       if (useNativeMemoryDataset) {
-          log.info("Using " + Dataset.class + " for input data");
-          Dataset dataset = Dataset.create(vectors.length, vectors[0].length);
-          for (float[] v: vectors) dataset.addVector(v);
+        Dataset dataset = Dataset.create(vectors.length, vectors[0].length);
+        for (float[] v: vectors) dataset.addVector(v);
         index = BruteForceIndex.newBuilder(resources)
                 .withDataset(dataset)
                 .withIndexParams(indexParams)
                 .build();
       } else {
-        log.info("Using float[][] for input data");
         index = BruteForceIndex.newBuilder(resources)
                 .withDataset(vectors)
                 .withIndexParams(indexParams)

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraRandomizedIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraRandomizedIT.java
@@ -44,12 +44,15 @@ public class CagraRandomizedIT extends CuVSTestCase {
 
   @Test
   public void testResultsTopKWithRandomValues() throws Throwable {
-    for (int i = 0; i < 10; i++) {
-      tmpResultsTopKWithRandomValues();
+    boolean useNativeMemoryDatasets[] = {true, false};
+	for (int i = 0; i < 10; i++) {
+	  for (boolean use: useNativeMemoryDatasets) {
+		  tmpResultsTopKWithRandomValues(use);
+	  }
     }
   }
 
-  private void tmpResultsTopKWithRandomValues() throws Throwable {
+  private void tmpResultsTopKWithRandomValues(boolean useNativeMemoryDataset) throws Throwable {
     int DATASET_SIZE_LIMIT = 10_000;
     int DIMENSIONS_LIMIT = 2048;
     int NUM_QUERIES_LIMIT = 10;
@@ -72,6 +75,7 @@ public class CagraRandomizedIT extends CuVSTestCase {
     log.info("Dataset size: {}x{}", datasetSize, dimensions);
     log.info("Query size: {}x{}", numQueries, dimensions);
     log.info("TopK: {}", topK);
+    log.info("Use native memory dataset? " + useNativeMemoryDataset);
 
     // Debugging: Log dataset and queries
     if (log.isDebugEnabled()) {
@@ -100,9 +104,7 @@ public class CagraRandomizedIT extends CuVSTestCase {
           .build();
 
       CagraIndex index;
-      boolean useNativeMemoryDataset = random.nextBoolean();
       if (useNativeMemoryDataset) {
-          log.info("Using " + Dataset.class + " for input data");
           Dataset dataset = Dataset.create(vectors.length, vectors[0].length);
           for (float[] v: vectors) dataset.addVector(v);
           index = CagraIndex.newBuilder(resources)
@@ -110,7 +112,6 @@ public class CagraRandomizedIT extends CuVSTestCase {
               .withIndexParams(indexParams)
               .build();
       } else {
-          log.info("Using float[][] for input data");
         index = CagraIndex.newBuilder(resources)
                 .withDataset(vectors)
                 .withIndexParams(indexParams)

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraRandomizedIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraRandomizedIT.java
@@ -98,7 +98,7 @@ public class CagraRandomizedIT extends CuVSTestCase {
       CagraIndexParams indexParams = new CagraIndexParams.Builder()
           .withCagraGraphBuildAlgo(CagraGraphBuildAlgo.NN_DESCENT)
           .build();
-      
+
       CagraIndex index;
       boolean useNativeMemoryDataset = random.nextBoolean();
       if (useNativeMemoryDataset) {
@@ -106,15 +106,15 @@ public class CagraRandomizedIT extends CuVSTestCase {
           Dataset dataset = Dataset.create(vectors.length, vectors[0].length);
           for (float[] v: vectors) dataset.addVector(v);
           index = CagraIndex.newBuilder(resources)
-        		  .withDataset(dataset)
-        		  .withIndexParams(indexParams)
-        		  .build();    	  
+              .withDataset(dataset)
+              .withIndexParams(indexParams)
+              .build();
       } else {
           log.info("Using float[][] for input data");
-    	  index = CagraIndex.newBuilder(resources)
-    	          .withDataset(vectors)
-    	          .withIndexParams(indexParams)
-    	          .build();
+        index = CagraIndex.newBuilder(resources)
+                .withDataset(vectors)
+                .withIndexParams(indexParams)
+                .build();
       }
       log.info("Index built successfully.");
 

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/HnswRandomizedIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/HnswRandomizedIT.java
@@ -50,12 +50,15 @@ public class HnswRandomizedIT extends CuVSTestCase {
 
   @Test
   public void testResultsTopKWithRandomValues() throws Throwable {
+	boolean useNativeMemoryDatasets[] = {true, false};
     for (int i = 0; i < 10; i++) {
-      tmpResultsTopKWithRandomValues();
+      for (boolean use: useNativeMemoryDatasets) {
+        tmpResultsTopKWithRandomValues(use);
+      }
     }
   }
 
-  private void tmpResultsTopKWithRandomValues() throws Throwable {
+  private void tmpResultsTopKWithRandomValues(boolean useNativeMemoryDataset) throws Throwable {
     int DATASET_SIZE_LIMIT = 10_000;
     int DIMENSIONS_LIMIT = 2048;
     int NUM_QUERIES_LIMIT = 10;
@@ -70,7 +73,7 @@ public class HnswRandomizedIT extends CuVSTestCase {
       datasetSize = topK;
 
     // Generate a random dataset
-    float[][] dataset = generateData(random, datasetSize, dimensions);
+    float[][] vectors = generateData(random, datasetSize, dimensions);
 
     // Generate random query vectors
     float[][] queries = generateData(random, numQueries, dimensions);
@@ -78,11 +81,12 @@ public class HnswRandomizedIT extends CuVSTestCase {
     log.info("Dataset size: {}x{}", datasetSize, dimensions);
     log.info("Query size: {}x{}", numQueries, dimensions);
     log.info("TopK: {}", topK);
+    log.info("Use native memory dataset? " + useNativeMemoryDataset);
 
     // Debugging: Log dataset and queries
     if (log.isDebugEnabled()) {
       log.debug("Dataset:");
-      for (float[] row : dataset) {
+      for (float[] row : vectors) {
         log.debug(java.util.Arrays.toString(row));
       }
       log.debug("Queries:");
@@ -91,13 +95,13 @@ public class HnswRandomizedIT extends CuVSTestCase {
       }
     }
     // Sanity checks
-    assert dataset.length > 0 : "Dataset is empty.";
+    assert vectors.length > 0 : "Dataset is empty.";
     assert queries.length > 0 : "Queries are empty.";
     assert dimensions > 0 : "Invalid dimensions.";
     assert topK > 0 && topK <= datasetSize : "Invalid topK value.";
 
     // Generate expected results using brute force
-    List<List<Integer>> expected = generateExpectedResults(topK, dataset, queries, null, log);
+    List<List<Integer>> expected = generateExpectedResults(topK, vectors, queries, null, log);
 
     // Create CuVS index and query
     try (CuVSResources resources = CuVSResources.create()) {
@@ -112,10 +116,20 @@ public class HnswRandomizedIT extends CuVSTestCase {
           .build();
 
       // Create the index with the dataset
-      CagraIndex index = CagraIndex.newBuilder(resources)
-          .withDataset(dataset)
-          .withIndexParams(indexParams)
-          .build();
+      CagraIndex index;
+      if (useNativeMemoryDataset) {
+        Dataset dataset = Dataset.create(vectors.length, vectors[0].length);
+        for (float[] v: vectors) dataset.addVector(v);
+        index = CagraIndex.newBuilder(resources)
+            .withDataset(dataset)
+            .withIndexParams(indexParams)
+            .build();
+      } else {
+        index = CagraIndex.newBuilder(resources)
+             .withDataset(vectors)
+             .withIndexParams(indexParams)
+             .build();
+      }
 
       // Saving the HNSW index on to the disk.
       String hnswIndexFileName = UUID.randomUUID().toString() + ".hnsw";

--- a/java/examples/src/main/java/com/nvidia/cuvs/examples/BruteForceExample.java
+++ b/java/examples/src/main/java/com/nvidia/cuvs/examples/BruteForceExample.java
@@ -20,7 +20,7 @@ public class BruteForceExample {
   public static void main(String[] args) throws Throwable {
 
     // Sample data and query
-    float[][] dataset = {
+    float[][] vectors = {
         { 0.74021935f, 0.9209938f },
         { 0.03902049f, 0.9689629f },
         { 0.92514056f, 0.4463501f },
@@ -48,7 +48,7 @@ public class BruteForceExample {
 
       // Create the index with the dataset
       BruteForceIndex index = BruteForceIndex.newBuilder(resources)
-          .withDataset(dataset)
+          .withDataset(vectors)
           .withIndexParams(indexParams)
           .build();
 

--- a/java/examples/src/main/java/com/nvidia/cuvs/examples/CagraExample.java
+++ b/java/examples/src/main/java/com/nvidia/cuvs/examples/CagraExample.java
@@ -23,7 +23,7 @@ public class CagraExample {
   public static void main(String[] args) throws Throwable {
 
     // Sample data and query
-    float[][] dataset = {
+    float[][] vectors = {
         { 0.74021935f, 0.9209938f },
         { 0.03902049f, 0.9689629f },
         { 0.92514056f, 0.4463501f },
@@ -42,14 +42,12 @@ public class CagraExample {
       // Configure index parameters
       CagraIndexParams indexParams = new CagraIndexParams.Builder()
           .withCagraGraphBuildAlgo(CagraGraphBuildAlgo.NN_DESCENT)
-          .withGraphDegree(1)
-          .withIntermediateGraphDegree(2)
           .withMetric(CuvsDistanceType.L2Expanded)
           .build();
 
       // Create the index with the dataset
       CagraIndex index = CagraIndex.newBuilder(resources)
-          .withDataset(dataset)
+          .withDataset(vectors)
           .withIndexParams(indexParams)
           .build();
 

--- a/java/examples/src/main/java/com/nvidia/cuvs/examples/HnswExample.java
+++ b/java/examples/src/main/java/com/nvidia/cuvs/examples/HnswExample.java
@@ -28,7 +28,7 @@ public class HnswExample {
   public static void main(String[] args) throws Throwable {
 
     // Sample data and query
-    float[][] dataset = {
+    float[][] vectors = {
         { 0.74021935f, 0.9209938f },
         { 0.03902049f, 0.9689629f },
         { 0.92514056f, 0.4463501f },
@@ -61,16 +61,13 @@ public class HnswExample {
       // Configure index parameters
       CagraIndexParams indexParams = new CagraIndexParams.Builder()
           .withCagraGraphBuildAlgo(CagraGraphBuildAlgo.IVF_PQ)
-          .withGraphDegree(64)
-          .withIntermediateGraphDegree(128)
-          .withNumWriterThreads(32)
           .withMetric(CuvsDistanceType.L2Expanded)
           .withCuVSIvfPqParams(cuVSIvfPqParams)
           .build();
 
       // Create the index with the dataset
       CagraIndex index = CagraIndex.newBuilder(resources)
-          .withDataset(dataset)
+          .withDataset(vectors)
           .withIndexParams(indexParams)
           .build();
 


### PR DESCRIPTION
As reported in #698, current `withDataset(float[][] arr)` requires the entire dataset to be copied in heap first, before writing out the MemorySegment for it.

Introducing a new `Dataset` (interface and impl) support with a `addVector(float[] vector)` support for adding the vectors into the MemorySegment one by one, without needing to load them all at once.