### PR TITLE
use 'rapids-init-pip' in wheel CI, other CI changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
   rust-build:
     needs: cpp-build
@@ -45,7 +46,7 @@ jobs:
       date: ${{ inputs.date }}
       container_image: "rapidsai/ci-conda:latest"
       node_type: "gpu-l4-latest-1"
-      run_script: "ci/build_rust.sh"
+      script: "ci/build_rust.sh"
       sha: ${{ inputs.sha }}
   rust-publish:
     needs: rust-build
@@ -62,7 +63,7 @@ jobs:
       date: ${{ inputs.date }}
       container_image: "rapidsai/ci-conda:latest"
       node_type: "gpu-l4-latest-1"
-      run_script: "ci/build_go.sh"
+      script: "ci/build_go.sh"
       sha: ${{ inputs.sha }}
   java-build:
     needs: cpp-build
@@ -74,7 +75,7 @@ jobs:
       arch: "amd64"
       date: ${{ inputs.date }}
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_java.sh"
+      script: "ci/build_java.sh"
       file_to_upload: "java/cuvs-java/target/"
       sha: ${{ inputs.sha }}
   python-build:
@@ -85,6 +86,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_python.sh
       sha: ${{ inputs.sha }}
   upload-conda:
     needs: [cpp-build, python-build]
@@ -108,7 +110,7 @@ jobs:
       container_image: "rapidsai/ci-conda:latest"
       date: ${{ inputs.date }}
       node_type: "gpu-l4-latest-1"
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}
   wheel-build-libcuvs:
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -122,6 +122,7 @@ jobs:
     with:
       build_type: pull-request
       node_type: cpu16
+      script: ci/build_cpp.sh
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
@@ -129,6 +130,7 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
+      script: ci/test_cpp.sh
   conda-cpp-checks:
     needs: conda-cpp-build
     secrets: inherit
@@ -143,6 +145,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
     with:
       build_type: pull-request
+      script: ci/build_python.sh
   conda-python-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -150,6 +153,7 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       build_type: pull-request
+      script: ci/test_python.sh
   conda-java-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
@@ -160,7 +164,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/test_java.sh"
+      script: "ci/test_java.sh"
       file_to_upload: "java/cuvs-java/target/"
   docs-build:
     needs: conda-python-build
@@ -171,7 +175,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"
   rust-build:
     needs: conda-cpp-build
     secrets: inherit
@@ -181,7 +185,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_rust.sh"
+      script: "ci/build_rust.sh"
   go-build:
     needs: conda-cpp-build
     secrets: inherit
@@ -191,7 +195,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_go.sh"
+      script: "ci/build_go.sh"
   wheel-build-libcuvs:
     needs: checks
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/test_cpp.sh
       sha: ${{ inputs.sha }}
   conda-python-tests:
     secrets: inherit
@@ -42,6 +43,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/test_python.sh
       sha: ${{ inputs.sha }}
   conda-java-tests:
     secrets: inherit
@@ -54,7 +56,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/test_java.sh"
+      script: "ci/test_java.sh"
   wheel-tests-cuvs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -3,8 +3,6 @@
 
 set -euo pipefail
 
-rapids-configure-conda-channels
-
 source rapids-configure-sccache
 
 source rapids-date-string

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -3,8 +3,6 @@
 
 set -euo pipefail
 
-rapids-configure-conda-channels
-
 source rapids-configure-sccache
 
 source rapids-date-string

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -10,6 +10,7 @@ underscore_package_name=$(echo "${package_name}" | tr "-" "_")
 
 source rapids-configure-sccache
 source rapids-date-string
+source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 

--- a/ci/build_wheel_cuvs.sh
+++ b/ci/build_wheel_cuvs.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_dir="python/cuvs"
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
@@ -11,10 +13,9 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 # then ensures 'cuvs' wheel builds always use the 'libcuvs' just built in the same CI run.
 #
 # Using env variable PIP_CONSTRAINT is necessary to ensure the constraints
-# are used when creating the isolated build environment.
+# Using env variable PIP_CONSTRAINT (initialized by 'rapids-init-pip') is necessary to ensure the constraints
 LIBCUVS_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcuvs_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
-echo "libcuvs-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBCUVS_WHEELHOUSE}"/libcuvs_*.whl)" > /tmp/constraints.txt
-export PIP_CONSTRAINT="/tmp/constraints.txt"
+echo "libcuvs-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBCUVS_WHEELHOUSE}"/libcuvs_*.whl)" >> "${PIP_CONSTRAINT}"
 
 ci/build_wheel.sh cuvs ${package_dir} python
 ci/validate_wheel.sh ${package_dir} "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/build_wheel_libcuvs.sh
+++ b/ci/build_wheel_libcuvs.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_name="libcuvs"
 package_dir="python/libcuvs"
 

--- a/ci/test_wheel_cuvs.sh
+++ b/ci/test_wheel_cuvs.sh
@@ -3,13 +3,14 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 # Delete system libnccl.so to ensure the wheel is used
 RAPIDS_CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
 if [[ ${RAPIDS_CUDA_MAJOR} != "11" ]]; then
   rm -rf /usr/lib64/libnccl*
 fi
 
-mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 LIBCUVS_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcuvs_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
 CUVS_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cuvs_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)


### PR DESCRIPTION
## Description

Proposes a batch of small, mostly-unrelated changes to building and packaging.

These are all part of RAPIDS-wide efforts to make it easier to reproduce CI locally and to use artifacts from one project's CI in another project's CI.

Contributes to https://github.com/rapidsai/shared-workflows/issues/356

* explicitly provides an input for `script` to workflows using it, instead of relying on a default value coming from the workflow file

Contributes to https://github.com/rapidsai/shared-workflows/issues/337

* switches from input `run_script` to `script` in uses of the `custom-job` workflow

Contributes to https://github.com/rapidsai/build-planning/issues/179

* adds a call to `rapids-init-pip` near the beginning of all CI scripts that use `pip`
* removes redefinitions of `PIP_CONSTRAINT` in scripts, in favor of using the one set up by `rapids-pip-init`

Contributes to https://github.com/rapidsai/gha-tools/issues/145

* removes unnecessary uses of `rapids-configure-conda-channels` in builds scripts using `rattler-build`