### PR TITLE
Fix the launch bounds for nn-descent kernel for __CUDA_ARCH__ 1210

### DIFF
--- a/cpp/src/neighbors/detail/nn_descent.cuh
+++ b/cpp/src/neighbors/detail/nn_descent.cuh
@@ -492,7 +492,7 @@ template <typename Index_t, typename ID_t = InternalID_t<Index_t>>
 RAFT_KERNEL
 #ifdef __CUDA_ARCH__
 #if (__CUDA_ARCH__) == 750 || ((__CUDA_ARCH__) >= 860 && (__CUDA_ARCH__) <= 890) || \
-  (__CUDA_ARCH__) == 1200
+  (__CUDA_ARCH__) == 1200 || (__CUDA_ARCH__) == 1210
 __launch_bounds__(BLOCK_SIZE)
 #else
 __launch_bounds__(BLOCK_SIZE, 4)


### PR DESCRIPTION
A fix to make cuVS build for a target architecture 1210