### PR TITLE
[BUG] Disable flaky cpp test `AnnIVFFlatTestF_half.AnnIVFFlat/21`

### DIFF
--- a/cpp/tests/neighbors/ann_ivf_flat.cuh
+++ b/cpp/tests/neighbors/ann_ivf_flat.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/neighbors/ann_ivf_flat.cuh
+++ b/cpp/tests/neighbors/ann_ivf_flat.cuh
@@ -561,7 +561,7 @@ const std::vector<AnnIvfFlatInputs<int64_t>> inputs = {
   {1000, 10000, 2049, 16, 40, 1024, cuvs::distance::DistanceType::CosineExpanded, false},
   {1000, 10000, 2050, 16, 40, 1024, cuvs::distance::DistanceType::InnerProduct, false},
   {1000, 10000, 2050, 16, 40, 1024, cuvs::distance::DistanceType::CosineExpanded, false},
-  // TODO: Disable flaky test. See https://github.com/rapidsai/cuvs/issues/1091
+  // TODO: Re-enable test after adjusting parameters for higher recall. See https://github.com/rapidsai/cuvs/issues/1091
   // {1000, 10000, 2051, 16, 40, 1024, cuvs::distance::DistanceType::InnerProduct, true},
   {1000, 10000, 2051, 16, 40, 1024, cuvs::distance::DistanceType::CosineExpanded, true},
   {1000, 10000, 2052, 16, 40, 1024, cuvs::distance::DistanceType::InnerProduct, false},

--- a/cpp/tests/neighbors/ann_ivf_flat.cuh
+++ b/cpp/tests/neighbors/ann_ivf_flat.cuh
@@ -561,7 +561,8 @@ const std::vector<AnnIvfFlatInputs<int64_t>> inputs = {
   {1000, 10000, 2049, 16, 40, 1024, cuvs::distance::DistanceType::CosineExpanded, false},
   {1000, 10000, 2050, 16, 40, 1024, cuvs::distance::DistanceType::InnerProduct, false},
   {1000, 10000, 2050, 16, 40, 1024, cuvs::distance::DistanceType::CosineExpanded, false},
-  {1000, 10000, 2051, 16, 40, 1024, cuvs::distance::DistanceType::InnerProduct, true},
+  // TODO: Disable flaky test. See https://github.com/rapidsai/cuvs/issues/1091
+  // {1000, 10000, 2051, 16, 40, 1024, cuvs::distance::DistanceType::InnerProduct, true},
   {1000, 10000, 2051, 16, 40, 1024, cuvs::distance::DistanceType::CosineExpanded, true},
   {1000, 10000, 2052, 16, 40, 1024, cuvs::distance::DistanceType::InnerProduct, false},
   {1000, 10000, 2052, 16, 40, 1024, cuvs::distance::DistanceType::CosineExpanded, false},

--- a/cpp/tests/neighbors/ann_ivf_flat.cuh
+++ b/cpp/tests/neighbors/ann_ivf_flat.cuh
@@ -561,7 +561,8 @@ const std::vector<AnnIvfFlatInputs<int64_t>> inputs = {
   {1000, 10000, 2049, 16, 40, 1024, cuvs::distance::DistanceType::CosineExpanded, false},
   {1000, 10000, 2050, 16, 40, 1024, cuvs::distance::DistanceType::InnerProduct, false},
   {1000, 10000, 2050, 16, 40, 1024, cuvs::distance::DistanceType::CosineExpanded, false},
-  // TODO: Re-enable test after adjusting parameters for higher recall. See https://github.com/rapidsai/cuvs/issues/1091
+  // TODO: Re-enable test after adjusting parameters for higher recall. See
+  // https://github.com/rapidsai/cuvs/issues/1091
   // {1000, 10000, 2051, 16, 40, 1024, cuvs::distance::DistanceType::InnerProduct, true},
   {1000, 10000, 2051, 16, 40, 1024, cuvs::distance::DistanceType::CosineExpanded, true},
   {1000, 10000, 2052, 16, 40, 1024, cuvs::distance::DistanceType::InnerProduct, false},


### PR DESCRIPTION
Disable flaky `AnnIVFFlat` test. See https://github.com/rapidsai/cuvs/issues/1091 for more details.