### PR TITLE
Remove nvidia and dask channels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,7 +120,7 @@ repos:
           - id: verify-codeowners
             args: [--fix, --project-prefix=cuvs]
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.18.1
+        rev: v1.19.0
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -259,7 +259,6 @@ dependencies:
         matrices:
           - matrix: {cuda: "12.*"}
             packages: [cuda-nvcc]
-
   rapids_build_setuptools:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -267,7 +266,6 @@ dependencies:
           - &rapids_build_backend rapids-build-backend>=0.3.0,<0.4.0.dev0
           - setuptools
           - wheel
-
   build_py_cuvs:
     common:
       - output_types: [conda]
@@ -356,7 +354,6 @@ dependencies:
               - nvidia-curand
               - nvidia-cusolver
               - nvidia-cusparse
-
   depends_on_cupy:
     common:
       - output_types: conda
@@ -369,7 +366,6 @@ dependencies:
             packages:
               - cupy-cuda12x>=12.0.0
           - {matrix: null, packages: [cupy-cuda12x>=12.0.0]}
-
   test_libcuvs:
     common:
       - output_types: [conda]
@@ -390,7 +386,7 @@ dependencies:
           - sphinx-copybutton
           - sphinx-markdown-tables
           - pip:
-            - nvidia-sphinx-theme
+              - nvidia-sphinx-theme
   rust:
     common:
       - output_types: [conda]


### PR DESCRIPTION
Now that we have dropped support for CUDA 11 we no longer require the nvidia channel.
With the changes in https://github.com/rapidsai/rapids-dask-dependency/pull/85, RAPIDS now only uses released versions of dask, so we no longer need the dask channel either.
Contributes to https://github.com/rapidsai/build-planning/issues/184
