### PR TITLE
Fix verify-copyright precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,7 @@ repos:
             exclude: |
               (?x)
                   docs/source/sphinxext/github_link\.py|
-                  cpp/cmake/modules/FindAVX\.cmake|
+                  cpp/cmake/modules/FindAVX\.cmake
           - id: verify-alpha-spec
           - id: verify-codeowners
             args: [--fix, --project-prefix=cuvs]


### PR DESCRIPTION
The verify-copyright precommit hook was excluding all files, because of an incorrect regex in the exclude leading to match all files. Fix

