### PR TITLE
Fix rust publishing step

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
               - id: check-json
               - id: trailing-whitespace
               - id: end-of-file-fixer
+              - id: check-symlinks
       - repo: https://github.com/PyCQA/isort
         rev: 5.12.0
         hooks:

--- a/java/internal/rapids_config.cmake
+++ b/java/internal/rapids_config.cmake
@@ -1,1 +1,1 @@
-../../rapids_config.cmake
+../../cmake/rapids_config.cmake

--- a/rust/cuvs-sys/rapids_config.cmake
+++ b/rust/cuvs-sys/rapids_config.cmake
@@ -1,1 +1,1 @@
-../../rapids_config.cmake
+../../cmake/rapids_config.cmake


### PR DESCRIPTION
In https://github.com/rapidsai/cuvs/pull/816 we started to vendor rapids_config.cmake - but this broke the symlinks that rust/java use to build.

Fix the symlinks to point to the new location, and add a precommit hook to check that symlinks are valid to prevent this from happening in the future

