### PR TITLE
`ReachabilityPostProcess` distance epilogue for NN Descent

### DIFF
--- a/cpp/src/neighbors/detail/nn_descent.cuh
+++ b/cpp/src/neighbors/detail/nn_descent.cuh
@@ -488,7 +488,7 @@ __device__ __forceinline__ void remove_duplicates(
 // MAX_RESIDENT_THREAD_PER_SM = BLOCK_SIZE * BLOCKS_PER_SM = 2048
 // For architectures 750 and 860 (890), the values for MAX_RESIDENT_THREAD_PER_SM
 // is 1024 and 1536 respectively, which means the bounds don't work anymore
-template <typename Index_t, typename ID_t = InternalID_t<Index_t>>
+template <typename Index_t, typename ID_t = InternalID_t<Index_t>, typename DistEpilogue_t>
 RAFT_KERNEL
 #ifdef __CUDA_ARCH__
 // Use minBlocksPerMultiprocessor = 4 on specific arches
@@ -513,7 +513,8 @@ __launch_bounds__(BLOCK_SIZE)
                     int graph_width,
                     int* locks,
                     DistData_t* l2_norms,
-                    cuvs::distance::DistanceType metric)
+                    cuvs::distance::DistanceType metric,
+                    DistEpilogue_t dist_epilogue)
 {
 #if (__CUDA_ARCH__ >= 700)
   using namespace nvcuda;
@@ -623,20 +624,22 @@ __launch_bounds__(BLOCK_SIZE)
   __syncthreads();
 
   for (int i = threadIdx.x; i < MAX_NUM_BI_SAMPLES * SKEWED_MAX_NUM_BI_SAMPLES; i += blockDim.x) {
-    if (i % SKEWED_MAX_NUM_BI_SAMPLES < list_new_size &&
-        i / SKEWED_MAX_NUM_BI_SAMPLES < list_new_size) {
+    int row_id = i % SKEWED_MAX_NUM_BI_SAMPLES;
+    int col_id = i / SKEWED_MAX_NUM_BI_SAMPLES;
+
+    if (row_id < list_new_size && col_id < list_new_size) {
       if (metric == cuvs::distance::DistanceType::InnerProduct) {
         s_distances[i] = -s_distances[i];
       } else if (metric == cuvs::distance::DistanceType::CosineExpanded) {
         s_distances[i] = 1.0 - s_distances[i];
       } else {  // L2Expanded or L2SqrtExpanded
-        s_distances[i] = l2_norms[new_neighbors[i % SKEWED_MAX_NUM_BI_SAMPLES]] +
-                         l2_norms[new_neighbors[i / SKEWED_MAX_NUM_BI_SAMPLES]] -
-                         2.0 * s_distances[i];
+        s_distances[i] =
+          l2_norms[new_neighbors[row_id]] + l2_norms[new_neighbors[col_id]] - 2.0 * s_distances[i];
         // for fp32 vs fp16 precision differences resulting in negative distances when distance
         // should be 0 related issue: https://github.com/rapidsai/cuvs/issues/991
         s_distances[i] = s_distances[i] < 0.0f ? 0.0f : s_distances[i];
       }
+      s_distances[i] = dist_epilogue(s_distances[i], new_neighbors[row_id], new_neighbors[col_id]);
     } else {
       s_distances[i] = std::numeric_limits<float>::max();
     }
@@ -707,20 +710,21 @@ __launch_bounds__(BLOCK_SIZE)
   __syncthreads();
 
   for (int i = threadIdx.x; i < MAX_NUM_BI_SAMPLES * SKEWED_MAX_NUM_BI_SAMPLES; i += blockDim.x) {
-    if (i % SKEWED_MAX_NUM_BI_SAMPLES < list_old_size &&
-        i / SKEWED_MAX_NUM_BI_SAMPLES < list_new_size) {
+    int row_id = i % SKEWED_MAX_NUM_BI_SAMPLES;
+    int col_id = i / SKEWED_MAX_NUM_BI_SAMPLES;
+    if (row_id < list_old_size && col_id < list_new_size) {
       if (metric == cuvs::distance::DistanceType::InnerProduct) {
         s_distances[i] = -s_distances[i];
       } else if (metric == cuvs::distance::DistanceType::CosineExpanded) {
         s_distances[i] = 1.0 - s_distances[i];
       } else {  // L2Expanded or L2SqrtExpanded
-        s_distances[i] = l2_norms[old_neighbors[i % SKEWED_MAX_NUM_BI_SAMPLES]] +
-                         l2_norms[new_neighbors[i / SKEWED_MAX_NUM_BI_SAMPLES]] -
-                         2.0 * s_distances[i];
+        s_distances[i] =
+          l2_norms[old_neighbors[row_id]] + l2_norms[new_neighbors[col_id]] - 2.0 * s_distances[i];
         // for fp32 vs fp16 precision differences resulting in negative distances when distance
         // should be 0 related issue: https://github.com/rapidsai/cuvs/issues/991
         s_distances[i] = s_distances[i] < 0.0f ? 0.0f : s_distances[i];
       }
+      s_distances[i] = dist_epilogue(s_distances[i], old_neighbors[row_id], new_neighbors[col_id]);
     } else {
       s_distances[i] = std::numeric_limits<float>::max();
     }
@@ -1034,7 +1038,8 @@ void GNND<Data_t, Index_t>::add_reverse_edges(Index_t* graph_ptr,
 }
 
 template <typename Data_t, typename Index_t>
-void GNND<Data_t, Index_t>::local_join(cudaStream_t stream)
+template <typename DistEpilogue_t>
+void GNND<Data_t, Index_t>::local_join(cudaStream_t stream, DistEpilogue_t dist_epilogue)
 {
   raft::matrix::fill(res, dists_buffer_.view(), std::numeric_limits<float>::max());
   local_join_kernel<<<nrow_, BLOCK_SIZE, 0, stream>>>(graph_.h_graph_new.data_handle(),
@@ -1051,15 +1056,18 @@ void GNND<Data_t, Index_t>::local_join(cudaStream_t stream)
                                                       DEGREE_ON_DEVICE,
                                                       d_locks_.data_handle(),
                                                       l2_norms_.data_handle(),
-                                                      build_config_.metric);
+                                                      build_config_.metric,
+                                                      dist_epilogue);
 }
 
 template <typename Data_t, typename Index_t>
+template <typename DistEpilogue_t>
 void GNND<Data_t, Index_t>::build(Data_t* data,
                                   const Index_t nrow,
                                   Index_t* output_graph,
                                   bool return_distances,
-                                  DistData_t* output_distances)
+                                  DistData_t* output_distances,
+                                  DistEpilogue_t dist_epilogue)
 {
   using input_t = typename std::remove_const<Data_t>::type;
 
@@ -1154,7 +1162,7 @@ void GNND<Data_t, Index_t>::build(Data_t* data,
       raft::util::arch::SM_range(raft::util::arch::SM_70(), raft::util::arch::SM_future());
 
     if (wmma_range.contains(runtime_arch)) {
-      local_join(stream);
+      local_join(stream, dist_epilogue);
     } else {
       THROW("NN_DESCENT cannot be run for __CUDA_ARCH__ < 700");
     }

--- a/cpp/src/neighbors/detail/nn_descent_gnnd.hpp
+++ b/cpp/src/neighbors/detail/nn_descent_gnnd.hpp
@@ -207,11 +207,13 @@ class GNND {
   GNND(const GNND&)            = delete;
   GNND& operator=(const GNND&) = delete;
 
+  template <typename DistEpilogue_t = raft::identity_op>
   void build(Data_t* data,
              const Index_t nrow,
              Index_t* output_graph,
              bool return_distances,
-             DistData_t* output_distances);
+             DistData_t* output_distances,
+             DistEpilogue_t dist_epilogue = DistEpilogue_t{});
   ~GNND()    = default;
   using ID_t = InternalID_t<Index_t>;
   void reset(raft::resources const& res);
@@ -222,7 +224,9 @@ class GNND {
                          Index_t* d_rev_graph_ptr,
                          int2* list_sizes,
                          cudaStream_t stream = 0);
-  void local_join(cudaStream_t stream = 0);
+
+  template <typename DistEpilogue_t = raft::identity_op>
+  void local_join(cudaStream_t stream = 0, DistEpilogue_t dist_epilogue = DistEpilogue_t{});
 
   raft::resources const& res;
 

--- a/cpp/src/neighbors/detail/reachability.cuh
+++ b/cpp/src/neighbors/detail/reachability.cuh
@@ -34,7 +34,6 @@
 
 namespace cuvs::neighbors::detail::reachability {
 
-using namespace cuvs::neighbors;
 /**
  * Extract core distances from KNN graph. This is essentially
  * performing a knn_dists[:,min_pts]

--- a/cpp/src/neighbors/detail/reachability_types.cuh
+++ b/cpp/src/neighbors/detail/reachability_types.cuh
@@ -31,7 +31,7 @@ struct ReachabilityPostProcess {
 
   const value_t* core_dists;
   value_t alpha;
-  size_t n;  // total number of elements
+  size_t n;  // size of core_dists array
 };
 
 }  // namespace cuvs::neighbors::detail::reachability

--- a/cpp/src/neighbors/detail/reachability_types.cuh
+++ b/cpp/src/neighbors/detail/reachability_types.cuh
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <raft/core/detail/macros.hpp>
+#include <raft/matrix/shift.cuh>
+#include <rmm/exec_policy.hpp>
+
+namespace cuvs::neighbors::detail::reachability {
+
+//  Functor to post-process distances into reachability space
+template <typename value_idx, typename value_t>
+struct ReachabilityPostProcess {
+  RAFT_DEVICE_INLINE_FUNCTION value_t operator()(value_t value, value_idx row, value_idx col) const
+  {
+    return max(core_dists[col], max(core_dists[row], alpha * value));
+  }
+
+  const value_t* core_dists;
+  value_t alpha;
+  size_t n;  // total number of elements
+};
+
+}  // namespace cuvs::neighbors::detail::reachability

--- a/cpp/src/neighbors/nn_descent_float.cu
+++ b/cpp/src/neighbors/nn_descent_float.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "./detail/nn_descent_gnnd.hpp"
+#include "./detail/reachability_types.cuh"
 #include "nn_descent.cuh"
 #include <cuvs/neighbors/nn_descent.hpp>
 
@@ -54,7 +56,30 @@ namespace cuvs::neighbors::nn_descent {
       return idx;                                                                             \
     }                                                                                         \
   };                                                                                          \
-  template class detail::GNND<const T, int>;
+  template class detail::GNND<const T, int>;                                                  \
+                                                                                              \
+  template void detail::GNND<const T, int>::build<                                            \
+    cuvs::neighbors::detail::reachability::ReachabilityPostProcess<int, T>>(                  \
+    const T* data,                                                                            \
+    const int nrow,                                                                           \
+    int* output_graph,                                                                        \
+    bool return_distances,                                                                    \
+    float* output_distances,                                                                  \
+    cuvs::neighbors::detail::reachability::ReachabilityPostProcess<int, T> dist_epilogue);    \
+  template void detail::GNND<const T, int>::local_join<                                       \
+    cuvs::neighbors::detail::reachability::ReachabilityPostProcess<int, T>>(                  \
+    cudaStream_t stream,                                                                      \
+    cuvs::neighbors::detail::reachability::ReachabilityPostProcess<int, T> dist_epilogue);    \
+                                                                                              \
+  template void detail::GNND<const T, int>::build<raft::identity_op>(                         \
+    const T* data,                                                                            \
+    const int nrow,                                                                           \
+    int* output_graph,                                                                        \
+    bool return_distances,                                                                    \
+    float* output_distances,                                                                  \
+    raft::identity_op dist_epilogue);                                                         \
+  template void detail::GNND<const T, int>::local_join<raft::identity_op>(                    \
+    cudaStream_t stream, raft::identity_op dist_epilogue);
 
 CUVS_INST_NN_DESCENT_BUILD(float, uint32_t);
 

--- a/cpp/tests/neighbors/ann_nn_descent.cuh
+++ b/cpp/tests/neighbors/ann_nn_descent.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,18 @@
  */
 #pragma once
 
+#include "../../src/neighbors/detail/knn_brute_force.cuh"
+#include "../../src/neighbors/detail/nn_descent_gnnd.hpp"
+#include "../../src/neighbors/detail/reachability.cuh"
 #include "../test_utils.cuh"
 #include "ann_utils.cuh"
-
+#include "naive_knn.cuh"
 #include <cuvs/distance/distance.hpp>
 #include <cuvs/neighbors/nn_descent.hpp>
-
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/util/cudart_utils.hpp>
 #include <raft/util/itertools.hpp>
 #include <rmm/device_uvector.hpp>
-
-#include "naive_knn.cuh"
-#include <cuvs/distance/distance.hpp>
 
 #include <gtest/gtest.h>
 
@@ -193,6 +192,165 @@ class AnnNNDescentTest : public ::testing::TestWithParam<AnnNNDescentInputs> {
 };
 
 template <typename DistanceT, typename DataT, typename IdxT>
+class AnnNNDescentDIstEpiTest : public ::testing::TestWithParam<AnnNNDescentInputs> {
+ public:
+  AnnNNDescentDIstEpiTest()
+    : stream_(raft::resource::get_cuda_stream(handle_)),
+      ps(::testing::TestWithParam<AnnNNDescentInputs>::GetParam()),
+      database(0, stream_)
+  {
+  }
+
+ protected:
+  void testNNDescent()
+  {
+    size_t queries_size = ps.n_rows * ps.graph_degree;
+    std::vector<IdxT> indices_NNDescent(queries_size);
+    std::vector<DistanceT> distances_NNDescent(queries_size);
+    std::vector<IdxT> indices_naive(queries_size);
+    std::vector<DistanceT> distances_naive(queries_size);
+
+    {
+      rmm::device_uvector<DistanceT> distances_naive_dev(queries_size, stream_);
+      rmm::device_uvector<IdxT> indices_naive_dev(queries_size, stream_);
+      naive_knn<DistanceT, DataT, IdxT>(handle_,
+                                        distances_naive_dev.data(),
+                                        indices_naive_dev.data(),
+                                        database.data(),
+                                        database.data(),
+                                        ps.n_rows,
+                                        ps.n_rows,
+                                        ps.dim,
+                                        ps.graph_degree,
+                                        ps.metric);
+      rmm::device_uvector<DistanceT> core_dists_dev(ps.n_rows, stream_);
+
+      cuvs::neighbors::detail::reachability::core_distances<IdxT, DistanceT>(
+        distances_naive_dev.data(),
+        ps.graph_degree,
+        ps.graph_degree,
+        ps.n_rows,
+        core_dists_dev.data(),
+        stream_);
+      auto epilogue =
+        cuvs::neighbors::detail::reachability::ReachabilityPostProcess<IdxT, DistanceT>{
+          core_dists_dev.data(), 1.0, static_cast<size_t>(ps.n_rows)};
+
+      cuvs::neighbors::detail::tiled_brute_force_knn<
+        DataT,
+        IdxT,
+        DistanceT,
+        cuvs::neighbors::detail::reachability::ReachabilityPostProcess<IdxT, DistanceT>>(
+        handle_,
+        database.data(),
+        database.data(),
+        ps.n_rows,
+        ps.n_rows,
+        ps.dim,
+        ps.graph_degree,
+        distances_naive_dev.data(),
+        indices_naive_dev.data(),
+        ps.metric,
+        2.0,
+        0,
+        0,
+        nullptr,
+        nullptr,
+        nullptr,
+        epilogue);
+      raft::update_host(indices_naive.data(), indices_naive_dev.data(), queries_size, stream_);
+      raft::update_host(distances_naive.data(), distances_naive_dev.data(), queries_size, stream_);
+      raft::resource::sync_stream(handle_);
+    }
+    {
+      nn_descent::index_params index_params;
+      index_params.metric                    = ps.metric;
+      index_params.graph_degree              = ps.graph_degree;
+      index_params.intermediate_graph_degree = 2 * ps.graph_degree;
+      index_params.max_iterations            = 100;
+      index_params.return_distances          = true;
+
+      auto database_host = raft::make_host_matrix<DataT, int64_t>(ps.n_rows, ps.dim);
+      raft::copy(database_host.data_handle(), database.data(), database.size(), stream_);
+      raft::resource::sync_stream(handle_);
+      auto database_host_view = raft::make_host_matrix_view<const DataT, int64_t>(
+        (const DataT*)database_host.data_handle(), ps.n_rows, ps.dim);
+      auto index = nn_descent::build(handle_, index_params, database_host_view);
+      // raft::copy(indices_NNDescent.data(), index.graph().data_handle(), queries_size, stream_);
+
+      rmm::device_uvector<DistanceT> core_dists_dev(ps.n_rows, stream_);
+      cuvs::neighbors::detail::reachability::core_distances<IdxT, DistanceT>(
+        index.distances().value().data_handle(),
+        ps.graph_degree,
+        ps.graph_degree,
+        ps.n_rows,
+        core_dists_dev.data(),
+        stream_);
+
+      // getting mutual reachability using nn descent should be done through all_neighbors
+      // API. this is just a simple check that the feature works well before integrating into
+      // all_neighbors API.
+      size_t extended_graph_degree, graph_degree;
+      auto build_config = nn_descent::detail::get_build_config(
+        handle_, index_params, ps.n_rows, ps.dim, ps.metric, extended_graph_degree, graph_degree);
+      auto gnnd      = nn_descent::detail::GNND<const DataT, int>(handle_, build_config);
+      auto int_graph = raft::make_host_matrix<int, IdxT, row_major>(
+        ps.n_rows, static_cast<IdxT>(extended_graph_degree));
+
+      auto dist_epilogue =
+        cuvs::neighbors::detail::reachability::ReachabilityPostProcess<int, DataT>{
+          core_dists_dev.data(), 1.0, static_cast<size_t>(ps.n_rows)};
+      rmm::device_uvector<DistanceT> distances_nnd_dev(queries_size, stream_);
+      gnnd.build(database_host.data_handle(),
+                 static_cast<int>(ps.n_rows),
+                 int_graph.data_handle(),
+                 true,
+                 distances_nnd_dev.data(),
+                 dist_epilogue);
+
+      // copy indices and distances graph
+      for (int i = 0; i < ps.n_rows; i++) {
+        for (int j = 0; j < ps.graph_degree; j++) {
+          indices_NNDescent[i * ps.graph_degree + j] = static_cast<IdxT>(int_graph(i, j));
+        }
+      }
+      raft::copy(distances_NNDescent.data(), distances_nnd_dev.data(), queries_size, stream_);
+      raft::resource::sync_stream(handle_);
+    }
+
+    double min_recall = ps.min_recall;
+    EXPECT_TRUE(eval_neighbours(indices_naive,
+                                indices_NNDescent,
+                                distances_naive,
+                                distances_NNDescent,
+                                ps.n_rows,
+                                ps.graph_degree,
+                                0.001,
+                                min_recall));
+  }
+
+  void SetUp() override
+  {
+    database.resize(((size_t)ps.n_rows) * ps.dim, stream_);
+    raft::random::RngState r(1234ULL);
+    raft::random::normal(handle_, r, database.data(), ps.n_rows * ps.dim, DataT(0.1), DataT(2.0));
+    raft::resource::sync_stream(handle_);
+  }
+
+  void TearDown() override
+  {
+    raft::resource::sync_stream(handle_);
+    database.resize(0, stream_);
+  }
+
+ private:
+  raft::resources handle_;
+  rmm::cuda_stream_view stream_;
+  AnnNNDescentInputs ps;
+  rmm::device_uvector<DataT> database;
+};
+
+template <typename DistanceT, typename DataT, typename IdxT>
 class AnnNNDescentBatchTest : public ::testing::TestWithParam<AnnNNDescentBatchInputs> {
  public:
   AnnNNDescentBatchTest()
@@ -320,6 +478,14 @@ const std::vector<AnnNNDescentInputs> inputs =
                                                       cuvs::distance::DistanceType::InnerProduct,
                                                       cuvs::distance::DistanceType::CosineExpanded},
                                                      {false, true},
+                                                     {0.90});
+
+const std::vector<AnnNNDescentInputs> inputsDistEpilogue =
+  raft::util::itertools::product<AnnNNDescentInputs>({2000, 4000},  // n_rows
+                                                     {64, 1024},    // dim
+                                                     {32, 64},      // graph_degree
+                                                     {cuvs::distance::DistanceType::L2Expanded},
+                                                     {true},  // data on host
                                                      {0.90});
 
 const std::vector<AnnNNDescentBatchInputs> inputsBatch =

--- a/cpp/tests/neighbors/ann_nn_descent.cuh
+++ b/cpp/tests/neighbors/ann_nn_descent.cuh
@@ -21,8 +21,10 @@
 #include "../test_utils.cuh"
 #include "ann_utils.cuh"
 #include "naive_knn.cuh"
+
 #include <cuvs/distance/distance.hpp>
 #include <cuvs/neighbors/nn_descent.hpp>
+
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/util/cudart_utils.hpp>
 #include <raft/util/itertools.hpp>

--- a/cpp/tests/neighbors/ann_nn_descent/test_float_uint32_t.cu
+++ b/cpp/tests/neighbors/ann_nn_descent/test_float_uint32_t.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,16 @@ namespace cuvs::neighbors::nn_descent {
 typedef AnnNNDescentTest<float, float, std::uint32_t> AnnNNDescentTestF_U32;
 TEST_P(AnnNNDescentTestF_U32, AnnNNDescent) { this->testNNDescent(); }
 
+typedef AnnNNDescentDIstEpiTest<float, float, std::uint32_t> AnnNNDescentTestDistEpiF_U32;
+TEST_P(AnnNNDescentTestDistEpiF_U32, AnnNNDescentDistEpi) { this->testNNDescent(); }
+
 typedef AnnNNDescentBatchTest<float, float, std::uint32_t> AnnNNDescentBatchTestF_U32;
 TEST_P(AnnNNDescentBatchTestF_U32, AnnNNDescentBatch) { this->testNNDescentBatch(); }
 
 INSTANTIATE_TEST_CASE_P(AnnNNDescentTest, AnnNNDescentTestF_U32, ::testing::ValuesIn(inputs));
+INSTANTIATE_TEST_CASE_P(AnnNNDescentDistEpi,
+                        AnnNNDescentTestDistEpiF_U32,
+                        ::testing::ValuesIn(inputsDistEpilogue));
 INSTANTIATE_TEST_CASE_P(AnnNNDescentBatchTest,
                         AnnNNDescentBatchTestF_U32,
                         ::testing::ValuesIn(inputsBatch));


### PR DESCRIPTION
NN Descent changed to support distance epilogues. Currently supporting `ReachabilityPostProcess` and `identity_op`. A new distance epilogue will need new instantiations.

Mutual reachability computation will eventually be hidden behind the `all_neighbors` API. Basic tests are still added in this PR to ensure the correctness of this feature.