### PR TITLE
[Java] Fix CAGRA params allocation

### DIFF
--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/CagraIndexImpl.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/CagraIndexImpl.java
@@ -15,6 +15,7 @@
  */
 package com.nvidia.cuvs.internal;
 
+import static com.nvidia.cuvs.internal.CuVSParamsHelper.*;
 import static com.nvidia.cuvs.internal.common.LinkerHelper.C_FLOAT;
 import static com.nvidia.cuvs.internal.common.LinkerHelper.C_FLOAT_BYTE_SIZE;
 import static com.nvidia.cuvs.internal.common.LinkerHelper.C_INT;
@@ -26,21 +27,7 @@ import static com.nvidia.cuvs.internal.common.Util.checkCuVSError;
 import static com.nvidia.cuvs.internal.common.Util.concatenate;
 import static com.nvidia.cuvs.internal.common.Util.cudaMemcpy;
 import static com.nvidia.cuvs.internal.common.Util.prepareTensor;
-import static com.nvidia.cuvs.internal.panama.headers_h.cudaStream_t;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsCagraBuild;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsCagraDeserialize;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsCagraIndexCreate;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsCagraIndexDestroy;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsCagraIndex_t;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsCagraMerge;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsCagraSearch;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsCagraSerialize;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsCagraSerializeToHnswlib;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsRMMAlloc;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsRMMFree;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsStreamGet;
-import static com.nvidia.cuvs.internal.panama.headers_h.cuvsStreamSync;
-import static com.nvidia.cuvs.internal.panama.headers_h.omp_set_num_threads;
+import static com.nvidia.cuvs.internal.panama.headers_h.*;
 
 import com.nvidia.cuvs.CagraCompressionParams;
 import com.nvidia.cuvs.CagraIndex;
@@ -54,6 +41,8 @@ import com.nvidia.cuvs.CuVSIvfPqSearchParams;
 import com.nvidia.cuvs.CuVSResources;
 import com.nvidia.cuvs.Dataset;
 import com.nvidia.cuvs.SearchResults;
+import com.nvidia.cuvs.internal.common.CloseableHandle;
+import com.nvidia.cuvs.internal.common.CompositeCloseableHandle;
 import com.nvidia.cuvs.internal.panama.cuvsCagraCompressionParams;
 import com.nvidia.cuvs.internal.panama.cuvsCagraIndexParams;
 import com.nvidia.cuvs.internal.panama.cuvsCagraMergeParams;
@@ -72,9 +61,7 @@ import java.lang.foreign.SequenceLayout;
 import java.lang.foreign.ValueLayout;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.BitSet;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * {@link CagraIndex} encapsulates a CAGRA index, along with methods to interact
