### PR TITLE
[java] Copy `pom.xml` to `target/` on build

### DIFF
--- a/java/build.sh
+++ b/java/build.sh
@@ -39,4 +39,4 @@ export LD_LIBRARY_PATH=${CURDIR}/../cpp/build:${LD_LIBRARY_PATH}
 cd cuvs-java
 mvn verify "${MAVEN_VERIFY_ARGS[@]}" \
   && mvn install:install-file -Dfile=./target/cuvs-java-$VERSION-jar-with-dependencies.jar -DgroupId=$GROUP_ID -DartifactId=cuvs-java -Dversion=$VERSION -Dpackaging=jar \
-  && cp pom.xml ./target/	
+  && cp pom.xml ./target/

--- a/java/build.sh
+++ b/java/build.sh
@@ -38,4 +38,5 @@ fi
 export LD_LIBRARY_PATH=${CURDIR}/../cpp/build:${LD_LIBRARY_PATH}
 cd cuvs-java
 mvn verify "${MAVEN_VERIFY_ARGS[@]}" \
-  && mvn install:install-file -Dfile=./target/cuvs-java-$VERSION-jar-with-dependencies.jar -DgroupId=$GROUP_ID -DartifactId=cuvs-java -Dversion=$VERSION -Dpackaging=jar
+  && mvn install:install-file -Dfile=./target/cuvs-java-$VERSION-jar-with-dependencies.jar -DgroupId=$GROUP_ID -DartifactId=cuvs-java -Dversion=$VERSION -Dpackaging=jar \
+  && cp pom.xml ./target/	


### PR DESCRIPTION
Fixes #978.

This commit modifies the `java/build.sh` script to also copy the `pom.xml` to the `target/` directory.  This will allow all artifacts for publication to Maven (i.e. all the jars and the pom) to be fetched from a single location.
