### PR TITLE
Fix kmeans::predict argument order

### DIFF
--- a/cpp/include/cuvs/cluster/kmeans.hpp
+++ b/cpp/include/cuvs/cluster/kmeans.hpp
@@ -519,9 +519,25 @@ void predict(raft::resources const& handle,
              raft::device_matrix_view<const float, int> X,
              std::optional<raft::device_vector_view<const float, int>> sample_weight,
              raft::device_matrix_view<const float, int> centroids,
-             raft::device_vector_view<int, int> labels,
              bool normalize_weight,
+             raft::device_vector_view<int, int> labels,
              raft::host_scalar_view<float> inertia);
+
+// This overload is retained for backward compatibility.
+[[deprecated(
+  "The argument order of kmeans::predict has been corrected. Please use the new function "
+  "instead.")]]
+inline void predict(raft::resources const& handle,
+                    const kmeans::params& params,
+                    raft::device_matrix_view<const float, int> X,
+                    std::optional<raft::device_vector_view<const float, int>> sample_weight,
+                    raft::device_matrix_view<const float, int> centroids,
+                    raft::device_vector_view<int, int> labels,
+                    bool normalize_weight,
+                    raft::host_scalar_view<float> inertia)
+{
+  predict(handle, params, X, sample_weight, centroids, normalize_weight, labels, inertia);
+}
 
 /**
  * @brief Predict the closest cluster each sample in X belongs to.
@@ -577,9 +593,25 @@ void predict(raft::resources const& handle,
              raft::device_matrix_view<const float, int> X,
              std::optional<raft::device_vector_view<const float, int>> sample_weight,
              raft::device_matrix_view<const float, int> centroids,
-             raft::device_vector_view<int64_t, int> labels,
              bool normalize_weight,
+             raft::device_vector_view<int64_t, int> labels,
              raft::host_scalar_view<float> inertia);
+
+// This overload is retained for backward compatibility.
+[[deprecated(
+  "The argument order of kmeans::predict has been corrected. Please use the new function "
+  "instead.")]]
+inline void predict(raft::resources const& handle,
+                    const kmeans::params& params,
+                    raft::device_matrix_view<const float, int> X,
+                    std::optional<raft::device_vector_view<const float, int>> sample_weight,
+                    raft::device_matrix_view<const float, int> centroids,
+                    raft::device_vector_view<int64_t, int> labels,
+                    bool normalize_weight,
+                    raft::host_scalar_view<float> inertia)
+{
+  predict(handle, params, X, sample_weight, centroids, normalize_weight, labels, inertia);
+}
 
 /**
  * @brief Predict the closest cluster each sample in X belongs to.
@@ -635,9 +667,25 @@ void predict(raft::resources const& handle,
              raft::device_matrix_view<const double, int> X,
              std::optional<raft::device_vector_view<const double, int>> sample_weight,
              raft::device_matrix_view<const double, int> centroids,
-             raft::device_vector_view<int, int> labels,
              bool normalize_weight,
+             raft::device_vector_view<int, int> labels,
              raft::host_scalar_view<double> inertia);
+
+// This overload is retained for backward compatibility.
+[[deprecated(
+  "The argument order of kmeans::predict has been corrected. Please use the new function "
+  "instead.")]]
+inline void predict(raft::resources const& handle,
+                    const kmeans::params& params,
+                    raft::device_matrix_view<const double, int> X,
+                    std::optional<raft::device_vector_view<const double, int>> sample_weight,
+                    raft::device_matrix_view<const double, int> centroids,
+                    raft::device_vector_view<int, int> labels,
+                    bool normalize_weight,
+                    raft::host_scalar_view<double> inertia)
+{
+  predict(handle, params, X, sample_weight, centroids, normalize_weight, labels, inertia);
+}
 
 /**
  * @brief Predict the closest cluster each sample in X belongs to.
@@ -693,9 +741,25 @@ void predict(raft::resources const& handle,
              raft::device_matrix_view<const double, int> X,
              std::optional<raft::device_vector_view<const double, int>> sample_weight,
              raft::device_matrix_view<const double, int> centroids,
-             raft::device_vector_view<int64_t, int> labels,
              bool normalize_weight,
+             raft::device_vector_view<int64_t, int> labels,
              raft::host_scalar_view<double> inertia);
+
+// This overload is retained for backward compatibility.
+[[deprecated(
+  "The argument order of kmeans::predict has been corrected. Please use the new function "
+  "instead.")]]
+inline void predict(raft::resources const& handle,
+                    const kmeans::params& params,
+                    raft::device_matrix_view<const double, int> X,
+                    std::optional<raft::device_vector_view<const double, int>> sample_weight,
+                    raft::device_matrix_view<const double, int> centroids,
+                    raft::device_vector_view<int64_t, int> labels,
+                    bool normalize_weight,
+                    raft::host_scalar_view<double> inertia)
+{
+  predict(handle, params, X, sample_weight, centroids, normalize_weight, labels, inertia);
+}
 
 /**
  * @brief Predict the closest cluster each sample in X belongs to.

--- a/cpp/src/cluster/kmeans.cuh
+++ b/cpp/src/cluster/kmeans.cuh
@@ -163,8 +163,8 @@ void predict(raft::resources const& handle,
              raft::device_matrix_view<const DataT, IndexT> X,
              std::optional<raft::device_vector_view<const DataT, IndexT>> sample_weight,
              raft::device_matrix_view<const DataT, IndexT> centroids,
-             raft::device_vector_view<IndexT, IndexT> labels,
              bool normalize_weight,
+             raft::device_vector_view<IndexT, IndexT> labels,
              raft::host_scalar_view<DataT> inertia)
 {
   cuvs::cluster::kmeans::detail::kmeans_predict<DataT, IndexT>(

--- a/cpp/src/cluster/kmeans_predict_double.cu
+++ b/cpp/src/cluster/kmeans_predict_double.cu
@@ -24,13 +24,13 @@ void predict(raft::resources const& handle,
              raft::device_matrix_view<const double, int> X,
              std::optional<raft::device_vector_view<const double, int>> sample_weight,
              raft::device_matrix_view<const double, int> centroids,
-             raft::device_vector_view<int, int> labels,
              bool normalize_weight,
+             raft::device_vector_view<int, int> labels,
              raft::host_scalar_view<double> inertia)
 
 {
   cuvs::cluster::kmeans::predict<double, int>(
-    handle, params, X, sample_weight, centroids, labels, normalize_weight, inertia);
+    handle, params, X, sample_weight, centroids, normalize_weight, labels, inertia);
 }
 
 void predict(raft::resources const& handle,
@@ -38,12 +38,12 @@ void predict(raft::resources const& handle,
              raft::device_matrix_view<const double, int> X,
              std::optional<raft::device_vector_view<const double, int>> sample_weight,
              raft::device_matrix_view<const double, int> centroids,
-             raft::device_vector_view<int64_t, int> labels,
              bool normalize_weight,
+             raft::device_vector_view<int64_t, int> labels,
              raft::host_scalar_view<double> inertia)
 
 {
   cuvs::cluster::kmeans::predict<double, int64_t>(
-    handle, params, X, sample_weight, centroids, labels, normalize_weight, inertia);
+    handle, params, X, sample_weight, centroids, normalize_weight, labels, inertia);
 }
 }  // namespace cuvs::cluster::kmeans

--- a/cpp/src/cluster/kmeans_predict_float.cu
+++ b/cpp/src/cluster/kmeans_predict_float.cu
@@ -24,25 +24,25 @@ void predict(raft::resources const& handle,
              raft::device_matrix_view<const float, int> X,
              std::optional<raft::device_vector_view<const float, int>> sample_weight,
              raft::device_matrix_view<const float, int> centroids,
-             raft::device_vector_view<int, int> labels,
              bool normalize_weight,
+             raft::device_vector_view<int, int> labels,
              raft::host_scalar_view<float> inertia)
 
 {
   cuvs::cluster::kmeans::predict<float, int>(
-    handle, params, X, sample_weight, centroids, labels, normalize_weight, inertia);
+    handle, params, X, sample_weight, centroids, normalize_weight, labels, inertia);
 }
 void predict(raft::resources const& handle,
              const kmeans::params& params,
              raft::device_matrix_view<const float, int> X,
              std::optional<raft::device_vector_view<const float, int>> sample_weight,
              raft::device_matrix_view<const float, int> centroids,
-             raft::device_vector_view<int64_t, int> labels,
              bool normalize_weight,
+             raft::device_vector_view<int64_t, int> labels,
              raft::host_scalar_view<float> inertia)
 
 {
   cuvs::cluster::kmeans::predict<float, int64_t>(
-    handle, params, X, sample_weight, centroids, labels, normalize_weight, inertia);
+    handle, params, X, sample_weight, centroids, normalize_weight, labels, inertia);
 }
 }  // namespace cuvs::cluster::kmeans


### PR DESCRIPTION
This PR updates the order of arguments in `kmeans::predict` to match the order in the documentation. The order in the documentation is considered appropriate because it lists the output arguments last, unlike the order of the actual function arguments.