@@ -164,14 +151,11 @@ public class CagraIndexImpl implements CagraIndex {
    *         index
    */
   private IndexReference build(CagraIndexParams indexParameters, DatasetImpl dataset) {
-    try (var localArena = Arena.ofConfined()) {
-      long rows = dataset.size();
-      long cols = dataset.dimensions();
+    long rows = dataset.size();
+    long cols = dataset.dimensions();
 
-      MemorySegment indexParamsMemorySegment =
-          indexParameters != null
-              ? segmentFromIndexParams(localArena, indexParameters)
-              : MemorySegment.NULL;
+    try (var indexParams = segmentFromIndexParams(indexParameters)) {
+      MemorySegment indexParamsMemorySegment = indexParams.handle();
 
       int numWriterThreads = indexParameters != null ? indexParameters.getNumWriterThreads() : 1;
       omp_set_num_threads(numWriterThreads);
@@ -490,20 +474,39 @@ public class CagraIndexImpl implements CagraIndex {
   }
 
   /**
-   * Allocates the configured index parameters in the MemorySegment.
+   * Allocates the native CagraIndexParams data structures and fills the configured index parameters in.
    */
-  private static MemorySegment segmentFromIndexParams(Arena arena, CagraIndexParams params) {
-    MemorySegment seg = cuvsCagraIndexParams.allocate(arena);
-    cuvsCagraIndexParams.intermediate_graph_degree(seg, params.getIntermediateGraphDegree());
-    cuvsCagraIndexParams.graph_degree(seg, params.getGraphDegree());
-    cuvsCagraIndexParams.build_algo(seg, params.getCagraGraphBuildAlgo().value);
-    cuvsCagraIndexParams.nn_descent_niter(seg, params.getNNDescentNumIterations());
-    cuvsCagraIndexParams.metric(seg, params.getCuvsDistanceType().value);
+  private static CloseableHandle segmentFromIndexParams(CagraIndexParams params) {
+
+    if (params == null) {
+      return CloseableHandle.NULL;
+    }
+
+    var handles = new ArrayList<CloseableHandle>();
+
+    var indexParams = createCagraIndexParams();
+    handles.add(indexParams);
+    var indexPtr = indexParams.handle();
+
+    populateNativeIndexParams(indexPtr, params, handles);
+
+    return new CompositeCloseableHandle(indexPtr, handles);
+  }
+
+  private static void populateNativeIndexParams(
+      MemorySegment indexPtr, CagraIndexParams params, List<CloseableHandle> handles) {
+
+    cuvsCagraIndexParams.intermediate_graph_degree(indexPtr, params.getIntermediateGraphDegree());
+    cuvsCagraIndexParams.graph_degree(indexPtr, params.getGraphDegree());
+    cuvsCagraIndexParams.build_algo(indexPtr, params.getCagraGraphBuildAlgo().value);
+    cuvsCagraIndexParams.nn_descent_niter(indexPtr, params.getNNDescentNumIterations());
+    cuvsCagraIndexParams.metric(indexPtr, params.getCuvsDistanceType().value);
 
     CagraCompressionParams cagraCompressionParams = params.getCagraCompressionParams();
     if (cagraCompressionParams != null) {
-      MemorySegment cuvsCagraCompressionParamsMemorySegment =
-          cuvsCagraCompressionParams.allocate(arena);
+      var compressionParams = createCagraCompressionParams();
+      handles.add(compressionParams);
+      MemorySegment cuvsCagraCompressionParamsMemorySegment = compressionParams.handle();
       cuvsCagraCompressionParams.pq_bits(
           cuvsCagraCompressionParamsMemorySegment, cagraCompressionParams.getPqBits());
       cuvsCagraCompressionParams.pq_dim(
@@ -518,12 +521,14 @@ public class CagraIndexImpl implements CagraIndex {
       cuvsCagraCompressionParams.pq_kmeans_trainset_fraction(
           cuvsCagraCompressionParamsMemorySegment,
           cagraCompressionParams.getPqKmeansTrainsetFraction());
-      cuvsCagraIndexParams.compression(seg, cuvsCagraCompressionParamsMemorySegment);
+      cuvsCagraIndexParams.compression(indexPtr, cuvsCagraCompressionParamsMemorySegment);
     }
 
     if (params.getCagraGraphBuildAlgo().equals(CagraGraphBuildAlgo.IVF_PQ)) {
 
-      MemorySegment ivfpqIndexParamsMemorySegment = cuvsIvfPqIndexParams.allocate(arena);
+      var ivfPqIndexParams = createIvfPqIndexParams();
+      handles.add(ivfPqIndexParams);
+      MemorySegment ivfpqIndexParamsMemorySegment = ivfPqIndexParams.handle();
       CuVSIvfPqIndexParams cuVSIvfPqIndexParams = params.getCuVSIvfPqParams().getIndexParams();
 
       cuvsIvfPqIndexParams.metric(
@@ -548,7 +553,9 @@ public class CagraIndexImpl implements CagraIndex {
       cuvsIvfPqIndexParams.max_train_points_per_pq_code(
           ivfpqIndexParamsMemorySegment, cuVSIvfPqIndexParams.getMaxTrainPointsPerPqCode());
 
-      MemorySegment ivfpqSearchParamsMemorySegment = cuvsIvfPqSearchParams.allocate(arena);
+      var ivfPqSearchParams = createIvfPqSearchParams();
+      handles.add(ivfPqSearchParams);
+      MemorySegment ivfpqSearchParamsMemorySegment = ivfPqSearchParams.handle();
       CuVSIvfPqSearchParams cuVSIvfPqSearchParams = params.getCuVSIvfPqParams().getSearchParams();
       cuvsIvfPqSearchParams.n_probes(
           ivfpqSearchParamsMemorySegment, cuVSIvfPqSearchParams.getnProbes());
@@ -559,7 +566,10 @@ public class CagraIndexImpl implements CagraIndex {
       cuvsIvfPqSearchParams.preferred_shmem_carveout(
           ivfpqSearchParamsMemorySegment, cuVSIvfPqSearchParams.getPreferredShmemCarveout());
 
-      MemorySegment cuvsIvfPqParamsMemorySegment = cuvsIvfPqParams.allocate(arena);
+      // This is already allocated by cuvsCagraIndexParamsCreate,
+      // we just need to populate it.
+      MemorySegment cuvsIvfPqParamsMemorySegment =
+          cuvsCagraIndexParams.graph_build_params(indexPtr);
       cuvsIvfPqParams.ivf_pq_build_params(
           cuvsIvfPqParamsMemorySegment, ivfpqIndexParamsMemorySegment);
       cuvsIvfPqParams.ivf_pq_search_params(
@@ -567,10 +577,8 @@ public class CagraIndexImpl implements CagraIndex {
       cuvsIvfPqParams.refinement_rate(
           cuvsIvfPqParamsMemorySegment, params.getCuVSIvfPqParams().getRefinementRate());
 
-      cuvsCagraIndexParams.graph_build_params(seg, cuvsIvfPqParamsMemorySegment);
+      cuvsCagraIndexParams.graph_build_params(indexPtr, cuvsIvfPqParamsMemorySegment);
     }
-
-    return seg;
   }
 
   /**
@@ -637,11 +645,12 @@ public class CagraIndexImpl implements CagraIndex {
             ValueLayout.ADDRESS, i, indexImpl.cagraIndexReference.getMemorySegment());
       }
 
-      MemorySegment mergeParamsSegment = createMergeParamsSegment(mergeParams, resources);
-      int returnValue =
-          cuvsCagraMerge(cuvsRes, mergeParamsSegment, indexesSegment, indexes.length, mergedIndex);
-
-      checkCuVSError(returnValue, "cuvsCagraMerge");
+      try (var nativeMergeParams = createMergeParamsSegment(mergeParams)) {
+        checkCuVSError(
+            cuvsCagraMerge(
+                cuvsRes, nativeMergeParams.handle(), indexesSegment, indexes.length, mergedIndex),
+            "cuvsCagraMerge");
+      }
     }
 
     return new CagraIndexImpl(new IndexReference(mergedIndex, null), resources);
@@ -651,31 +660,27 @@ public class CagraIndexImpl implements CagraIndex {
    * Creates a memory segment for merge parameters.
    *
    * @param mergeParams The merge parameters
-   * @param resources The CuVS resources
    * @return A memory segment with the merge parameters
    */
-  private static MemorySegment createMergeParamsSegment(
-      CagraMergeParams mergeParams, CuVSResourcesImpl resources) {
-    var arena = resources.getArena();
-    MemorySegment seg = cuvsCagraMergeParams.allocate(arena);
+  private static CloseableHandle createMergeParamsSegment(CagraMergeParams mergeParams) {
+    var handles = new ArrayList<CloseableHandle>();
 
+    var nativeMergeParams = createCagraMergeParams();
+    handles.add(nativeMergeParams);
+    var seg = nativeMergeParams.handle();
+
+    // The output index params are already allocated by cuvsCagraMergeParamsCreate,
+    // we just need to populate it.
+    var outputIndexParamsPtr = cuvsCagraMergeParams.output_index_params(seg);
     if (mergeParams != null) {
-      if (mergeParams.getOutputIndexParams() != null) {
-        MemorySegment outputIndexParamsSeg =
-            segmentFromIndexParams(arena, mergeParams.getOutputIndexParams());
-        cuvsCagraMergeParams.output_index_params(seg, outputIndexParamsSeg);
-      } else {
-        cuvsCagraMergeParams.output_index_params(seg, MemorySegment.NULL);
-      }
-
+      populateNativeIndexParams(outputIndexParamsPtr, mergeParams.getOutputIndexParams(), handles);
       cuvsCagraMergeParams.strategy(seg, mergeParams.getStrategy().value);
     } else {
-      MemorySegment outputIndexParamsSeg =
-          segmentFromIndexParams(arena, new CagraIndexParams.Builder().build());
-      cuvsCagraMergeParams.output_index_params(seg, outputIndexParamsSeg);
+      populateNativeIndexParams(
+          outputIndexParamsPtr, new CagraIndexParams.Builder().build(), handles);
     }
 
-    return seg;
+    return new CompositeCloseableHandle(seg, handles);
   }
 
   /**

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/CuVSParamsHelper.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/CuVSParamsHelper.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.cuvs.internal;
+
+import static com.nvidia.cuvs.internal.common.Util.checkCuVSError;
+import static com.nvidia.cuvs.internal.panama.headers_h.*;
+
+import com.nvidia.cuvs.internal.common.CloseableHandle;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+/**
+ * A set of helpers to create various types of native CuVS "params" data structures.
+ * The CuVS API encapsulates and hides these data structures behind opaque handles
+ * (e.g. {@code cuvsCagraIndexParams_t}, and provides functions to create (allocate)
+ * and destroy (free) them.
+ * The helpers wrap the Create calls and return a {@link CloseableHandle} to hold the
+ * opaque handle (to access the params data structure) and pair them with their respective
+ * Destroy calls, so that the params native resources will be cleared when
+ * {@link AutoCloseable#close()} is called.
+ */
+final class CuVSParamsHelper {
+
+  private CuVSParamsHelper() {}
+
+  static CloseableHandle createCagraIndexParams() {
+    try (var localArena = Arena.ofConfined()) {
+      var paramsPtrPtr = localArena.allocate(cuvsCagraIndexParams_t);
+      checkCuVSError(cuvsCagraIndexParamsCreate(paramsPtrPtr), "cuvsCagraIndexParamsCreate");
+      var paramsPtr = paramsPtrPtr.get(cuvsCagraIndexParams_t, 0L);
+      return new CloseableHandle() {
+        @Override
+        public MemorySegment handle() {
+          return paramsPtr;
+        }
+
+        @Override
+        public void close() {
+          checkCuVSError(cuvsCagraIndexParamsDestroy(paramsPtr), "cuvsCagraIndexParamsDestroy");
+        }
+      };
+    }
+  }
+
+  static CloseableHandle createCagraCompressionParams() {
+    try (var localArena = Arena.ofConfined()) {
+      var paramsPtrPtr = localArena.allocate(cuvsCagraCompressionParams_t);
+      checkCuVSError(
+          cuvsCagraCompressionParamsCreate(paramsPtrPtr), "cuvsCagraCompressionParamsCreate");
+      var paramsPtr = paramsPtrPtr.get(cuvsCagraCompressionParams_t, 0L);
+      return new CloseableHandle() {
+        @Override
+        public MemorySegment handle() {
+          return paramsPtr;
+        }
+
+        @Override
+        public void close() {
+          checkCuVSError(
+              cuvsCagraCompressionParamsDestroy(paramsPtr), "cuvsCagraCompressionParamsDestroy");
+        }
+      };
+    }
+  }
+
+  static CloseableHandle createIvfPqIndexParams() {
+    try (var localArena = Arena.ofConfined()) {
+      var paramsPtrPtr = localArena.allocate(cuvsIvfPqIndexParams_t);
+      checkCuVSError(cuvsIvfPqIndexParamsCreate(paramsPtrPtr), "cuvsIvfPqIndexParamsCreate");
+      var paramsPtr = paramsPtrPtr.get(cuvsIvfPqIndexParams_t, 0L);
+      return new CloseableHandle() {
+        @Override
+        public MemorySegment handle() {
+          return paramsPtr;
+        }
+
+        @Override
+        public void close() {
+          checkCuVSError(cuvsIvfPqIndexParamsDestroy(paramsPtr), "cuvsIvfPqIndexParamsDestroy");
+        }
+      };
+    }
+  }
+
+  static CloseableHandle createIvfPqSearchParams() {
+    try (var localArena = Arena.ofConfined()) {
+      var paramsPtrPtr = localArena.allocate(cuvsIvfPqSearchParams_t);
+      checkCuVSError(cuvsIvfPqSearchParamsCreate(paramsPtrPtr), "cuvsIvfPqSearchParamsCreate");
+      var paramsPtr = paramsPtrPtr.get(cuvsIvfPqSearchParams_t, 0L);
+      return new CloseableHandle() {
+        @Override
+        public MemorySegment handle() {
+          return paramsPtr;
+        }
+
+        @Override
+        public void close() {
+          checkCuVSError(cuvsIvfPqSearchParamsDestroy(paramsPtr), "cuvsIvfPqSearchParamsDestroy");
+        }
+      };
+    }
+  }
+
+  static CloseableHandle createCagraMergeParams() {
+    try (var localArena = Arena.ofConfined()) {
+      var paramsPtrPtr = localArena.allocate(cuvsCagraMergeParams_t);
+      checkCuVSError(cuvsCagraMergeParamsCreate(paramsPtrPtr), "cuvsCagraMergeParamsCreate");
+      var paramsPtr = paramsPtrPtr.get(cuvsCagraMergeParams_t, 0L);
+      return new CloseableHandle() {
+        @Override
+        public MemorySegment handle() {
+          return paramsPtr;
+        }
+
+        @Override
+        public void close() {
+          checkCuVSError(cuvsCagraMergeParamsDestroy(paramsPtr), "cuvsCagraMergeParamsDestroy");
+        }
+      };
+    }
+  }
+}

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/CloseableHandle.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/CloseableHandle.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.cuvs.internal.common;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * An interface holding a "handle" (C pointer type) for a native resource that needs to
+ * be manually freed. It is used to pair {@code cuvsXxxCreate} calls (which create a CuVS
+ * native object) to their respective {@code cuvsXxxDestroy} calls (which destroys it,
+ * freeing any associated resources), while holding the "handle" (represented as
+ * a {@link MemorySegment}) used to access the CuVS native object.
+ */
+public interface CloseableHandle extends AutoCloseable {
+
+  /**
+   * A "null" handle, associated to no native object. {@code close()} is a no-op.
+   */
+  CloseableHandle NULL =
+      new CloseableHandle() {
+        @Override
+        public MemorySegment handle() {
+          return MemorySegment.NULL;
+        }
+
+        @Override
+        public void close() {}
+      };
+
+  MemorySegment handle();
+
+  @Override
+  void close();
+}

--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/CompositeCloseableHandle.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/CompositeCloseableHandle.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.cuvs.internal.common;
+
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+
+/**
+ * A composite {@link CloseableHandle}. A native object might need the creation of nested native objects,
+ * which handle is then embedded within the outer object(s) structures. This composite helps in keeping
+ * track of the nested native objects, so when the parent is cleared, the child objects are cleared too.
+ */
+public class CompositeCloseableHandle implements CloseableHandle {
+  private final MemorySegment indexPtr;
+  private final ArrayList<CloseableHandle> handles;
+
+  public CompositeCloseableHandle(MemorySegment indexPtr, ArrayList<CloseableHandle> handles) {
+    this.indexPtr = indexPtr;
+    this.handles = handles;
+  }
+
+  @Override
+  public MemorySegment handle() {
+    return indexPtr;
+  }
+
+  @Override
+  public void close() {
+    for (var closeable : handles) {
+      closeable.close();
+    }
+  }
+}

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraBuildAndSearchIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraBuildAndSearchIT.java
@@ -193,28 +193,26 @@ public class CagraBuildAndSearchIT extends CuVSTestCase {
     List<Map<Integer, Float>> expectedResults = getExpectedResults();
 
     int numTestsRuns = 10;
-    try (CuVSResources resources = CuVSResources.create()) {
-      runConcurrently(
-          numTestsRuns,
-          () ->
-              () -> {
-                try {
-                  var index = indexOnce(dataset, resources);
-                  var indexPath = serializeOnce(index);
-                  var loadedIndex = deserializeOnce(indexPath, resources);
-                  queryOnce(
-                      index,
-                      loadedIndex,
-                      SearchResults.IDENTITY_MAPPING,
-                      queries,
-                      expectedResults,
-                      resources);
-                  cleanup(indexPath, index, loadedIndex);
-                } catch (Throwable e) {
-                  throw new RuntimeException(e);
-                }
-              });
-    }
+    runConcurrently(
+        numTestsRuns,
+        () ->
+            () -> {
+              try (CuVSResources resources = CuVSResources.create()) {
+                var index = indexOnce(dataset, resources);
+                var indexPath = serializeOnce(index);
+                var loadedIndex = deserializeOnce(indexPath, resources);
+                queryOnce(
+                    index,
+                    loadedIndex,
+                    SearchResults.IDENTITY_MAPPING,
+                    queries,
+                    expectedResults,
+                    resources);
+                cleanup(indexPath, index, loadedIndex);
+              } catch (Throwable e) {
+                throw new RuntimeException(e);
+              }
+            });
   }
 
   @Test


### PR DESCRIPTION
The current code allocates data structures for various "params" CuVS objects manually, i.e. through a Java Arena. This is not supposed to happen: the CuVS C API provides an API for creating ad destroying these objects. At present, the code works as it is mimicking what the C API is doing, but if the C API changes (e.g. allocating more nested objects, or initializing the data structures with default values etc.) the Java API could break in a way that is difficult to track.

This PR replaces direct allocations with calls to the appropriate `cuvsXxxCreate` and `cuvsXxxDestroy` functions; tracking usage is more difficult than using an Arena (which will claim all the allocated memory when closed), but I think we need to ensure correctness here. To alleviate the difficulties, this PR also introduces some helpers and a `CloseableHandle` type to keep track of the created params and destroy all of them when no longer needed.

CC @benfred 