### PR TITLE
Instantiate only specific RAFT reduction kernels

### DIFF
--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -35,6 +35,8 @@ function(find_and_configure_raft)
         string(APPEND RAFT_COMPONENTS " distributed")
     endif()
 
+    set(CPM_raft_SOURCE /raid/dgala/raft)
+
     #-----------------------------------------------------
     # Invoke CPM find_package()
     #-----------------------------------------------------

--- a/cpp/src/cluster/detail/kmeans.cuh
+++ b/cpp/src/cluster/detail/kmeans.cuh
@@ -143,13 +143,8 @@ void kmeansPlusPlus(raft::resources const& handle,
 
   if (metric == cuvs::distance::DistanceType::L2Expanded ||
       metric == cuvs::distance::DistanceType::L2SqrtExpanded) {
-    raft::linalg::rowNorm(L2NormX.data_handle(),
-                          X.data_handle(),
-                          X.extent(1),
-                          X.extent(0),
-                          raft::linalg::L2Norm,
-                          true,
-                          stream);
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+      L2NormX.data_handle(), X.data_handle(), X.extent(1), X.extent(0), stream);
   }
 
   raft::random::RngState rng(params.rng_state.seed, params.rng_state.type);
@@ -216,14 +211,12 @@ void kmeansPlusPlus(raft::resources const& handle,
 
     // Calculate costPerCandidate[n_trials] where costPerCandidate[i] is the cluster cost when using
     // centroid candidate-i
-    raft::linalg::reduce(costPerCandidate.data_handle(),
-                         minDistBuf.data_handle(),
-                         minDistBuf.extent(1),
-                         minDistBuf.extent(0),
-                         static_cast<DataT>(0),
-                         true,
-                         true,
-                         stream);
+    raft::linalg::reduce<true, true>(costPerCandidate.data_handle(),
+                                     minDistBuf.data_handle(),
+                                     minDistBuf.extent(1),
+                                     minDistBuf.extent(0),
+                                     static_cast<DataT>(0),
+                                     stream);
 
     // Greedy Choice - Choose the candidate that has minimum cluster cost
     // ArgMin operation below identifies the index of minimum cost in costPerCandidate
@@ -406,13 +399,8 @@ void kmeans_fit_main(raft::resources const& handle,
 
   if (metric == cuvs::distance::DistanceType::L2Expanded ||
       metric == cuvs::distance::DistanceType::L2SqrtExpanded) {
-    raft::linalg::rowNorm(L2NormX.data_handle(),
-                          X.data_handle(),
-                          X.extent(1),
-                          X.extent(0),
-                          raft::linalg::L2Norm,
-                          true,
-                          stream);
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+      L2NormX.data_handle(), X.data_handle(), X.extent(1), X.extent(0), stream);
   }
 
   RAFT_LOG_DEBUG(
@@ -634,13 +622,8 @@ void initScalableKMeansPlusPlus(raft::resources const& handle,
   auto L2NormX = raft::make_device_vector<DataT, IndexT>(handle, n_samples);
   if (metric == cuvs::distance::DistanceType::L2Expanded ||
       metric == cuvs::distance::DistanceType::L2SqrtExpanded) {
-    raft::linalg::rowNorm(L2NormX.data_handle(),
-                          X.data_handle(),
-                          X.extent(1),
-                          X.extent(0),
-                          raft::linalg::L2Norm,
-                          true,
-                          stream);
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+      L2NormX.data_handle(), X.data_handle(), X.extent(1), X.extent(0), stream);
   }
 
   auto minClusterDistanceVec = raft::make_device_vector<DataT, IndexT>(handle, n_samples);
@@ -1049,13 +1032,8 @@ void kmeans_predict(raft::resources const& handle,
   auto L2NormX = raft::make_device_vector<DataT, IndexT>(handle, n_samples);
   if (metric == cuvs::distance::DistanceType::L2Expanded ||
       metric == cuvs::distance::DistanceType::L2SqrtExpanded) {
-    raft::linalg::rowNorm(L2NormX.data_handle(),
-                          X.data_handle(),
-                          X.extent(1),
-                          X.extent(0),
-                          raft::linalg::L2Norm,
-                          true,
-                          stream);
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+      L2NormX.data_handle(), X.data_handle(), X.extent(1), X.extent(0), stream);
   }
 
   // computes minClusterAndDistance[0:n_samples) where  minClusterAndDistance[i]

--- a/cpp/src/cluster/detail/kmeans_balanced.cuh
+++ b/cpp/src/cluster/detail/kmeans_balanced.cuh
@@ -113,8 +113,8 @@ inline std::enable_if_t<std::is_floating_point_v<MathT>> predict_core(
 
       auto centroidsNorm =
         raft::make_device_mdarray<MathT, IdxT>(handle, mr, raft::make_extents<IdxT>(n_clusters));
-      raft::linalg::rowNorm<MathT, IdxT>(
-        centroidsNorm.data_handle(), centers, dim, n_clusters, raft::linalg::L2Norm, true, stream);
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true, MathT, IdxT>(
+        centroidsNorm.data_handle(), centers, dim, n_clusters, stream);
 
       cuvs::distance::fusedDistanceNNMinReduce<MathT, raft::KeyValuePair<IdxT, MathT>, IdxT>(
         minClusterAndDistance.data_handle(),
@@ -156,14 +156,8 @@ inline std::enable_if_t<std::is_floating_point_v<MathT>> predict_core(
 
       auto centroidsNorm =
         raft::make_device_mdarray<MathT, IdxT>(handle, mr, raft::make_extents<IdxT>(n_clusters));
-      raft::linalg::rowNorm<MathT, IdxT>(centroidsNorm.data_handle(),
-                                         centers,
-                                         dim,
-                                         n_clusters,
-                                         raft::linalg::L2Norm,
-                                         true,
-                                         stream,
-                                         raft::sqrt_op{});
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true, MathT, IdxT>(
+        centroidsNorm.data_handle(), centers, dim, n_clusters, stream, raft::sqrt_op{});
 
       cuvs::distance::fusedDistanceNNMinReduce<MathT, raft::KeyValuePair<IdxT, MathT>, IdxT>(
         minClusterAndDistance.data_handle(),
@@ -395,8 +389,8 @@ void compute_norm(const raft::resources& handle,
     dataset_ptr = static_cast<const MathT*>(mapped_dataset.data());
   }
 
-  raft::linalg::rowNorm<MathT, IdxT>(
-    dataset_norm, dataset_ptr, dim, n_rows, raft::linalg::L2Norm, true, stream, norm_fin_op);
+  raft::linalg::rowNorm<raft::linalg::L2Norm, true, MathT, IdxT>(
+    dataset_norm, dataset_ptr, dim, n_rows, stream, norm_fin_op);
 }
 
 /**
@@ -732,8 +726,8 @@ void balancing_em_iters(const raft::resources& handle,
           cluster_centers, n_clusters, dim);
         auto clusters_out_view = raft::make_device_matrix_view<MathT, IdxT, raft::row_major>(
           cluster_centers, n_clusters, dim);
-        raft::linalg::row_normalize(
-          handle, clusters_in_view, clusters_out_view, raft::linalg::L2Norm);
+        raft::linalg::row_normalize<raft::linalg::L2Norm>(
+          handle, clusters_in_view, clusters_out_view);
         break;
       }
       default: break;

--- a/cpp/src/cluster/detail/kmeans_common.cuh
+++ b/cpp/src/cluster/detail/kmeans_common.cuh
@@ -382,13 +382,11 @@ void minClusterAndDistanceCompute(
 
   if (is_fused) {
     L2NormBuf_OR_DistBuf.resize(n_clusters, stream);
-    raft::linalg::rowNorm(L2NormBuf_OR_DistBuf.data(),
-                          centroids.data_handle(),
-                          centroids.extent(1),
-                          centroids.extent(0),
-                          raft::linalg::L2Norm,
-                          true,
-                          stream);
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(L2NormBuf_OR_DistBuf.data(),
+                                                      centroids.data_handle(),
+                                                      centroids.extent(1),
+                                                      centroids.extent(0),
+                                                      stream);
   } else {
     // TODO: Unless pool allocator is used, passing in a workspace for this
     // isn't really increasing performance because this needs to do a re-allocation
@@ -518,13 +516,11 @@ void minClusterDistanceCompute(raft::resources const& handle,
 
   if (is_fused) {
     L2NormBuf_OR_DistBuf.resize(n_clusters, stream);
-    raft::linalg::rowNorm(L2NormBuf_OR_DistBuf.data(),
-                          centroids.data_handle(),
-                          centroids.extent(1),
-                          centroids.extent(0),
-                          raft::linalg::L2Norm,
-                          true,
-                          stream);
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(L2NormBuf_OR_DistBuf.data(),
+                                                      centroids.data_handle(),
+                                                      centroids.extent(1),
+                                                      centroids.extent(0),
+                                                      stream);
   } else {
     L2NormBuf_OR_DistBuf.resize(dataBatchSize * centroidsBatchSize, stream);
   }

--- a/cpp/src/cluster/detail/kmeans_mg.cuh
+++ b/cpp/src/cluster/detail/kmeans_mg.cuh
@@ -228,13 +228,8 @@ void initKMeansPlusPlus(const raft::resources& handle,
   auto L2NormX = raft::make_device_vector<DataT, IndexT>(handle, n_samples);
   if (metric == cuvs::distance::DistanceType::L2Expanded ||
       metric == cuvs::distance::DistanceType::L2SqrtExpanded) {
-    raft::linalg::rowNorm(L2NormX.data_handle(),
-                          X.data_handle(),
-                          X.extent(1),
-                          X.extent(0),
-                          raft::linalg::L2Norm,
-                          true,
-                          stream);
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+      L2NormX.data_handle(), X.data_handle(), X.extent(1), X.extent(0), stream);
   }
 
   auto minClusterDistance = raft::make_device_vector<DataT, IndexT>(handle, n_samples);
@@ -578,13 +573,8 @@ void fit(const raft::resources& handle,
   auto L2NormX = raft::make_device_vector<DataT, IndexT>(handle, n_samples);
   if (metric == cuvs::distance::DistanceType::L2Expanded ||
       metric == cuvs::distance::DistanceType::L2SqrtExpanded) {
-    raft::linalg::rowNorm(L2NormX.data_handle(),
-                          X.data_handle(),
-                          X.extent(1),
-                          X.extent(0),
-                          raft::linalg::L2Norm,
-                          true,
-                          stream);
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+      L2NormX.data_handle(), X.data_handle(), X.extent(1), X.extent(0), stream);
   }
 
   DataT priorClusteringCost = 0;

--- a/cpp/src/cluster/kmeans.cuh
+++ b/cpp/src/cluster/kmeans.cuh
@@ -481,13 +481,8 @@ void cluster_cost(raft::resources const& handle,
 
   auto x_norms = raft::make_device_vector<DataT>(handle, n_samples);
 
-  raft::linalg::rowNorm(x_norms.data_handle(),
-                        X.data_handle(),
-                        n_features,
-                        n_samples,
-                        raft::linalg::L2Norm,
-                        true,
-                        stream);
+  raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+    x_norms.data_handle(), X.data_handle(), n_features, n_samples, stream);
 
   auto min_cluster_distance = raft::make_device_vector<DataT>(handle, n_samples);
   rmm::device_uvector<DataT> l2_norm_or_distance_buffer(0, stream);

--- a/cpp/src/distance/detail/distance.cuh
+++ b/cpp/src/distance/detail/distance.cuh
@@ -141,50 +141,34 @@ void distance_impl(raft::resources const& handle,
   // perhaps the use of stridedSummationKernel could be causing this,
   // need to investigate and fix.
   if (x == y && is_row_major) {
-    raft::linalg::reduce(x_norm,
-                         x,
-                         k,
-                         std::max(m, n),
-                         (AccT)0,
-                         is_row_major,
-                         true,
-                         stream,
-                         false,
-                         raft::identity_op(),
-                         raft::add_op());
+    raft::linalg::reduce<true, true>(
+      x_norm, x, k, std::max(m, n), (AccT)0, stream, false, raft::identity_op(), raft::add_op());
     sq_x_norm += std::max(m, n);
     sq_y_norm = sq_x_norm;
-    raft::linalg::rowNorm(
-      sq_x_norm, x, k, std::max(m, n), raft::linalg::L2Norm, is_row_major, stream);
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(sq_x_norm, x, k, std::max(m, n), stream);
   } else {
     y_norm += m;
-    raft::linalg::reduce(x_norm,
-                         x,
-                         k,
-                         m,
-                         (AccT)0,
-                         is_row_major,
-                         true,
-                         stream,
-                         false,
-                         raft::identity_op(),
-                         raft::add_op());
-    raft::linalg::reduce(y_norm,
-                         y,
-                         k,
-                         n,
-                         (AccT)0,
-                         is_row_major,
-                         true,
-                         stream,
-                         false,
-                         raft::identity_op(),
-                         raft::add_op());
+    if (is_row_major) {
+      raft::linalg::reduce<true, true>(
+        x_norm, x, k, m, (AccT)0, stream, false, raft::identity_op(), raft::add_op());
+      raft::linalg::reduce<true, true>(
+        y_norm, y, k, n, (AccT)0, stream, false, raft::identity_op(), raft::add_op());
+    } else {
+      raft::linalg::reduce<false, true>(
+        x_norm, x, k, m, (AccT)0, stream, false, raft::identity_op(), raft::add_op());
+      raft::linalg::reduce<false, true>(
+        y_norm, y, k, n, (AccT)0, stream, false, raft::identity_op(), raft::add_op());
+    }
 
     sq_x_norm += (m + n);
     sq_y_norm = sq_x_norm + m;
-    raft::linalg::rowNorm(sq_x_norm, x, k, m, raft::linalg::L2Norm, is_row_major, stream);
-    raft::linalg::rowNorm(sq_y_norm, y, k, n, raft::linalg::L2Norm, is_row_major, stream);
+    if (is_row_major) {
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true>(sq_x_norm, x, k, m, stream);
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true>(sq_y_norm, y, k, n, stream);
+    } else {
+      raft::linalg::rowNorm<raft::linalg::L2Norm, false>(sq_x_norm, x, k, m, stream);
+      raft::linalg::rowNorm<raft::linalg::L2Norm, false>(sq_y_norm, y, k, n, stream);
+    }
   }
 
   using OpT = ops::correlation_distance_op<DataT, AccT, IdxT>;
@@ -224,14 +208,17 @@ void distance_impl(raft::resources const& handle,
   // perhaps the use of stridedSummationKernel could be causing this,
   // need to investigate and fix.
   if (x == y && is_row_major) {
-    raft::linalg::rowNorm(
-      x_norm, x, k, std::max(m, n), raft::linalg::L2Norm, is_row_major, stream, raft::sqrt_op{});
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+      x_norm, x, k, std::max(m, n), stream, raft::sqrt_op{});
   } else {
     y_norm += m;
-    raft::linalg::rowNorm(
-      x_norm, x, k, m, raft::linalg::L2Norm, is_row_major, stream, raft::sqrt_op{});
-    raft::linalg::rowNorm(
-      y_norm, y, k, n, raft::linalg::L2Norm, is_row_major, stream, raft::sqrt_op{});
+    if (is_row_major) {
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true>(x_norm, x, k, m, stream, raft::sqrt_op{});
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true>(y_norm, y, k, n, stream, raft::sqrt_op{});
+    } else {
+      raft::linalg::rowNorm<raft::linalg::L2Norm, false>(x_norm, x, k, m, stream, raft::sqrt_op{});
+      raft::linalg::rowNorm<raft::linalg::L2Norm, false>(y_norm, y, k, n, stream, raft::sqrt_op{});
+    }
   }
 
   ops::cosine_distance_op<DataT, AccT, IdxT> distance_op{};
@@ -482,20 +469,21 @@ void distance_impl_l2_expanded(  // NOTE: different name
   // perhaps the use of stridedSummationKernel could be causing this,
   // need to investigate and fix.
   if ((x == y) && is_row_major) {
-    raft::linalg::rowNorm(x_norm,
-                          x,
-                          k,
-                          std::max(m, n),
-                          raft::linalg::L2Norm,
-                          is_row_major,
-                          stream,
-                          raft::identity_op{});
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+      x_norm, x, k, std::max(m, n), stream, raft::identity_op{});
   } else {
     y_norm += m;
-    raft::linalg::rowNorm(
-      x_norm, x, k, m, raft::linalg::L2Norm, is_row_major, stream, raft::identity_op{});
-    raft::linalg::rowNorm(
-      y_norm, y, k, n, raft::linalg::L2Norm, is_row_major, stream, raft::identity_op{});
+    if (is_row_major) {
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+        x_norm, x, k, m, stream, raft::identity_op{});
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+        y_norm, y, k, n, stream, raft::identity_op{});
+    } else {
+      raft::linalg::rowNorm<raft::linalg::L2Norm, false>(
+        x_norm, x, k, m, stream, raft::identity_op{});
+      raft::linalg::rowNorm<raft::linalg::L2Norm, false>(
+        y_norm, y, k, n, stream, raft::identity_op{});
+    }
   }
 
   ops::l2_exp_distance_op<DataT, AccT, IdxT> distance_op{perform_sqrt};

--- a/cpp/src/distance/detail/kernels/kernel_matrices.cu
+++ b/cpp/src/distance/detail/kernels/kernel_matrices.cu
@@ -477,13 +477,19 @@ void RBFKernel<math_t>::matrixRowNormL2(raft::resources const& handle,
   int minor         = is_row_major ? matrix.extent(1) : matrix.extent(0);
   int ld            = is_row_major ? matrix.stride(0) : matrix.stride(1);
   ASSERT(ld == minor, "RBF Kernel lazy rowNorm compute does not support ld parameter");
-  raft::linalg::rowNorm(target,
-                        matrix.data_handle(),
-                        matrix.extent(1),
-                        matrix.extent(0),
-                        raft::linalg::NormType::L2Norm,
-                        is_row_major,
-                        raft::resource::get_cuda_stream(handle));
+  if (is_row_major) {
+    raft::linalg::rowNorm<raft::linalg::L2Norm, true>(target,
+                                                      matrix.data_handle(),
+                                                      matrix.extent(1),
+                                                      matrix.extent(0),
+                                                      raft::resource::get_cuda_stream(handle));
+  } else {
+    raft::linalg::rowNorm<raft::linalg::L2Norm, false>(target,
+                                                       matrix.data_handle(),
+                                                       matrix.extent(1),
+                                                       matrix.extent(0),
+                                                       raft::resource::get_cuda_stream(handle));
+  }
 }
 
 template <typename math_t>

--- a/cpp/src/neighbors/detail/fused_l2_knn.cuh
+++ b/cpp/src/neighbors/detail/fused_l2_knn.cuh
@@ -792,8 +792,13 @@ void fusedL2ExpKnnImpl(const DataT* x,
     if (!xn) {
       AccT* xn_ = (AccT*)workspace;
       workspace = xn_ + m;
-      raft::linalg::rowNorm(
-        xn_, x, k, m, raft::linalg::L2Norm, isRowMajor, stream, raft::identity_op{});
+      if (isRowMajor) {
+        raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+          xn_, x, k, m, stream, raft::identity_op{});
+      } else {
+        raft::linalg::rowNorm<raft::linalg::L2Norm, false>(
+          xn_, x, k, m, stream, raft::identity_op{});
+      }
       xn = xn_;
     }
     if (!yn) {
@@ -801,8 +806,13 @@ void fusedL2ExpKnnImpl(const DataT* x,
         yn = xn;
       } else {
         AccT* yn_ = (AccT*)(workspace);
-        raft::linalg::rowNorm(
-          yn_, y, k, n, raft::linalg::L2Norm, isRowMajor, stream, raft::identity_op{});
+        if (isRowMajor) {
+          raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+            yn_, y, k, n, stream, raft::identity_op{});
+        } else {
+          raft::linalg::rowNorm<raft::linalg::L2Norm, false>(
+            yn_, y, k, n, stream, raft::identity_op{});
+        }
         yn = yn_;
       }
     }

--- a/cpp/src/neighbors/detail/knn_brute_force.cuh
+++ b/cpp/src/neighbors/detail/knn_brute_force.cuh
@@ -122,33 +122,20 @@ void tiled_brute_force_knn(const raft::resources& handle,
     // cosine needs the l2norm, where as l2 distances needs the squared norm
     if (metric == cuvs::distance::DistanceType::CosineExpanded) {
       if (!precomputed_search_norms) {
-        raft::linalg::rowNorm(search_norms.data(),
-                              search,
-                              d,
-                              m,
-                              raft::linalg::NormType::L2Norm,
-                              true,
-                              stream,
-                              raft::sqrt_op{});
+        raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+          search_norms.data(), search, d, m, stream, raft::sqrt_op{});
       }
       if (!precomputed_index_norms) {
-        raft::linalg::rowNorm(index_norms.data(),
-                              index,
-                              d,
-                              n,
-                              raft::linalg::NormType::L2Norm,
-                              true,
-                              stream,
-                              raft::sqrt_op{});
+        raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+          index_norms.data(), index, d, n, stream, raft::sqrt_op{});
       }
     } else {
       if (!precomputed_search_norms) {
-        raft::linalg::rowNorm(
-          search_norms.data(), search, d, m, raft::linalg::NormType::L2Norm, true, stream);
+        raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+          search_norms.data(), search, d, m, stream);
       }
       if (!precomputed_index_norms) {
-        raft::linalg::rowNorm(
-          index_norms.data(), index, d, n, raft::linalg::NormType::L2Norm, true, stream);
+        raft::linalg::rowNorm<raft::linalg::L2Norm, true>(index_norms.data(), index, d, n, stream);
       }
     }
     pairwise_metric = cuvs::distance::DistanceType::InnerProduct;
@@ -700,26 +687,24 @@ void brute_force_search_filtered(
       if (metric == cuvs::distance::DistanceType::CosineExpanded) {
         if (!query_norms) {
           query_norms_ = raft::make_device_vector<DistanceT, IdxT>(res, n_queries);
-          raft::linalg::rowNorm((DistanceT*)(query_norms_->data_handle()),
-                                queries.data_handle(),
-                                dim,
-                                n_queries,
-                                raft::linalg::L2Norm,
-                                true,
-                                stream,
-                                raft::sqrt_op{});
+          raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+            (DistanceT*)(query_norms_->data_handle()),
+            queries.data_handle(),
+            dim,
+            n_queries,
+            stream,
+            raft::sqrt_op{});
         }
       } else {
         if (!query_norms) {
           query_norms_ = raft::make_device_vector<DistanceT, IdxT>(res, n_queries);
-          raft::linalg::rowNorm((DistanceT*)(query_norms_->data_handle()),
-                                queries.data_handle(),
-                                dim,
-                                n_queries,
-                                raft::linalg::L2Norm,
-                                true,
-                                stream,
-                                raft::identity_op{});
+          raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+            (DistanceT*)(query_norms_->data_handle()),
+            queries.data_handle(),
+            dim,
+            n_queries,
+            stream,
+            raft::identity_op{});
         }
       }
       cuvs::neighbors::detail::epilogue_on_csr(
@@ -813,18 +798,11 @@ cuvs::neighbors::brute_force::index<T, DistT> build(
     norms = raft::make_device_vector<DistT, int64_t>(res, dataset.extent(0));
     // cosine needs the l2norm, where as l2 distances needs the squared norm
     if (metric == cuvs::distance::DistanceType::CosineExpanded) {
-      raft::linalg::norm(res,
-                         dataset_view,
-                         norms->view(),
-                         raft::linalg::NormType::L2Norm,
-                         raft::linalg::Apply::ALONG_ROWS,
-                         raft::sqrt_op{});
+      raft::linalg::norm<raft::linalg::L2Norm, raft::Apply::ALONG_ROWS>(
+        res, dataset_view, norms->view(), raft::sqrt_op{});
     } else {
-      raft::linalg::norm(res,
-                         dataset_view,
-                         norms->view(),
-                         raft::linalg::NormType::L2Norm,
-                         raft::linalg::Apply::ALONG_ROWS);
+      raft::linalg::norm<raft::linalg::L2Norm, raft::Apply::ALONG_ROWS>(
+        res, dataset_view, norms->view());
     }
   }
 

--- a/cpp/src/neighbors/ivf_flat/ivf_flat_build.cuh
+++ b/cpp/src/neighbors/ivf_flat/ivf_flat_build.cuh
@@ -340,43 +340,32 @@ void extend(raft::resources const& handle,
     index->allocate_center_norms(handle);
     if (index->center_norms().has_value()) {
       if (index->metric() == cuvs::distance::DistanceType::CosineExpanded) {
-        raft::linalg::rowNorm(index->center_norms()->data_handle(),
-                              index->centers().data_handle(),
-                              dim,
-                              n_lists,
-                              raft::linalg::L2Norm,
-                              true,
-                              stream,
-                              raft::sqrt_op{});
+        raft::linalg::rowNorm<raft::linalg::L2Norm, true>(index->center_norms()->data_handle(),
+                                                          index->centers().data_handle(),
+                                                          dim,
+                                                          n_lists,
+                                                          stream,
+                                                          raft::sqrt_op{});
       } else {
-        raft::linalg::rowNorm(index->center_norms()->data_handle(),
-                              index->centers().data_handle(),
-                              dim,
-                              n_lists,
-                              raft::linalg::L2Norm,
-                              true,
-                              stream);
+        raft::linalg::rowNorm<raft::linalg::L2Norm, true>(index->center_norms()->data_handle(),
+                                                          index->centers().data_handle(),
+                                                          dim,
+                                                          n_lists,
+                                                          stream);
       }
       RAFT_LOG_TRACE_VEC(index->center_norms()->data_handle(), std::min<uint32_t>(dim, 20));
     }
   } else if (index->center_norms().has_value() && index->adaptive_centers()) {
     if (index->metric() == cuvs::distance::DistanceType::CosineExpanded) {
-      raft::linalg::rowNorm(index->center_norms()->data_handle(),
-                            index->centers().data_handle(),
-                            dim,
-                            n_lists,
-                            raft::linalg::L2Norm,
-                            true,
-                            stream,
-                            raft::sqrt_op{});
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true>(index->center_norms()->data_handle(),
+                                                        index->centers().data_handle(),
+                                                        dim,
+                                                        n_lists,
+                                                        stream,
+                                                        raft::sqrt_op{});
     } else {
-      raft::linalg::rowNorm(index->center_norms()->data_handle(),
-                            index->centers().data_handle(),
-                            dim,
-                            n_lists,
-                            raft::linalg::L2Norm,
-                            true,
-                            stream);
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+        index->center_norms()->data_handle(), index->centers().data_handle(), dim, n_lists, stream);
     }
     RAFT_LOG_TRACE_VEC(index->center_norms()->data_handle(), std::min<uint32_t>(dim, 20));
   }

--- a/cpp/src/neighbors/ivf_flat/ivf_flat_search.cuh
+++ b/cpp/src/neighbors/ivf_flat/ivf_flat_search.cuh
@@ -108,13 +108,11 @@ void search_impl(raft::resources const& handle,
     case cuvs::distance::DistanceType::L2SqrtExpanded: {
       alpha = -2.0f;
       beta  = 1.0f;
-      raft::linalg::rowNorm(query_norm_dev.data(),
-                            converted_queries_ptr,
-                            static_cast<IdxT>(index.dim()),
-                            static_cast<IdxT>(n_queries),
-                            raft::linalg::L2Norm,
-                            true,
-                            stream);
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true>(query_norm_dev.data(),
+                                                        converted_queries_ptr,
+                                                        static_cast<IdxT>(index.dim()),
+                                                        static_cast<IdxT>(n_queries),
+                                                        stream);
       utils::outer_add(query_norm_dev.data(),
                        (IdxT)n_queries,
                        index.center_norms()->data_handle(),
@@ -126,14 +124,12 @@ void search_impl(raft::resources const& handle,
       break;
     }
     case cuvs::distance::DistanceType::CosineExpanded: {
-      raft::linalg::rowNorm(query_norm_dev.data(),
-                            converted_queries_ptr,
-                            static_cast<IdxT>(index.dim()),
-                            static_cast<IdxT>(n_queries),
-                            raft::linalg::L2Norm,
-                            true,
-                            stream,
-                            raft::sqrt_op{});
+      raft::linalg::rowNorm<raft::linalg::L2Norm, true>(query_norm_dev.data(),
+                                                        converted_queries_ptr,
+                                                        static_cast<IdxT>(index.dim()),
+                                                        static_cast<IdxT>(n_queries),
+                                                        stream,
+                                                        raft::sqrt_op{});
       alpha = -1.0f;
       beta  = 0.0f;
       break;

--- a/cpp/src/neighbors/ivf_pq/ivf_pq_build.cuh
+++ b/cpp/src/neighbors/ivf_pq/ivf_pq_build.cuh
@@ -254,13 +254,8 @@ void set_centers(raft::resources const& handle, index<IdxT>* index, const float*
                                   stream));
 
   rmm::device_uvector<float> center_norms(index->n_lists(), stream, device_memory);
-  raft::linalg::rowNorm(center_norms.data(),
-                        cluster_centers,
-                        index->dim(),
-                        index->n_lists(),
-                        raft::linalg::L2Norm,
-                        true,
-                        stream);
+  raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+    center_norms.data(), cluster_centers, index->dim(), index->n_lists(), stream);
   RAFT_CUDA_TRY(cudaMemcpy2DAsync(index->centers().data_handle() + index->dim(),
                                   sizeof(float) * index->dim_ext(),
                                   center_norms.data(),
@@ -1649,10 +1644,8 @@ void extend(raft::resources const& handle,
     if (index->metric() == CosineExpanded) {
       auto vec_batch_view = raft::make_device_matrix_view<T, internal_extents_t>(
         const_cast<T*>(vec_batch.data()), vec_batch.size(), index->dim());
-      raft::linalg::row_normalize(handle,
-                                  raft::make_const_mdspan(vec_batch_view),
-                                  vec_batch_view,
-                                  raft::linalg::NormType::L2Norm);
+      raft::linalg::row_normalize<raft::linalg::L2Norm>(
+        handle, raft::make_const_mdspan(vec_batch_view), vec_batch_view);
     }
     process_and_fill_codes(handle,
                            *index,
@@ -1789,8 +1782,8 @@ auto build(raft::resources const& handle,
     kmeans_params.metric  = static_cast<cuvs::distance::DistanceType>((int)index.metric());
 
     if (index.metric() == distance::DistanceType::CosineExpanded) {
-      raft::linalg::row_normalize(
-        handle, trainset_const_view, trainset.view(), raft::linalg::NormType::L2Norm);
+      raft::linalg::row_normalize<raft::linalg::L2Norm>(
+        handle, trainset_const_view, trainset.view());
     }
     cuvs::cluster::kmeans_balanced::fit(
       handle, kmeans_params, trainset_const_view, centers_view, utils::mapping<float>{});
@@ -1800,8 +1793,7 @@ auto build(raft::resources const& handle,
     auto centers_const_view = raft::make_device_matrix_view<const float, internal_extents_t>(
       cluster_centers, index.n_lists(), index.dim());
     if (index.metric() == distance::DistanceType::CosineExpanded) {
-      raft::linalg::row_normalize(
-        handle, centers_const_view, centers_view, raft::linalg::NormType::L2Norm);
+      raft::linalg::row_normalize<raft::linalg::L2Norm>(handle, centers_const_view, centers_view);
     }
     auto labels_view =
       raft::make_device_vector_view<uint32_t, internal_extents_t>(labels.data(), n_rows_train);

--- a/cpp/src/neighbors/ivf_pq/ivf_pq_search.cuh
+++ b/cpp/src/neighbors/ivf_pq/ivf_pq_search.cuh
@@ -943,10 +943,8 @@ inline void search(raft::resources const& handle,
     if (index.metric() == distance::DistanceType::CosineExpanded) {
       auto rot_queries_view = raft::make_device_matrix_view<float, uint32_t>(
         rot_queries.data(), max_queries, index.rot_dim());
-      raft::linalg::row_normalize(handle,
-                                  raft::make_const_mdspan(rot_queries_view),
-                                  rot_queries_view,
-                                  raft::linalg::NormType::L2Norm);
+      raft::linalg::row_normalize<raft::linalg::L2Norm>(
+        handle, raft::make_const_mdspan(rot_queries_view), rot_queries_view);
     }
     for (uint32_t offset_b = 0; offset_b < queries_batch; offset_b += max_batch_size) {
       uint32_t batch_size = min(max_batch_size, queries_batch - offset_b);

--- a/cpp/src/sparse/cluster/detail/spectral/modularity_maximization.hpp
+++ b/cpp/src/sparse/cluster/detail/spectral/modularity_maximization.hpp
@@ -109,8 +109,8 @@ std::tuple<vertex_t, weight_t, vertex_t> modularity_maximization(
   // notice that at this point the matrix has already been transposed, so we are scaling
   // columns
   auto dataset_view = raft::make_device_matrix_view(eigVecs, nEigVecs, n);
-  raft::linalg::row_normalize(
-    handle, raft::make_const_mdspan(dataset_view), dataset_view, raft::linalg::L2Norm);
+  raft::linalg::row_normalize<raft::linalg::L2Norm>(
+    handle, raft::make_const_mdspan(dataset_view), dataset_view);
 
   // Find partition clustering
   auto pair_cluster = cluster_solver.solve(handle, n, nEigVecs, eigVecs, clusters);

--- a/cpp/src/sparse/neighbors/detail/cross_component_nn.cuh
+++ b/cpp/src/sparse/neighbors/detail/cross_component_nn.cuh
@@ -249,8 +249,8 @@ void perform_1nn(raft::resources const& handle,
     colors_group_idxs.data_handle() + 1, n_components);
 
   auto x_norm = raft::make_device_vector<value_t, value_idx>(handle, (value_idx)n_rows);
-  raft::linalg::rowNorm(
-    x_norm.data_handle(), X, n_cols, n_rows, raft::linalg::L2Norm, true, stream);
+  raft::linalg::rowNorm<raft::linalg::L2Norm, true>(
+    x_norm.data_handle(), X, n_cols, n_rows, stream);
 
   auto adj     = raft::make_device_matrix<bool, value_idx>(handle, row_batch_size, n_components);
   using OutT   = raft::KeyValuePair<value_idx, value_t>;

--- a/cpp/src/stats/detail/batched/silhouette_score.cuh
+++ b/cpp/src/stats/detail/batched/silhouette_score.cuh
@@ -259,14 +259,12 @@ value_t silhouette_score(
 
   // calculating row-wise minimum in b
   // this prim only supports int indices for now
-  raft::linalg::reduce<value_t, value_t, value_idx, raft::identity_op, raft::min_op>(
+  raft::linalg::reduce<true, true, value_t, value_t, value_idx, raft::identity_op, raft::min_op>(
     b_ptr,
     b_ptr,
     n_labels,
     n_rows,
     std::numeric_limits<value_t>::max(),
-    true,
-    true,
     stream,
     false,
     raft::identity_op(),

--- a/cpp/src/stats/detail/silhouette_score.cuh
+++ b/cpp/src/stats/detail/silhouette_score.cuh
@@ -286,14 +286,12 @@ DataT silhouette_score(
                                stream);
 
   // calculating row-wise minimum
-  raft::linalg::reduce<DataT, DataT, int, raft::identity_op, raft::min_op>(
+  raft::linalg::reduce<true, true, DataT, DataT, int, raft::identity_op, raft::min_op>(
     d_bArray.data(),
     averageDistanceBetweenSampleAndCluster.data(),
     nLabels,
     nRows,
     std::numeric_limits<DataT>::max(),
-    true,
-    true,
     stream,
     false,
     raft::identity_op{},

--- a/cpp/tests/distance/masked_nn.cu
+++ b/cpp/tests/distance/masked_nn.cu
@@ -251,16 +251,10 @@ auto run_masked_nn(const raft::handle_t& handle, Inputs<DataT> inp, const Params
   auto x_norm = raft::make_device_vector<DataT, int>(handle, p.m);
   auto y_norm = raft::make_device_vector<DataT, int>(handle, p.n);
 
-  raft::linalg::norm(handle,
-                     std::as_const(inp.x).view(),
-                     x_norm.view(),
-                     raft::linalg::L2Norm,
-                     raft::linalg::Apply::ALONG_ROWS);
-  raft::linalg::norm(handle,
-                     std::as_const(inp.y).view(),
-                     y_norm.view(),
-                     raft::linalg::L2Norm,
-                     raft::linalg::Apply::ALONG_ROWS);
+  raft::linalg::norm<raft::linalg::L2Norm, raft::Apply::ALONG_ROWS>(
+    handle, std::as_const(inp.x).view(), x_norm.view());
+  raft::linalg::norm<raft::linalg::L2Norm, raft::Apply::ALONG_ROWS>(
+    handle, std::as_const(inp.y).view(), y_norm.view());
 
   // Create parameters for masked_l2_nn
   using IdxT       = int;

--- a/cpp/tests/neighbors/ann_cagra.cuh
+++ b/cpp/tests/neighbors/ann_cagra.cuh
@@ -201,8 +201,8 @@ void InitDataset(const raft::resources& handle,
 
     if (metric == InnerProduct) {
       auto dataset_view = raft::make_device_matrix_view(datatset_ptr, size, dim);
-      raft::linalg::row_normalize(
-        handle, raft::make_const_mdspan(dataset_view), dataset_view, raft::linalg::L2Norm);
+      raft::linalg::row_normalize<raft::linalg::L2Norm>(
+        handle, raft::make_const_mdspan(dataset_view), dataset_view);
     }
   } else if constexpr (std::is_same_v<DataT, std::uint8_t> || std::is_same_v<DataT, std::int8_t>) {
     if constexpr (std::is_same_v<DataT, std::int8_t>) {
@@ -221,24 +221,22 @@ void InitDataset(const raft::resources& handle,
       const auto normalized_norm =
         (std::is_same_v<DataT, std::uint8_t> ? 40 : 20) * std::sqrt(static_cast<ComputeT>(dim));
 
-      raft::linalg::reduce(dev_row_norm.data_handle(),
-                           datatset_ptr,
-                           dim,
-                           size,
-                           0.f,
-                           true,
-                           true,
-                           raft::resource::get_cuda_stream(handle),
-                           false,
-                           raft::sq_op(),
-                           raft::add_op(),
-                           raft::sqrt_op());
+      raft::linalg::reduce<true, true>(dev_row_norm.data_handle(),
+                                       datatset_ptr,
+                                       dim,
+                                       size,
+                                       0.f,
+                                       raft::resource::get_cuda_stream(handle),
+                                       false,
+                                       raft::sq_op(),
+                                       raft::add_op(),
+                                       raft::sqrt_op());
       raft::linalg::matrix_vector_op(
         handle,
         raft::make_const_mdspan(dataset_view),
         raft::make_const_mdspan(dev_row_norm.view()),
         dataset_view,
-        raft::linalg::Apply::ALONG_COLUMNS,
+        raft::Apply::ALONG_COLUMNS,
         [normalized_norm] __device__(DataT elm, ComputeT norm) {
           const ComputeT v           = elm / norm * normalized_norm;
           const ComputeT max_v_range = std::numeric_limits<DataT>::max();

--- a/cpp/tests/neighbors/ann_ivf_flat.cuh
+++ b/cpp/tests/neighbors/ann_ivf_flat.cuh
@@ -239,8 +239,8 @@ class AnnIVFFlatTest : public ::testing::TestWithParam<AnnIvfFlatInputs<IdxT>> {
                                                                     cluster_data.data(),
                                                                     (IdxT)ps.dim,
                                                                     stream_);
-            raft::stats::mean<float, uint32_t>(
-              centroid.data(), cluster_data.data(), ps.dim, list_sizes[l], false, true, stream_);
+            raft::stats::mean<true, float, uint32_t>(
+              centroid.data(), cluster_data.data(), ps.dim, list_sizes[l], false, stream_);
             ASSERT_TRUE(cuvs::devArrMatch(index_2.centers().data_handle() + ps.dim * l,
                                           centroid.data(),
                                           ps.dim,

--- a/cpp/tests/preprocessing/scalar_quantization.cu
+++ b/cpp/tests/preprocessing/scalar_quantization.cu
@@ -78,14 +78,13 @@ class QuantizationTest : public ::testing::TestWithParam<QuantizationInputs<T>> 
     RAFT_CUDA_TRY(cudaMemsetAsync(mu.data(), 0, sizeof(double), stream));
 
     rmm::device_uvector<double> error_stddev(1, stream);
-    raft::stats::stddev(error_stddev.data(),
-                        relative_error.data(),
-                        mu.data(),
-                        1,
-                        elements_to_consider,
-                        false,
-                        true,
-                        stream);
+    raft::stats::stddev<true>(error_stddev.data(),
+                              relative_error.data(),
+                              mu.data(),
+                              1,
+                              elements_to_consider,
+                              false,
+                              stream);
 
     double error_stddev_h;
     raft::update_host(&error_stddev_h, error_stddev.data(), 1, stream);


### PR DESCRIPTION
Depends on https://github.com/rapidsai/raft/pull/2679 with reference issue https://github.com/rapidsai/raft/issues/2681.