### PR TITLE
Fix for recent NCCL resource update

### DIFF
--- a/cpp/src/neighbors/mg/snmg.cuh
+++ b/cpp/src/neighbors/mg/snmg.cuh
@@ -97,6 +97,10 @@ void build(const raft::resources& clique,
            const cuvs::neighbors::index_params* index_params,
            raft::host_matrix_view<const T, int64_t, row_major> index_dataset)
 {
+  // Making sure that the NCCL comms are instantiated at this stage.
+  // This prevents it being done inside of an OpenMP thread.
+  raft::resource::get_nccl_comms(clique);
+
   if (index.mode_ == REPLICATED) {
     int64_t n_rows = index_dataset.extent(0);
     RAFT_LOG_DEBUG("REPLICATED BUILD: %d*%drows", index.num_ranks_, n_rows);

--- a/cpp/src/neighbors/mg/snmg.cuh
+++ b/cpp/src/neighbors/mg/snmg.cuh
@@ -97,10 +97,6 @@ void build(const raft::resources& clique,
            const cuvs::neighbors::index_params* index_params,
            raft::host_matrix_view<const T, int64_t, row_major> index_dataset)
 {
-  // Making sure that the NCCL comms are instantiated at this stage.
-  // This prevents it being done inside of an OpenMP thread.
-  raft::resource::get_nccl_comms(clique);
-
   if (index.mode_ == REPLICATED) {
     int64_t n_rows = index_dataset.extent(0);
     RAFT_LOG_DEBUG("REPLICATED BUILD: %d*%drows", index.num_ranks_, n_rows);
@@ -487,6 +483,10 @@ void search(const raft::resources& clique,
             raft::host_matrix_view<IdxT, int64_t, row_major> neighbors,
             raft::host_matrix_view<float, int64_t, row_major> distances)
 {
+  // Making sure that the NCCL comms are instantiated at this stage.
+  // This prevents it being done inside of an OpenMP thread.
+  raft::resource::get_nccl_comms(clique);
+
   int64_t n_rows      = queries.extent(0);
   int64_t n_cols      = queries.extent(1);
   int64_t n_neighbors = neighbors.extent(1);


### PR DESCRIPTION
The `device_resources_snmg` utility was previously responsible for [initializing NCCL communicators during construction](https://github.com/jinsolp/raft/blob/fbdec327eca8b434fda4eb36df1b115a01dca4d3/cpp/include/raft/core/device_resources_snmg.hpp#L80). However, with the recent decoupling of multi-GPU resource management from NCCL usage, the communicators are now initialized lazily. As a result, SNMG ANN may trigger NCCL initialization during the search phase inside an OpenMP thread which can lead to the NCCL clique being invalid across threads.

This PR ensures that the NCCL clique is initialized ahead of time, before entering any OpenMP thread, thereby avoiding thread-local initialization issues and ensuring global validity of the communicator group.