### PR TITLE
[Java] Fix POM

### DIFF
--- a/java/build.sh
+++ b/java/build.sh
@@ -40,5 +40,5 @@ fi
 export LD_LIBRARY_PATH=${CURDIR}/../cpp/build:${LD_LIBRARY_PATH}
 cd cuvs-java
 mvn verify "${MAVEN_VERIFY_ARGS[@]}" \
-  && mvn install:install-file -Dfile=./target/cuvs-java-$VERSION-jar-with-dependencies.jar -DgroupId=$GROUP_ID -DartifactId=cuvs-java -Dversion=$VERSION -Dpackaging=jar \
+  && mvn install:install-file -Dfile=./target/cuvs-java-$VERSION.jar -DgroupId=$GROUP_ID -DartifactId=cuvs-java -Dversion=$VERSION -Dpackaging=jar \
   && cp pom.xml ./target/

--- a/java/cuvs-java/pom.xml
+++ b/java/cuvs-java/pom.xml
@@ -155,7 +155,29 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <mergeManifestMode>merge</mergeManifestMode>
+                    <archiverConfig>
+                        <duplicateBehavior>add</duplicateBehavior>
+                    </archiverConfig>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>assemble-all</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/java/cuvs-java/pom.xml
+++ b/java/cuvs-java/pom.xml
@@ -101,13 +101,6 @@
             <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.diffplug.spotless</groupId>
-            <artifactId>spotless-maven-plugin</artifactId>
-            <version>2.44.5</version>
-        </dependency>
-
     </dependencies>
 
     <build>
@@ -162,29 +155,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.4.2</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <mergeManifestMode>merge</mergeManifestMode>
-                    <archiverConfig>
-                        <duplicateBehavior>add</duplicateBehavior>
-                    </archiverConfig>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>assemble-all</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
As reported in https://github.com/rapidsai/cuvs/issues/1090, we are producing a "broken" "jar with dependecies" today: the Jar contains extra files that make it impossible to consume from a modularized application, as it breaks the module definition.

This PR fixes this by:
- removing `spotless` as a dependency: adding it as a dependency is not needed, as spotless is used at build time
- ~~removing the `jar-with-dependency` build task: we don't need it, as we don't have dependencies today. If we have in the future, we can re-introduce it, with a better handling of the merge process~~
- change the build script to install in the local maven repository the "regular" jar produced by the build process

EDIT: after review, we decided to revert the removal of the task creating  `jar-with-dependency`, as we might need it in the future (will need fixing anyway, but we can defer that until we need it).

Closes #1090