### PR TITLE
IVF-PQ tests: fix segfault when accessing empty lists

### DIFF
--- a/cpp/tests/neighbors/ann_ivf_pq.cuh
+++ b/cpp/tests/neighbors/ann_ivf_pq.cuh
@@ -318,7 +318,7 @@ class ivf_pq_test : public ::testing::TestWithParam<ivf_pq_inputs> {
     auto old_list = index->lists()[label];
     // If the data is unbalanced the list might be empty, which is actually nullptr
     if (!old_list) { return; }
-    auto n_rows   = old_list->size.load();
+    auto n_rows = old_list->size.load();
     if (n_rows == 0) { return; }
     if (index->metric() == cuvs::distance::DistanceType::CosineExpanded) { return; }
 
@@ -354,7 +354,7 @@ class ivf_pq_test : public ::testing::TestWithParam<ivf_pq_inputs> {
     auto old_list = index->lists()[label];
     // If the data is unbalanced the list might be empty, which is actually nullptr
     if (!old_list) { return; }
-    auto n_rows   = old_list->size.load();
+    auto n_rows = old_list->size.load();
 
     if (n_rows == 0) { return; }
 


### PR DESCRIPTION
Check if the `index.lists()[label]` is not an empty shared pointer before accessing its content in tests.

This is a follow-up on https://github.com/rapidsai/cuvs/pull/838, in which I fixed this problem in one place, but not in two others in the same file.