### PR TITLE
Fix TieredIndexIT,  Scoped resource access change was missed

### DIFF
--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/TieredIndexIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/TieredIndexIT.java
@@ -18,6 +18,7 @@ package com.nvidia.cuvs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import java.lang.invoke.MethodHandles;
@@ -39,6 +40,7 @@ public class TieredIndexIT extends CuVSTestCase {
 
   @Before
   public void setup() {
+    assumeTrue("not supported on " + System.getProperty("os.name"), isLinuxAmd64());
     initializeRandom();
     log.debug("Random context initialized for test");
   }

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/TieredIndexIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/TieredIndexIT.java
@@ -67,7 +67,7 @@ public class TieredIndexIT extends CuVSTestCase {
     List<Map<Integer, Float>> expectedExtendedResults =
         Arrays.asList(Map.of(0, 0.02f, 1, 1.62f, 2, 7.22f), Map.of(2, 0.02f, 3, 2.42f, 1, 1.62f));
 
-    try (CuVSResources resources = CuVSResources.create()) {
+    try (CuVSResources resources = CheckedCuVSResources.create()) {
       CagraIndexParams cagraParams =
           new CagraIndexParams.Builder().withGraphDegree(4).withIntermediateGraphDegree(8).build();
 
@@ -114,7 +114,7 @@ public class TieredIndexIT extends CuVSTestCase {
 
   @Test(expected = IllegalArgumentException.class)
   public void testErrorHandling() throws Throwable {
-    try (CuVSResources resources = CuVSResources.create()) {
+    try (CuVSResources resources = CheckedCuVSResources.create()) {
       CagraIndexParams cagraParams =
           new CagraIndexParams.Builder().withGraphDegree(4).withIntermediateGraphDegree(8).build();
 
@@ -141,7 +141,7 @@ public class TieredIndexIT extends CuVSTestCase {
 
     float[][] queries = {{0.1f, 0.1f}};
 
-    try (CuVSResources resources = CuVSResources.create()) {
+    try (CuVSResources resources = CheckedCuVSResources.create()) {
       CagraIndexParams cagraParams =
           new CagraIndexParams.Builder().withGraphDegree(4).withIntermediateGraphDegree(8).build();
 
@@ -204,7 +204,7 @@ public class TieredIndexIT extends CuVSTestCase {
     float[][] dataset = {{0.0f, 0.0f}, {1.0f, 1.0f}, {2.0f, 2.0f}, {3.0f, 3.0f}};
     float[][] queryVectors = {{0.1f, 0.1f}};
 
-    try (CuVSResources resources = CuVSResources.create()) {
+    try (CuVSResources resources = CheckedCuVSResources.create()) {
       CagraIndexParams cagraParams =
           new CagraIndexParams.Builder().withGraphDegree(4).withIntermediateGraphDegree(8).build();
 


### PR DESCRIPTION
#1089 Scoped Resource access changes were missed in the TieredIndex test causing them to fail.
 - Using CheckedCuVSResources.create() now
 - Skip TieredIndex tests if CuVS native support is unavailable

<!--

Thank you for contributing to cuvs :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
