### PR TITLE
Fix for `hellinger` metric

### DIFF
--- a/cpp/src/distance/detail/distance.cuh
+++ b/cpp/src/distance/detail/distance.cuh
@@ -298,27 +298,49 @@ void distance_impl(raft::resources const& handle,
 {
   cudaStream_t stream = raft::resource::get_cuda_stream(handle);
 
-  rmm::device_uvector<DataT> y_temp(n * k, stream);
-  raft::copy(y_temp.data(), y, n * k, stream);
-  const DataT* y_temp_ptr = y_temp.data();
+  // Check if arrays overlap
+  const DataT* x_end  = x + m * k;
+  const DataT* y_end  = y + n * k;
+  bool arrays_overlap = (x < y_end) && (y < x_end);
 
-  // First sqrt x and y
   const auto raft_sqrt = raft::linalg::unaryOp<DataT, raft::sqrt_op, IdxT>;
-  raft_sqrt((DataT*)x, x, m * k, raft::sqrt_op{}, stream);
-  raft_sqrt((DataT*)y_temp_ptr, y_temp_ptr, n * k, raft::sqrt_op{}, stream);
+  const auto raft_sq   = raft::linalg::unaryOp<DataT, raft::sq_op, IdxT>;
 
-  // Then calculate Hellinger distance
+  if (!arrays_overlap) {
+    // Arrays don't overlap: sqrt each array independently
+    raft_sqrt((DataT*)x, x, m * k, raft::sqrt_op{}, stream);
+    raft_sqrt((DataT*)y, y, n * k, raft::sqrt_op{}, stream);
+  } else {
+    // Arrays overlap: sqrt the union of both arrays exactly once
+    const DataT* start = (x < y) ? x : y;
+    const DataT* end   = (x_end > y_end) ? x_end : y_end;
+    IdxT union_size    = end - start;
+
+    raft_sqrt((DataT*)start, start, union_size, raft::sqrt_op{}, stream);
+  }
+
+  // Calculate Hellinger distance
   ops::hellinger_distance_op<DataT, AccT, IdxT> distance_op{};
 
   const OutT* x_norm = nullptr;
   const OutT* y_norm = nullptr;
 
   pairwise_matrix_dispatch<decltype(distance_op), DataT, AccT, OutT, FinOpT, IdxT>(
-    distance_op, m, n, k, x, y_temp_ptr, x_norm, y_norm, out, fin_op, stream, is_row_major);
+    distance_op, m, n, k, x, y, x_norm, y_norm, out, fin_op, stream, is_row_major);
 
-  // Finally revert sqrt of x and y
-  const auto raft_sq = raft::linalg::unaryOp<DataT, raft::sq_op, IdxT>;
-  raft_sq((DataT*)x, x, m * k, raft::sq_op{}, stream);
+  // Restore arrays by squaring back
+  if (!arrays_overlap) {
+    // Arrays don't overlap: square each array independently
+    raft_sq((DataT*)x, x, m * k, raft::sq_op{}, stream);
+    raft_sq((DataT*)y, y, n * k, raft::sq_op{}, stream);
+  } else {
+    // Arrays overlap: square the union back
+    const DataT* start = (x < y) ? x : y;
+    const DataT* end   = (x_end > y_end) ? x_end : y_end;
+    IdxT union_size    = end - start;
+
+    raft_sq((DataT*)start, start, union_size, raft::sq_op{}, stream);
+  }
 
   RAFT_CUDA_TRY(cudaGetLastError());
 }

--- a/cpp/src/distance/detail/distance.cuh
+++ b/cpp/src/distance/detail/distance.cuh
@@ -300,7 +300,7 @@ void distance_impl(raft::resources const& handle,
 
   rmm::device_uvector<DataT> y_temp(n * k, stream);
   raft::copy(y_temp.data(), y, n * k, stream);
-  const DataT* y_temp_ptr = y.data();
+  const DataT* y_temp_ptr = y_temp.data();
 
   // First sqrt x and y
   const auto raft_sqrt = raft::linalg::unaryOp<DataT, raft::sqrt_op, IdxT>;


### PR DESCRIPTION
The implementation of the distance function for the `hellinger` metric had two issues :
1) It did not restore data integrity correctly : double `sqrt` operation
2) It did not check for data overlap (two data chunks/tiles in the pairwise operation have overlapping data).

Closes https://github.com/rapidsai/cuml/issues/7011