### PR TITLE
[REVIEW][Java] Add jextract artifacts to gitignore

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -3,5 +3,7 @@
 /cuvs-java/bin/
 /cuvs-java/src/main/java22/com/nvidia/cuvs/internal/panama/
 /cuvs-java/*.cag
+jextract-22/
+openjdk-22-jextract*
 # examples
 /examples/target/


### PR DESCRIPTION
The build process for Java uses `jextract` to generate panama bindings. Jextract is downloaded from the JDK website.
This PR excludes the downloaded Jextract archive and the Jextract files from the repository by adding them to `.gitignore`