### PR TITLE
[BUG] Fix Large Batch Preprocessing for NN Descent

### DIFF
--- a/cpp/src/neighbors/detail/nn_descent.cuh
+++ b/cpp/src/neighbors/detail/nn_descent.cuh
@@ -289,7 +289,7 @@ RAFT_KERNEL preprocess_data_kernel(
       } else if (metric == cuvs::distance::DistanceType::BitwiseHamming) {
         int idx_for_byte           = list_id * dim + idx;  // uint8 or int8 data
         uint8_t* output_bytes      = reinterpret_cast<uint8_t*>(output_data);
-        output_bytes[idx_for_byte] = input_data[idx_for_byte];
+        output_bytes[idx_for_byte] = input_data[(size_t)blockIdx.x * dim + idx];
       } else {  // L2Expanded or L2SqrtExpanded
         output_data[list_id * dim + idx] = input_data[(size_t)blockIdx.x * dim + idx];
         if (idx == 0) { l2_norms[list_id] = l2_norm; }

--- a/cpp/tests/neighbors/ann_nn_descent.cuh
+++ b/cpp/tests/neighbors/ann_nn_descent.cuh
@@ -487,6 +487,16 @@ const std::vector<AnnNNDescentInputs> inputs =
                                                      {false, true},
                                                      {0.90});
 
+// Additional test cases for large datasets to test batching
+const std::vector<AnnNNDescentInputs> inputsLargeBatch =
+  raft::util::itertools::product<AnnNNDescentInputs>(
+    {150000},  // n_rows > 100000 to trigger batching
+    {64},
+    {32},
+    {cuvs::distance::DistanceType::BitwiseHamming},
+    {true},
+    {0.90});
+
 const std::vector<AnnNNDescentInputs> inputsDistEpilogue =
   raft::util::itertools::product<AnnNNDescentInputs>({2000, 4000},  // n_rows
                                                      {64, 1024},    // dim

--- a/cpp/tests/neighbors/ann_nn_descent/test_uint8_t_uint32_t.cu
+++ b/cpp/tests/neighbors/ann_nn_descent/test_uint8_t_uint32_t.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,5 +24,12 @@ typedef AnnNNDescentTest<float, uint8_t, std::uint32_t> AnnNNDescentTestUI8_U32;
 TEST_P(AnnNNDescentTestUI8_U32, AnnNNDescent) { this->testNNDescent(); }
 
 INSTANTIATE_TEST_CASE_P(AnnNNDescentTest, AnnNNDescentTestUI8_U32, ::testing::ValuesIn(inputs));
+
+typedef AnnNNDescentTest<float, uint8_t, std::uint32_t> AnnNNDescentTestUI8_U32_LargeBatch;
+TEST_P(AnnNNDescentTestUI8_U32_LargeBatch, AnnNNDescent) { this->testNNDescent(); }
+
+INSTANTIATE_TEST_CASE_P(AnnNNDescentTestLargeBatch,
+                        AnnNNDescentTestUI8_U32_LargeBatch,
+                        ::testing::ValuesIn(inputsLargeBatch));
 
 }  // namespace   cuvs::neighbors::nn_descent


### PR DESCRIPTION
Bug fix for illegal memory access while preprocessing batches in nn descent with BitwiseHamming.