### PR TITLE
Reduce binary size of refine functions

### DIFF
--- a/cpp/src/neighbors/ivf_flat/ivf_flat_interleaved_scan_ext.cuh
+++ b/cpp/src/neighbors/ivf_flat/ivf_flat_interleaved_scan_ext.cuh
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuvs/neighbors/common.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resources.hpp>
+
+namespace cuvs::neighbors::ivf_flat::detail {
+template <typename T, typename AccT, typename IdxT, typename IvfSampleFilterT>
+void ivfflat_interleaved_scan(const index<T, IdxT>& index,
+                              const T* queries,
+                              const uint32_t* coarse_query_results,
+                              const uint32_t n_queries,
+                              const uint32_t queries_offset,
+                              const cuvs::distance::DistanceType metric,
+                              const uint32_t n_probes,
+                              const uint32_t k,
+                              const uint32_t max_samples,
+                              const uint32_t* chunk_indices,
+                              const bool select_min,
+                              IvfSampleFilterT sample_filter,
+                              uint32_t* neighbors,
+                              float* distances,
+                              uint32_t& grid_dim_x,
+                              rmm::cuda_stream_view stream);
+
+#define CUVS_INST_IVF_FLAT_INTERLEAVED_SCAN(T, IdxT, AccT, SampleFilterT)      \
+  extern template void ivfflat_interleaved_scan<T, AccT, IdxT, SampleFilterT>( \
+    const index<T, IdxT>& index,                                               \
+    const T* queries,                                                          \
+    const uint32_t* coarse_query_results,                                      \
+    const uint32_t n_queries,                                                  \
+    const uint32_t queries_offset,                                             \
+    const cuvs::distance::DistanceType metric,                                 \
+    const uint32_t n_probes,                                                   \
+    const uint32_t k,                                                          \
+    const uint32_t max_samples,                                                \
+    const uint32_t* chunk_indices,                                             \
+    const bool select_min,                                                     \
+    SampleFilterT sample_filter,                                               \
+    uint32_t* neighbors,                                                       \
+    float* distances,                                                          \
+    uint32_t& grid_dim_x,                                                      \
+    rmm::cuda_stream_view stream);
+
+CUVS_INST_IVF_FLAT_INTERLEAVED_SCAN(float,
+                                    int64_t,
+                                    float,
+                                    cuvs::neighbors::filtering::none_sample_filter);
+CUVS_INST_IVF_FLAT_INTERLEAVED_SCAN(half,
+                                    int64_t,
+                                    float,
+                                    cuvs::neighbors::filtering::none_sample_filter);
+
+CUVS_INST_IVF_FLAT_INTERLEAVED_SCAN(int8_t,
+                                    int64_t,
+                                    float,
+                                    cuvs::neighbors::filtering::none_sample_filter);
+CUVS_INST_IVF_FLAT_INTERLEAVED_SCAN(uint8_t,
+                                    int64_t,
+                                    float,
+                                    cuvs::neighbors::filtering::none_sample_filter);
+
+#undef CUVS_INST_IVF_FLAT_INTERLEAVED_SCAN
+
+}  // namespace cuvs::neighbors::ivf_flat::detail

--- a/cpp/src/neighbors/refine/refine_device.cuh
+++ b/cpp/src/neighbors/refine/refine_device.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include "../../core/nvtx.hpp"
 #include "../detail/ann_utils.cuh"
 #include "../ivf_flat/ivf_flat_build.cuh"
-#include "../ivf_flat/ivf_flat_interleaved_scan.cuh"
+#include "../ivf_flat/ivf_flat_interleaved_scan_ext.cuh"
 #include "refine_common.hpp"
 #include <cuvs/neighbors/common.hpp>
 #include <cuvs/neighbors/ivf_flat.hpp>


### PR DESCRIPTION
The refine functions that work with GPU data use IVF-Flat under the hood to perform the refinement operation. This PR adds extern template declarations for `ivfflat_interleaved_scan` and uses these in the refine functions. This way we avoid recompiling the IVF-Flat search kernels, and save binary size.
