### PR TITLE
CAGRA build heuristics for HNSW

### DIFF
--- a/cpp/include/cuvs/neighbors/graph_build_types.hpp
+++ b/cpp/include/cuvs/neighbors/graph_build_types.hpp
@@ -56,10 +56,32 @@ struct ivf_pq_params {
   ivf_pq_params(raft::matrix_extent<int64_t> dataset_extents,
                 cuvs::distance::DistanceType metric = cuvs::distance::DistanceType::L2Expanded)
   {
-    build_params = cuvs::neighbors::ivf_pq::index_params::from_dataset(dataset_extents, metric);
+    build_params    = ivf_pq::index_params::from_dataset(dataset_extents, metric);
+    auto n_rows     = dataset_extents.extent(0);
+    auto n_features = dataset_extents.extent(1);
+    if (n_features <= 32) {
+      build_params.pq_dim  = 16;
+      build_params.pq_bits = 8;
+    } else {
+      build_params.pq_bits = 4;
+      if (n_features <= 64) {
+        build_params.pq_dim = 32;
+      } else if (n_features <= 128) {
+        build_params.pq_dim = 64;
+      } else if (n_features <= 192) {
+        build_params.pq_dim = 96;
+      } else {
+        build_params.pq_dim = raft::round_up_safe<uint32_t>(n_features / 2, 128);
+      }
+    }
+
+    build_params.n_lists                  = std::max<uint32_t>(1, n_rows / 2000);
+    build_params.kmeans_n_iters           = 10;
+    build_params.kmeans_trainset_fraction = std::min(1.0, 1.0 / std::sqrt(n_rows * 1e-5));
+    build_params.codebook_kind            = ivf_pq::codebook_gen::PER_SUBSPACE;
 
     search_params                         = cuvs::neighbors::ivf_pq::search_params{};
-    search_params.n_probes                = std::max<uint32_t>(10, build_params.n_lists * 0.01);
+    search_params.n_probes                = std::round(std::sqrt(build_params.n_lists) / 20 + 4);
     search_params.lut_dtype               = CUDA_R_16F;
     search_params.internal_distance_dtype = CUDA_R_16F;
     search_params.coarse_search_dtype     = CUDA_R_16F;

--- a/cpp/include/cuvs/neighbors/hnsw.hpp
+++ b/cpp/include/cuvs/neighbors/hnsw.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,30 @@ struct index_params : cuvs::neighbors::index_params {
    */
   int num_threads = 0;
 };
+
+/**
+ * @brief Create a CAGRA index parameters compatible with HNSW index
+ *
+ * @param dataset The shape of the input dataset.
+ * @param M HNSW index parameter M.
+ * @param ef_construction HNSW index parameter ef_construction.
+ * @param metric The distance metric to search.
+ *
+ * Usage example:
+ * @code{.cpp}
+ *   using namespace cuvs::neighbors;
+ *   raft::resources res;
+ *   auto dataset = raft::make_device_matrix<float, int64_t>(res, N, D);
+ *   auto cagra_params = cagra_compat_params(dataset.extents(), M, efc);
+ *   auto cagra_index = cagra::build(res, cagra_params, dataset);
+ *   auto hnsw_index = hnsw::from_cagra(res, hnsw_params, cagra_index);
+ * @endcode
+ */
+cuvs::neighbors::cagra::index_params cagra_compat_params(
+  raft::matrix_extent<int64_t> dataset,
+  int M,
+  int ef_construction,
+  cuvs::distance::DistanceType metric = cuvs::distance::DistanceType::L2Expanded);
 
 /**@}*/
 

--- a/cpp/src/neighbors/detail/hnsw.hpp
+++ b/cpp/src/neighbors/detail/hnsw.hpp
@@ -123,6 +123,24 @@ struct index_impl : index<T> {
   std::unique_ptr<hnswlib::SpaceInterface<typename hnsw_dist_t<T>::type>> space_;
 };
 
+cuvs::neighbors::cagra::index_params cagra_compat_params(
+  raft::matrix_extent<int64_t> dataset,
+  int M,
+  int ef_construction,
+  cuvs::distance::DistanceType metric = cuvs::distance::DistanceType::L2Expanded)
+{
+  auto ivf_pq_params = cuvs::neighbors::graph_build_params::ivf_pq_params(dataset, metric);
+  ivf_pq_params.search_params.n_probes =
+    std::round(std::sqrt(ivf_pq_params.build_params.n_lists) / 20 + ef_construction / 16);
+
+  cagra::index_params params;
+  params.graph_build_params        = ivf_pq_params;
+  params.graph_degree              = M * 2;
+  params.intermediate_graph_degree = M * 3;
+
+  return params;
+}
+
 template <typename T, HnswHierarchy hierarchy>
 std::enable_if_t<hierarchy == HnswHierarchy::NONE, std::unique_ptr<index<T>>> from_cagra(
   raft::resources const& res,


### PR DESCRIPTION
Add helper functions to construct a reasonable default CAGRA build parameters based on HNSW parameters.
The goal is to build a CAGRA graph that can be converted to an HNSW graph which has very similar search performance as the corresponding HNSW-built graph.