### PR TITLE
batch_load_iterator shall copy data located in host memory

### DIFF
--- a/cpp/src/neighbors/detail/ann_utils.cuh
+++ b/cpp/src/neighbors/detail/ann_utils.cuh
@@ -470,8 +470,8 @@ struct batch_load_iterator {
 
       if (dev_ptr_ == nullptr) { needs_copy_ = true; }
       if (attr.type != cudaMemoryTypeDevice) {
-        // Data is available in host memory. Although it might be accessible through UVM,
-        // it is preferred to copy the dataset explicitly.
+        // Although data might be accessible on device through HMM or ATS,
+        // it is preferred to copy the dataset explicitly when it is not device data.
         needs_copy_ = true;
       }
       if (needs_copy_) {

--- a/cpp/src/neighbors/detail/ann_utils.cuh
+++ b/cpp/src/neighbors/detail/ann_utils.cuh
@@ -469,7 +469,7 @@ struct batch_load_iterator {
       dev_ptr_ = reinterpret_cast<T*>(attr.devicePointer);
 
       if (dev_ptr_ == nullptr) { needs_copy_ = true; }
-      if (attr.hostPointer != nullptr) {
+      if (attr.type != cudaMemoryTypeDevice) {
         // Data is available in host memory. Although it might be accessible through UVM,
         // it is preferred to copy the dataset explicitly.
         needs_copy_ = true;


### PR DESCRIPTION
This PR changes the `batch_load_iterator` helper to copy the data explicitly if it is host accessible.

Previously, if the data was both host and device accessible, then there was no explicit copy done by `batch_load_iterator`, since we could access the data directly on the GPU.

In practice, the datasets handled by `batch_load_iterator` are expected to be large, and in that case relying on automatic page migration to access the data is not as efficient as the explicit copy facilitated by `batch_load_iterator`. This PR enables the explicit copy op by `batch_load_iterator` in this case.
