### PR TITLE
Add error checking for our C example code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,18 @@
 #cpp code owners
 cpp/               @rapidsai/cuvs-cpp-codeowners
+examples/cpp/
+examples/c/
 
 #java code owners
 java/              @rapidsai/cuvs-java-codeowners
+examples/java/
 
 #python code owners
 python/            @rapidsai/cuvs-python-codeowners
 
 #rust code owners
 rust/              @rapidsai/cuvs-rust-codeowners
+examples/rust/
 
 #docs code owners
 docs/              @rapidsai/cuvs-docs-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,18 @@
 #cpp code owners
 cpp/               @rapidsai/cuvs-cpp-codeowners
-examples/cpp/
-examples/c/
+examples/cpp/      @rapidsai/cuvs-cpp-codeowners
+examples/c/        @rapidsai/cuvs-cpp-codeowners
 
 #java code owners
 java/              @rapidsai/cuvs-java-codeowners
-examples/java/
+examples/java/     @rapidsai/cuvs-java-codeowners
 
 #python code owners
 python/            @rapidsai/cuvs-python-codeowners
 
 #rust code owners
 rust/              @rapidsai/cuvs-rust-codeowners
-examples/rust/
+examples/rust/     @rapidsai/cuvs-rust-codeowners
 
 #docs code owners
 docs/              @rapidsai/cuvs-docs-codeowners

--- a/examples/.clang-format
+++ b/examples/.clang-format
@@ -1,0 +1,1 @@
+../cpp/.clang-format

--- a/examples/.clang-tidy
+++ b/examples/.clang-tidy
@@ -1,0 +1,1 @@
+../cpp/.clang-tidy

--- a/examples/.clangd
+++ b/examples/.clangd
@@ -1,0 +1,1 @@
+../cpp/.clangd

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -34,6 +34,8 @@ rapids_cpm_init()
 set(BUILD_CUVS_C_LIBRARY ON)
 include(../cmake/thirdparty/get_dlpack.cmake)
 include(../cmake/thirdparty/get_cuvs.cmake)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
 
 add_executable(CAGRA_C_EXAMPLE src/cagra_c_example.c)
 target_include_directories(CAGRA_C_EXAMPLE PUBLIC "$<BUILD_INTERFACE:${DLPACK_INCLUDE_DIR}>")

--- a/examples/c/src/L2_c_example.c
+++ b/examples/c/src/L2_c_example.c
@@ -29,15 +29,15 @@
 #define DIM 4
 #define N_ROWS 1
 
-float PointA[N_ROWS][DIM] = {{1.0,2.0,3.0,4.0}};
-float PointB[N_ROWS][DIM] = {{2.0,3.0,4.0,5.0}};
+float PointA[N_ROWS][DIM] = {{1.0, 2.0, 3.0, 4.0}};
+float PointB[N_ROWS][DIM] = {{2.0, 3.0, 4.0, 5.0}};
 
 cuvsResources_t res;
 
-void outputVector(float * Vec) {
+void outputVector(float *Vec) {
   printf("Vector is ");
-  for (int i = 0; i < DIM; ++i){
-    printf(" %f",Vec[i]);
+  for (int i = 0; i < DIM; ++i) {
+    printf(" %f", Vec[i]);
   }
   printf("\n");
 }
@@ -46,10 +46,12 @@ void outputVector(float * Vec) {
  * @brief Initialize Tensor.
  *
  * @param[in] x_d Pointer to a vector
- * @param[in] x_shape[] Two-dimensional array, which stores the number of rows and columns of vectors.
+ * @param[in] x_shape[] Two-dimensional array, which stores the number of rows
+ * and columns of vectors.
  * @param[out] x_tensor Stores the initialized DLManagedTensor.
  */
-void tensor_initialize(float* x_d, int64_t x_shape[2], DLManagedTensor* x_tensor) {
+void tensor_initialize(float *x_d, int64_t x_shape[2],
+                       DLManagedTensor *x_tensor) {
   x_tensor->dl_tensor.data = x_d;
   x_tensor->dl_tensor.device.device_type = kDLCUDA;
   x_tensor->dl_tensor.ndim = 2;
@@ -68,16 +70,19 @@ void tensor_initialize(float* x_d, int64_t x_shape[2], DLManagedTensor* x_tensor
  * @param[in] y[] Pointer to another vector
  * @param[out] ret will store the result about the euclidean distance
  */
-void l2_distance_calc(int64_t n_cols,float x[], float y[], float *ret) {
+void l2_distance_calc(int64_t n_cols, float x[], float y[], float *ret) {
   float *x_d, *y_d;
   float *distance_d;
-  CHECK_CUVS(cuvsRMMAlloc(res, (void**) &x_d, sizeof(float) * N_ROWS * n_cols));
-  CHECK_CUVS(cuvsRMMAlloc(res, (void**) &y_d, sizeof(float) * N_ROWS * n_cols));
-  CHECK_CUVS(cuvsRMMAlloc(res, (void**) &distance_d, sizeof(float) * N_ROWS * N_ROWS));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&x_d, sizeof(float) * N_ROWS * n_cols));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&y_d, sizeof(float) * N_ROWS * n_cols));
+  CHECK_CUVS(
+      cuvsRMMAlloc(res, (void **)&distance_d, sizeof(float) * N_ROWS * N_ROWS));
 
   // Use DLPack to represent x[] and y[] as tensors
-  CHECK_CUDA(cudaMemcpy(x_d, x, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault));
-  CHECK_CUDA(cudaMemcpy(y_d, y, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault));
+  CHECK_CUDA(
+      cudaMemcpy(x_d, x, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault));
+  CHECK_CUDA(
+      cudaMemcpy(y_d, y, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault));
 
   DLManagedTensor x_tensor;
   int64_t x_shape[2] = {N_ROWS, n_cols};
@@ -92,14 +97,15 @@ void l2_distance_calc(int64_t n_cols,float x[], float y[], float *ret) {
   tensor_initialize(distance_d, distances_shape, &dist_tensor);
 
   // metric_arg default value is 2.0,used for Minkowski distance
-  CHECK_CUVS(cuvsPairwiseDistance(res, &x_tensor, &y_tensor, &dist_tensor, L2SqrtUnexpanded, 2.0));
+  CHECK_CUVS(cuvsPairwiseDistance(res, &x_tensor, &y_tensor, &dist_tensor,
+                                  L2SqrtUnexpanded, 2.0));
 
-  CHECK_CUDA(cudaMemcpy(ret, distance_d, sizeof(float) * N_ROWS * N_ROWS, cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(ret, distance_d, sizeof(float) * N_ROWS * N_ROWS,
+                        cudaMemcpyDefault));
 
   CHECK_CUVS(cuvsRMMFree(res, distance_d, sizeof(float) * N_ROWS * N_ROWS));
   CHECK_CUVS(cuvsRMMFree(res, x_d, sizeof(float) * N_ROWS * n_cols));
   CHECK_CUVS(cuvsRMMFree(res, y_d, sizeof(float) * N_ROWS * n_cols));
-
 }
 
 int euclidean_distance_calculation_example() {
@@ -120,6 +126,6 @@ int euclidean_distance_calculation_example() {
 }
 
 int main() {
-    euclidean_distance_calculation_example();
-    return 0;
+  euclidean_distance_calculation_example();
+  return 0;
 }

--- a/examples/c/src/L2_c_example.c
+++ b/examples/c/src/L2_c_example.c
@@ -24,11 +24,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "common.h"
+
 #define DIM 4
 #define N_ROWS 1
 
-float PointA[N_ROWS][DIM] = {1.0,2.0,3.0,4.0};
-float PointB[N_ROWS][DIM] = {2.0,3.0,4.0,5.0};
+float PointA[N_ROWS][DIM] = {{1.0,2.0,3.0,4.0}};
+float PointB[N_ROWS][DIM] = {{2.0,3.0,4.0,5.0}};
 
 cuvsResources_t res;
 
@@ -69,13 +71,13 @@ void tensor_initialize(float* x_d, int64_t x_shape[2], DLManagedTensor* x_tensor
 void l2_distance_calc(int64_t n_cols,float x[], float y[], float *ret) {
   float *x_d, *y_d;
   float *distance_d;
-  cuvsRMMAlloc(res, (void**) &x_d, sizeof(float) * N_ROWS * n_cols);
-  cuvsRMMAlloc(res, (void**) &y_d, sizeof(float) * N_ROWS * n_cols);
-  cuvsRMMAlloc(res, (void**) &distance_d, sizeof(float) * N_ROWS * N_ROWS);
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**) &x_d, sizeof(float) * N_ROWS * n_cols));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**) &y_d, sizeof(float) * N_ROWS * n_cols));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**) &distance_d, sizeof(float) * N_ROWS * N_ROWS));
 
   // Use DLPack to represent x[] and y[] as tensors
-  cudaMemcpy(x_d, x, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault);
-  cudaMemcpy(y_d, y, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault);
+  CHECK_CUDA(cudaMemcpy(x_d, x, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(y_d, y, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault));
 
   DLManagedTensor x_tensor;
   int64_t x_shape[2] = {N_ROWS, n_cols};
@@ -90,13 +92,13 @@ void l2_distance_calc(int64_t n_cols,float x[], float y[], float *ret) {
   tensor_initialize(distance_d, distances_shape, &dist_tensor);
 
   // metric_arg default value is 2.0,used for Minkowski distance
-  cuvsPairwiseDistance(res, &x_tensor, &y_tensor, &dist_tensor, L2SqrtUnexpanded, 2.0);
+  CHECK_CUVS(cuvsPairwiseDistance(res, &x_tensor, &y_tensor, &dist_tensor, L2SqrtUnexpanded, 2.0));
 
-  cudaMemcpy(ret, distance_d, sizeof(float) * N_ROWS * N_ROWS, cudaMemcpyDefault);
+  CHECK_CUDA(cudaMemcpy(ret, distance_d, sizeof(float) * N_ROWS * N_ROWS, cudaMemcpyDefault));
 
-  cuvsRMMFree(res, distance_d, sizeof(float) * N_ROWS * N_ROWS);
-  cuvsRMMFree(res, x_d, sizeof(float) * N_ROWS * n_cols);
-  cuvsRMMFree(res, y_d, sizeof(float) * N_ROWS * n_cols);
+  CHECK_CUVS(cuvsRMMFree(res, distance_d, sizeof(float) * N_ROWS * N_ROWS));
+  CHECK_CUVS(cuvsRMMFree(res, x_d, sizeof(float) * N_ROWS * n_cols));
+  CHECK_CUVS(cuvsRMMFree(res, y_d, sizeof(float) * N_ROWS * n_cols));
 
 }
 
@@ -112,7 +114,7 @@ int euclidean_distance_calculation_example() {
   l2_distance_calc(DIM, (float *)PointA, (float *)PointB, &ret);
   printf("L2 distance is %f.\n", ret);
 
-  cuvsResourcesDestroy(res);
+  CHECK_CUVS(cuvsResourcesDestroy(res));
 
   return 0;
 }

--- a/examples/c/src/L2_c_example.c
+++ b/examples/c/src/L2_c_example.c
@@ -26,7 +26,7 @@
 
 #include "common.h"
 
-#define DIM 4
+#define DIM    4
 #define N_ROWS 1
 
 float PointA[N_ROWS][DIM] = {{1.0, 2.0, 3.0, 4.0}};
@@ -34,7 +34,8 @@ float PointB[N_ROWS][DIM] = {{2.0, 3.0, 4.0, 5.0}};
 
 cuvsResources_t res;
 
-void outputVector(float *Vec) {
+void outputVector(float* Vec)
+{
   printf("Vector is ");
   for (int i = 0; i < DIM; ++i) {
     printf(" %f", Vec[i]);
@@ -50,16 +51,16 @@ void outputVector(float *Vec) {
  * and columns of vectors.
  * @param[out] x_tensor Stores the initialized DLManagedTensor.
  */
-void tensor_initialize(float *x_d, int64_t x_shape[2],
-                       DLManagedTensor *x_tensor) {
-  x_tensor->dl_tensor.data = x_d;
+void tensor_initialize(float* x_d, int64_t x_shape[2], DLManagedTensor* x_tensor)
+{
+  x_tensor->dl_tensor.data               = x_d;
   x_tensor->dl_tensor.device.device_type = kDLCUDA;
-  x_tensor->dl_tensor.ndim = 2;
-  x_tensor->dl_tensor.dtype.code = kDLFloat;
-  x_tensor->dl_tensor.dtype.bits = 32;
-  x_tensor->dl_tensor.dtype.lanes = 1;
-  x_tensor->dl_tensor.shape = x_shape;
-  x_tensor->dl_tensor.strides = NULL;
+  x_tensor->dl_tensor.ndim               = 2;
+  x_tensor->dl_tensor.dtype.code         = kDLFloat;
+  x_tensor->dl_tensor.dtype.bits         = 32;
+  x_tensor->dl_tensor.dtype.lanes        = 1;
+  x_tensor->dl_tensor.shape              = x_shape;
+  x_tensor->dl_tensor.strides            = NULL;
 }
 
 /**
@@ -70,19 +71,17 @@ void tensor_initialize(float *x_d, int64_t x_shape[2],
  * @param[in] y[] Pointer to another vector
  * @param[out] ret will store the result about the euclidean distance
  */
-void l2_distance_calc(int64_t n_cols, float x[], float y[], float *ret) {
+void l2_distance_calc(int64_t n_cols, float x[], float y[], float* ret)
+{
   float *x_d, *y_d;
-  float *distance_d;
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&x_d, sizeof(float) * N_ROWS * n_cols));
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&y_d, sizeof(float) * N_ROWS * n_cols));
-  CHECK_CUVS(
-      cuvsRMMAlloc(res, (void **)&distance_d, sizeof(float) * N_ROWS * N_ROWS));
+  float* distance_d;
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**)&x_d, sizeof(float) * N_ROWS * n_cols));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**)&y_d, sizeof(float) * N_ROWS * n_cols));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**)&distance_d, sizeof(float) * N_ROWS * N_ROWS));
 
   // Use DLPack to represent x[] and y[] as tensors
-  CHECK_CUDA(
-      cudaMemcpy(x_d, x, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault));
-  CHECK_CUDA(
-      cudaMemcpy(y_d, y, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(x_d, x, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(y_d, y, sizeof(float) * N_ROWS * n_cols, cudaMemcpyDefault));
 
   DLManagedTensor x_tensor;
   int64_t x_shape[2] = {N_ROWS, n_cols};
@@ -97,27 +96,26 @@ void l2_distance_calc(int64_t n_cols, float x[], float y[], float *ret) {
   tensor_initialize(distance_d, distances_shape, &dist_tensor);
 
   // metric_arg default value is 2.0,used for Minkowski distance
-  CHECK_CUVS(cuvsPairwiseDistance(res, &x_tensor, &y_tensor, &dist_tensor,
-                                  L2SqrtUnexpanded, 2.0));
+  CHECK_CUVS(cuvsPairwiseDistance(res, &x_tensor, &y_tensor, &dist_tensor, L2SqrtUnexpanded, 2.0));
 
-  CHECK_CUDA(cudaMemcpy(ret, distance_d, sizeof(float) * N_ROWS * N_ROWS,
-                        cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(ret, distance_d, sizeof(float) * N_ROWS * N_ROWS, cudaMemcpyDefault));
 
   CHECK_CUVS(cuvsRMMFree(res, distance_d, sizeof(float) * N_ROWS * N_ROWS));
   CHECK_CUVS(cuvsRMMFree(res, x_d, sizeof(float) * N_ROWS * n_cols));
   CHECK_CUVS(cuvsRMMFree(res, y_d, sizeof(float) * N_ROWS * n_cols));
 }
 
-int euclidean_distance_calculation_example() {
+int euclidean_distance_calculation_example()
+{
   // Create a cuvsResources_t object
   cuvsResourcesCreate(&res);
 
-  outputVector((float *)PointA);
-  outputVector((float *)PointB);
+  outputVector((float*)PointA);
+  outputVector((float*)PointB);
 
   float ret;
 
-  l2_distance_calc(DIM, (float *)PointA, (float *)PointB, &ret);
+  l2_distance_calc(DIM, (float*)PointA, (float*)PointB, &ret);
   printf("L2 distance is %f.\n", ret);
 
   CHECK_CUVS(cuvsResourcesDestroy(res));
@@ -125,7 +123,8 @@ int euclidean_distance_calculation_example() {
   return 0;
 }
 
-int main() {
+int main()
+{
   euclidean_distance_calculation_example();
   return 0;
 }

--- a/examples/c/src/cagra_c_example.c
+++ b/examples/c/src/cagra_c_example.c
@@ -34,11 +34,11 @@ float queries[4][2] = {{0.48216683, 0.0428398},
                        {0.51260436, 0.2643005},
                        {0.05198065, 0.5789965}};
 
-void cagra_build_search_simple() {
-
-  int64_t n_rows = 4;
-  int64_t n_cols = 2;
-  int64_t topk = 2;
+void cagra_build_search_simple()
+{
+  int64_t n_rows    = 4;
+  int64_t n_cols    = 2;
+  int64_t topk      = 2;
   int64_t n_queries = 4;
 
   // Create a cuvsResources_t object
@@ -47,15 +47,15 @@ void cagra_build_search_simple() {
 
   // Use DLPack to represent `dataset` as a tensor
   DLManagedTensor dataset_tensor;
-  dataset_tensor.dl_tensor.data = dataset;
+  dataset_tensor.dl_tensor.data               = dataset;
   dataset_tensor.dl_tensor.device.device_type = kDLCPU;
-  dataset_tensor.dl_tensor.ndim = 2;
-  dataset_tensor.dl_tensor.dtype.code = kDLFloat;
-  dataset_tensor.dl_tensor.dtype.bits = 32;
-  dataset_tensor.dl_tensor.dtype.lanes = 1;
-  int64_t dataset_shape[2] = {n_rows, n_cols};
-  dataset_tensor.dl_tensor.shape = dataset_shape;
-  dataset_tensor.dl_tensor.strides = NULL;
+  dataset_tensor.dl_tensor.ndim               = 2;
+  dataset_tensor.dl_tensor.dtype.code         = kDLFloat;
+  dataset_tensor.dl_tensor.dtype.bits         = 32;
+  dataset_tensor.dl_tensor.dtype.lanes        = 1;
+  int64_t dataset_shape[2]                    = {n_rows, n_cols};
+  dataset_tensor.dl_tensor.shape              = dataset_shape;
+  dataset_tensor.dl_tensor.strides            = NULL;
 
   // Build the CAGRA index
   cuvsCagraIndexParams_t index_params;
@@ -67,51 +67,47 @@ void cagra_build_search_simple() {
   CHECK_CUVS(cuvsCagraBuild(res, index_params, &dataset_tensor, index));
 
   // Allocate memory for `queries`, `neighbors` and `distances` output
-  uint32_t *neighbors;
+  uint32_t* neighbors;
   float *distances, *queries_d;
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&queries_d,
-                          sizeof(float) * n_queries * n_cols));
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&neighbors,
-                          sizeof(uint32_t) * n_queries * topk));
-  CHECK_CUVS(
-      cuvsRMMAlloc(res, (void **)&distances, sizeof(float) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**)&queries_d, sizeof(float) * n_queries * n_cols));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**)&neighbors, sizeof(uint32_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**)&distances, sizeof(float) * n_queries * topk));
 
   // Use DLPack to represent `queries`, `neighbors` and `distances` as tensors
-  CHECK_CUDA(
-      cudaMemcpy(queries_d, queries, sizeof(float) * 4 * 2, cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(queries_d, queries, sizeof(float) * 4 * 2, cudaMemcpyDefault));
 
   DLManagedTensor queries_tensor;
-  queries_tensor.dl_tensor.data = queries_d;
+  queries_tensor.dl_tensor.data               = queries_d;
   queries_tensor.dl_tensor.device.device_type = kDLCUDA;
-  queries_tensor.dl_tensor.ndim = 2;
-  queries_tensor.dl_tensor.dtype.code = kDLFloat;
-  queries_tensor.dl_tensor.dtype.bits = 32;
-  queries_tensor.dl_tensor.dtype.lanes = 1;
-  int64_t queries_shape[2] = {n_queries, n_cols};
-  queries_tensor.dl_tensor.shape = queries_shape;
-  queries_tensor.dl_tensor.strides = NULL;
+  queries_tensor.dl_tensor.ndim               = 2;
+  queries_tensor.dl_tensor.dtype.code         = kDLFloat;
+  queries_tensor.dl_tensor.dtype.bits         = 32;
+  queries_tensor.dl_tensor.dtype.lanes        = 1;
+  int64_t queries_shape[2]                    = {n_queries, n_cols};
+  queries_tensor.dl_tensor.shape              = queries_shape;
+  queries_tensor.dl_tensor.strides            = NULL;
 
   DLManagedTensor neighbors_tensor;
-  neighbors_tensor.dl_tensor.data = neighbors;
+  neighbors_tensor.dl_tensor.data               = neighbors;
   neighbors_tensor.dl_tensor.device.device_type = kDLCUDA;
-  neighbors_tensor.dl_tensor.ndim = 2;
-  neighbors_tensor.dl_tensor.dtype.code = kDLUInt;
-  neighbors_tensor.dl_tensor.dtype.bits = 32;
-  neighbors_tensor.dl_tensor.dtype.lanes = 1;
-  int64_t neighbors_shape[2] = {n_queries, topk};
-  neighbors_tensor.dl_tensor.shape = neighbors_shape;
-  neighbors_tensor.dl_tensor.strides = NULL;
+  neighbors_tensor.dl_tensor.ndim               = 2;
+  neighbors_tensor.dl_tensor.dtype.code         = kDLUInt;
+  neighbors_tensor.dl_tensor.dtype.bits         = 32;
+  neighbors_tensor.dl_tensor.dtype.lanes        = 1;
+  int64_t neighbors_shape[2]                    = {n_queries, topk};
+  neighbors_tensor.dl_tensor.shape              = neighbors_shape;
+  neighbors_tensor.dl_tensor.strides            = NULL;
 
   DLManagedTensor distances_tensor;
-  distances_tensor.dl_tensor.data = distances;
+  distances_tensor.dl_tensor.data               = distances;
   distances_tensor.dl_tensor.device.device_type = kDLCUDA;
-  distances_tensor.dl_tensor.ndim = 2;
-  distances_tensor.dl_tensor.dtype.code = kDLFloat;
-  distances_tensor.dl_tensor.dtype.bits = 32;
-  distances_tensor.dl_tensor.dtype.lanes = 1;
-  int64_t distances_shape[2] = {n_queries, topk};
-  distances_tensor.dl_tensor.shape = distances_shape;
-  distances_tensor.dl_tensor.strides = NULL;
+  distances_tensor.dl_tensor.ndim               = 2;
+  distances_tensor.dl_tensor.dtype.code         = kDLFloat;
+  distances_tensor.dl_tensor.dtype.bits         = 32;
+  distances_tensor.dl_tensor.dtype.lanes        = 1;
+  int64_t distances_shape[2]                    = {n_queries, topk};
+  distances_tensor.dl_tensor.shape              = distances_shape;
+  distances_tensor.dl_tensor.strides            = NULL;
 
   // Search the CAGRA index
   cuvsCagraSearchParams_t search_params;
@@ -121,22 +117,18 @@ void cagra_build_search_simple() {
   filter.type = NO_FILTER;
   filter.addr = (uintptr_t)NULL;
 
-  CHECK_CUVS(cuvsCagraSearch(res, search_params, index, &queries_tensor,
-                             &neighbors_tensor, &distances_tensor, filter));
+  CHECK_CUVS(cuvsCagraSearch(
+    res, search_params, index, &queries_tensor, &neighbors_tensor, &distances_tensor, filter));
 
   // print results
-  uint32_t *neighbors_h =
-      (uint32_t *)malloc(sizeof(uint32_t) * n_queries * topk);
-  float *distances_h = (float *)malloc(sizeof(float) * n_queries * topk);
-  CHECK_CUDA(cudaMemcpy(neighbors_h, neighbors,
-                        sizeof(uint32_t) * n_queries * topk,
-                        cudaMemcpyDefault));
-  CHECK_CUDA(cudaMemcpy(distances_h, distances,
-                        sizeof(float) * n_queries * topk, cudaMemcpyDefault));
-  printf("Query 0 neighbor indices: =[%d, %d]\n", neighbors_h[0],
-         neighbors_h[1]);
-  printf("Query 0 neighbor distances: =[%f, %f]\n", distances_h[0],
-         distances_h[1]);
+  uint32_t* neighbors_h = (uint32_t*)malloc(sizeof(uint32_t) * n_queries * topk);
+  float* distances_h    = (float*)malloc(sizeof(float) * n_queries * topk);
+  CHECK_CUDA(
+    cudaMemcpy(neighbors_h, neighbors, sizeof(uint32_t) * n_queries * topk, cudaMemcpyDefault));
+  CHECK_CUDA(
+    cudaMemcpy(distances_h, distances, sizeof(float) * n_queries * topk, cudaMemcpyDefault));
+  printf("Query 0 neighbor indices: =[%d, %d]\n", neighbors_h[0], neighbors_h[1]);
+  printf("Query 0 neighbor distances: =[%f, %f]\n", distances_h[0], distances_h[1]);
 
   // Free or destroy all allocations
   free(neighbors_h);
@@ -153,7 +145,8 @@ void cagra_build_search_simple() {
   CHECK_CUVS(cuvsResourcesDestroy(res));
 }
 
-int main() {
+int main()
+{
   // Simple build and search example.
   cagra_build_search_simple();
 }

--- a/examples/c/src/cagra_c_example.c
+++ b/examples/c/src/cagra_c_example.c
@@ -69,12 +69,16 @@ void cagra_build_search_simple() {
   // Allocate memory for `queries`, `neighbors` and `distances` output
   uint32_t *neighbors;
   float *distances, *queries_d;
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&queries_d, sizeof(float) * n_queries * n_cols));
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&neighbors, sizeof(uint32_t) * n_queries * topk));
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&distances, sizeof(float) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&queries_d,
+                          sizeof(float) * n_queries * n_cols));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&neighbors,
+                          sizeof(uint32_t) * n_queries * topk));
+  CHECK_CUVS(
+      cuvsRMMAlloc(res, (void **)&distances, sizeof(float) * n_queries * topk));
 
   // Use DLPack to represent `queries`, `neighbors` and `distances` as tensors
-  CHECK_CUDA(cudaMemcpy(queries_d, queries, sizeof(float) * 4 * 2, cudaMemcpyDefault));
+  CHECK_CUDA(
+      cudaMemcpy(queries_d, queries, sizeof(float) * 4 * 2, cudaMemcpyDefault));
 
   DLManagedTensor queries_tensor;
   queries_tensor.dl_tensor.data = queries_d;
@@ -117,17 +121,18 @@ void cagra_build_search_simple() {
   filter.type = NO_FILTER;
   filter.addr = (uintptr_t)NULL;
 
-  CHECK_CUVS(cuvsCagraSearch(res, search_params, index, &queries_tensor, &neighbors_tensor,
-                  &distances_tensor, filter));
+  CHECK_CUVS(cuvsCagraSearch(res, search_params, index, &queries_tensor,
+                             &neighbors_tensor, &distances_tensor, filter));
 
   // print results
   uint32_t *neighbors_h =
       (uint32_t *)malloc(sizeof(uint32_t) * n_queries * topk);
   float *distances_h = (float *)malloc(sizeof(float) * n_queries * topk);
-  CHECK_CUDA(cudaMemcpy(neighbors_h, neighbors, sizeof(uint32_t) * n_queries * topk,
-             cudaMemcpyDefault));
-  CHECK_CUDA(cudaMemcpy(distances_h, distances, sizeof(float) * n_queries * topk,
-             cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(neighbors_h, neighbors,
+                        sizeof(uint32_t) * n_queries * topk,
+                        cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(distances_h, distances,
+                        sizeof(float) * n_queries * topk, cudaMemcpyDefault));
   printf("Query 0 neighbor indices: =[%d, %d]\n", neighbors_h[0],
          neighbors_h[1]);
   printf("Query 0 neighbor distances: =[%f, %f]\n", distances_h[0],

--- a/examples/c/src/common.h
+++ b/examples/c/src/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,22 @@
 #include <stdlib.h>
 #include <time.h>
 #include <string.h>
+
+inline void check_cuvs(cuvsError_t code, const char * file, int line) {
+  if (code != CUVS_SUCCESS) {
+    fprintf(stderr, "CuVS Error @ (%s: %i): %s", file, line, cuvsGetLastErrorText());
+    exit(1);
+  }
+}
+#define CHECK_CUVS(code) { check_cuvs(code, __FILE__, __LINE__); }
+
+inline void check_cuda(cudaError_t code, const char *file, int line) {
+  if (code != cudaSuccess) {
+    fprintf(stderr, "CUDA Error @ (%s: %i): %s", file, line, cudaGetErrorString(code));
+    exit(1);
+  }
+}
+#define CHECK_CUDA(code) { check_cuda(code, __FILE__, __LINE__); }
 
 /**
  * @brief Initialize Tensor for kDLFloat.

--- a/examples/c/src/common.h
+++ b/examples/c/src/common.h
@@ -22,28 +22,28 @@
 #include <string.h>
 #include <time.h>
 
-inline void check_cuvs(cuvsError_t code, const char *file, int line) {
+inline void check_cuvs(cuvsError_t code, const char* file, int line)
+{
   if (code != CUVS_SUCCESS) {
-    fprintf(stderr, "CuVS Error @ (%s: %i): %s", file, line,
-            cuvsGetLastErrorText());
+    fprintf(stderr, "CuVS Error @ (%s: %i): %s", file, line, cuvsGetLastErrorText());
     exit(1);
   }
 }
-#define CHECK_CUVS(code)                                                       \
-  {                                                                            \
-    check_cuvs(code, __FILE__, __LINE__);                                      \
+#define CHECK_CUVS(code)                  \
+  {                                       \
+    check_cuvs(code, __FILE__, __LINE__); \
   }
 
-inline void check_cuda(cudaError_t code, const char *file, int line) {
+inline void check_cuda(cudaError_t code, const char* file, int line)
+{
   if (code != cudaSuccess) {
-    fprintf(stderr, "CUDA Error @ (%s: %i): %s", file, line,
-            cudaGetErrorString(code));
+    fprintf(stderr, "CUDA Error @ (%s: %i): %s", file, line, cudaGetErrorString(code));
     exit(1);
   }
 }
-#define CHECK_CUDA(code)                                                       \
-  {                                                                            \
-    check_cuda(code, __FILE__, __LINE__);                                      \
+#define CHECK_CUDA(code)                  \
+  {                                       \
+    check_cuda(code, __FILE__, __LINE__); \
   }
 
 /**
@@ -54,16 +54,16 @@ inline void check_cuda(cudaError_t code, const char *file, int line) {
  * and columns of vectors.
  * @param[out] t_tensor Stores the initialized DLManagedTensor.
  */
-void float_tensor_initialize(float *t_d, int64_t t_shape[2],
-                             DLManagedTensor *t_tensor) {
-  t_tensor->dl_tensor.data = t_d;
+void float_tensor_initialize(float* t_d, int64_t t_shape[2], DLManagedTensor* t_tensor)
+{
+  t_tensor->dl_tensor.data               = t_d;
   t_tensor->dl_tensor.device.device_type = kDLCUDA;
-  t_tensor->dl_tensor.ndim = 2;
-  t_tensor->dl_tensor.dtype.code = kDLFloat;
-  t_tensor->dl_tensor.dtype.bits = 32;
-  t_tensor->dl_tensor.dtype.lanes = 1;
-  t_tensor->dl_tensor.shape = t_shape;
-  t_tensor->dl_tensor.strides = NULL;
+  t_tensor->dl_tensor.ndim               = 2;
+  t_tensor->dl_tensor.dtype.code         = kDLFloat;
+  t_tensor->dl_tensor.dtype.bits         = 32;
+  t_tensor->dl_tensor.dtype.lanes        = 1;
+  t_tensor->dl_tensor.shape              = t_shape;
+  t_tensor->dl_tensor.strides            = NULL;
 }
 
 /**
@@ -74,16 +74,16 @@ void float_tensor_initialize(float *t_d, int64_t t_shape[2],
  * and columns of vectors.
  * @param[out] t_tensor Stores the initialized DLManagedTensor.
  */
-void int_tensor_initialize(int64_t *t_d, int64_t t_shape[],
-                           DLManagedTensor *t_tensor) {
-  t_tensor->dl_tensor.data = t_d;
+void int_tensor_initialize(int64_t* t_d, int64_t t_shape[], DLManagedTensor* t_tensor)
+{
+  t_tensor->dl_tensor.data               = t_d;
   t_tensor->dl_tensor.device.device_type = kDLCUDA;
-  t_tensor->dl_tensor.ndim = 2;
-  t_tensor->dl_tensor.dtype.code = kDLInt;
-  t_tensor->dl_tensor.dtype.bits = 64;
-  t_tensor->dl_tensor.dtype.lanes = 1;
-  t_tensor->dl_tensor.shape = t_shape;
-  t_tensor->dl_tensor.strides = NULL;
+  t_tensor->dl_tensor.ndim               = 2;
+  t_tensor->dl_tensor.dtype.code         = kDLInt;
+  t_tensor->dl_tensor.dtype.bits         = 64;
+  t_tensor->dl_tensor.dtype.lanes        = 1;
+  t_tensor->dl_tensor.shape              = t_shape;
+  t_tensor->dl_tensor.strides            = NULL;
 }
 
 /**
@@ -95,16 +95,16 @@ void int_tensor_initialize(int64_t *t_d, int64_t t_shape[],
  * @param[in] min Minimum value among random values.
  * @param[in] max Maximum value among random values.
  */
-void generate_dataset(float *Vec, int n_rows, int n_cols, float min,
-                      float max) {
+void generate_dataset(float* Vec, int n_rows, int n_cols, float min, float max)
+{
   float scale;
-  float *ptr = Vec;
+  float* ptr = Vec;
   srand((unsigned int)time(NULL));
   for (int i = 0; i < n_rows; i++) {
     for (int j = 0; j < n_cols; j++) {
       scale = rand() / (float)RAND_MAX;
-      ptr = Vec + i * n_cols + j;
-      *ptr = min + scale * (max - min);
+      ptr   = Vec + i * n_cols + j;
+      *ptr  = min + scale * (max - min);
     }
   }
 }
@@ -117,10 +117,10 @@ void generate_dataset(float *Vec, int n_rows, int n_cols, float min,
  * @param[in] n_rows the number of rows in the matrix.
  * @param[in] n_cols the number of columns in the matrix.
  */
-void print_results(int64_t *neighbor, float *distances, int n_rows,
-                   int n_cols) {
-  int64_t *pn = neighbor;
-  float *pd = distances;
+void print_results(int64_t* neighbor, float* distances, int n_rows, int n_cols)
+{
+  int64_t* pn = neighbor;
+  float* pd   = distances;
   for (int i = 0; i < n_rows; ++i) {
     printf("Query %d neighbor indices: =[", i);
     for (int j = 0; j < n_cols; ++j) {

--- a/examples/c/src/common.h
+++ b/examples/c/src/common.h
@@ -19,33 +19,43 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 #include <string.h>
+#include <time.h>
 
-inline void check_cuvs(cuvsError_t code, const char * file, int line) {
+inline void check_cuvs(cuvsError_t code, const char *file, int line) {
   if (code != CUVS_SUCCESS) {
-    fprintf(stderr, "CuVS Error @ (%s: %i): %s", file, line, cuvsGetLastErrorText());
+    fprintf(stderr, "CuVS Error @ (%s: %i): %s", file, line,
+            cuvsGetLastErrorText());
     exit(1);
   }
 }
-#define CHECK_CUVS(code) { check_cuvs(code, __FILE__, __LINE__); }
+#define CHECK_CUVS(code)                                                       \
+  {                                                                            \
+    check_cuvs(code, __FILE__, __LINE__);                                      \
+  }
 
 inline void check_cuda(cudaError_t code, const char *file, int line) {
   if (code != cudaSuccess) {
-    fprintf(stderr, "CUDA Error @ (%s: %i): %s", file, line, cudaGetErrorString(code));
+    fprintf(stderr, "CUDA Error @ (%s: %i): %s", file, line,
+            cudaGetErrorString(code));
     exit(1);
   }
 }
-#define CHECK_CUDA(code) { check_cuda(code, __FILE__, __LINE__); }
+#define CHECK_CUDA(code)                                                       \
+  {                                                                            \
+    check_cuda(code, __FILE__, __LINE__);                                      \
+  }
 
 /**
  * @brief Initialize Tensor for kDLFloat.
  *
  * @param[in] t_d Pointer to a vector
- * @param[in] t_shape[] Two-dimensional array, which stores the number of rows and columns of vectors.
+ * @param[in] t_shape[] Two-dimensional array, which stores the number of rows
+ * and columns of vectors.
  * @param[out] t_tensor Stores the initialized DLManagedTensor.
  */
-void float_tensor_initialize(float* t_d, int64_t t_shape[2], DLManagedTensor* t_tensor) {
+void float_tensor_initialize(float *t_d, int64_t t_shape[2],
+                             DLManagedTensor *t_tensor) {
   t_tensor->dl_tensor.data = t_d;
   t_tensor->dl_tensor.device.device_type = kDLCUDA;
   t_tensor->dl_tensor.ndim = 2;
@@ -60,10 +70,12 @@ void float_tensor_initialize(float* t_d, int64_t t_shape[2], DLManagedTensor* t_
  * @brief Initialize Tensor for kDLInt.
  *
  * @param[in] t_d Pointer to a vector
- * @param[in] t_shape[] Two-dimensional array, which stores the number of rows and columns of vectors.
+ * @param[in] t_shape[] Two-dimensional array, which stores the number of rows
+ * and columns of vectors.
  * @param[out] t_tensor Stores the initialized DLManagedTensor.
  */
-void int_tensor_initialize(int64_t* t_d, int64_t t_shape[], DLManagedTensor* t_tensor) {
+void int_tensor_initialize(int64_t *t_d, int64_t t_shape[],
+                           DLManagedTensor *t_tensor) {
   t_tensor->dl_tensor.data = t_d;
   t_tensor->dl_tensor.device.device_type = kDLCUDA;
   t_tensor->dl_tensor.ndim = 2;
@@ -83,17 +95,18 @@ void int_tensor_initialize(int64_t* t_d, int64_t t_shape[], DLManagedTensor* t_t
  * @param[in] min Minimum value among random values.
  * @param[in] max Maximum value among random values.
  */
-void generate_dataset(float * Vec,int n_rows, int n_cols, float min, float max) {
-    float scale;
-    float * ptr = Vec;
-    srand((unsigned int)time(NULL));
-    for (int i = 0; i < n_rows; i++) {
-        for (int j = 0; j < n_cols; j++) {
-            scale = rand()/(float)RAND_MAX;
-            ptr = Vec + i * n_cols + j;
-            *ptr = min + scale * (max - min);
-        }
+void generate_dataset(float *Vec, int n_rows, int n_cols, float min,
+                      float max) {
+  float scale;
+  float *ptr = Vec;
+  srand((unsigned int)time(NULL));
+  for (int i = 0; i < n_rows; i++) {
+    for (int j = 0; j < n_cols; j++) {
+      scale = rand() / (float)RAND_MAX;
+      ptr = Vec + i * n_cols + j;
+      *ptr = min + scale * (max - min);
     }
+  }
 }
 
 /**
@@ -104,21 +117,22 @@ void generate_dataset(float * Vec,int n_rows, int n_cols, float min, float max) 
  * @param[in] n_rows the number of rows in the matrix.
  * @param[in] n_cols the number of columns in the matrix.
  */
-void print_results(int64_t * neighbor, float* distances,int n_rows, int n_cols) {
-    int64_t * pn = neighbor;
-    float * pd = distances;
-    for (int i = 0; i < n_rows; ++i) {
-        printf("Query %d neighbor indices: =[", i);
-        for (int j = 0; j < n_cols; ++j) {
-            pn = neighbor + i * n_cols + j;
-            printf(" %ld", *pn);
-        }
-        printf("]\n");
-        printf("Query %d neighbor distances: =[", i);
-        for (int j = 0; j < n_cols; ++j) {
-            pd = distances + i * n_cols + j;
-            printf(" %f", *pd);
-        }
-        printf("]\n");
+void print_results(int64_t *neighbor, float *distances, int n_rows,
+                   int n_cols) {
+  int64_t *pn = neighbor;
+  float *pd = distances;
+  for (int i = 0; i < n_rows; ++i) {
+    printf("Query %d neighbor indices: =[", i);
+    for (int j = 0; j < n_cols; ++j) {
+      pn = neighbor + i * n_cols + j;
+      printf(" %ld", *pn);
     }
+    printf("]\n");
+    printf("Query %d neighbor distances: =[", i);
+    for (int j = 0; j < n_cols; ++j) {
+      pd = distances + i * n_cols + j;
+      printf(" %f", *pd);
+    }
+    printf("]\n");
+  }
 }

--- a/examples/c/src/ivf_flat_c_example.c
+++ b/examples/c/src/ivf_flat_c_example.c
@@ -17,234 +17,254 @@
 #include <cuvs/core/c_api.h>
 #include <cuvs/neighbors/ivf_flat.h>
 
-#include <cuda_runtime.h>
 #include "common.h"
+#include <cuda_runtime.h>
 
-void ivf_flat_build_search_simple(cuvsResources_t *res, DLManagedTensor * dataset_tensor, DLManagedTensor * queries_tensor) {
-    // Create default index params
-    cuvsIvfFlatIndexParams_t index_params;
-    CHECK_CUVS(cuvsIvfFlatIndexParamsCreate(&index_params));
-    index_params->n_lists                  = 1024; // default value
-    index_params->kmeans_n_iters = 20; // default value
-    index_params->kmeans_trainset_fraction = 0.1;
-    //index_params->metric default is L2Expanded
+void ivf_flat_build_search_simple(cuvsResources_t *res,
+                                  DLManagedTensor *dataset_tensor,
+                                  DLManagedTensor *queries_tensor) {
+  // Create default index params
+  cuvsIvfFlatIndexParams_t index_params;
+  CHECK_CUVS(cuvsIvfFlatIndexParamsCreate(&index_params));
+  index_params->n_lists = 1024;      // default value
+  index_params->kmeans_n_iters = 20; // default value
+  index_params->kmeans_trainset_fraction = 0.1;
+  // index_params->metric default is L2Expanded
 
-    // Create IVF-Flat index
-    cuvsIvfFlatIndex_t index;
-    CHECK_CUVS(cuvsIvfFlatIndexCreate(&index));
+  // Create IVF-Flat index
+  cuvsIvfFlatIndex_t index;
+  CHECK_CUVS(cuvsIvfFlatIndexCreate(&index));
 
-    printf("Building IVF-Flat index\n");
-    // Build the IVF-Flat Index
-    CHECK_CUVS(cuvsIvfFlatBuild(*res, index_params, dataset_tensor, index));
+  printf("Building IVF-Flat index\n");
+  // Build the IVF-Flat Index
+  CHECK_CUVS(cuvsIvfFlatBuild(*res, index_params, dataset_tensor, index));
 
-    // Create output arrays.
-    int64_t topk      = 10;
-    int64_t n_queries = queries_tensor->dl_tensor.shape[0];
+  // Create output arrays.
+  int64_t topk = 10;
+  int64_t n_queries = queries_tensor->dl_tensor.shape[0];
 
-    //Allocate memory for `neighbors` and `distances` output
-    int64_t *neighbors_d;
-    float *distances_d;
-    CHECK_CUVS(cuvsRMMAlloc(*res, (void**) &neighbors_d, sizeof(int64_t) * n_queries * topk));
-    CHECK_CUVS(cuvsRMMAlloc(*res, (void**) &distances_d, sizeof(float) * n_queries * topk));
+  // Allocate memory for `neighbors` and `distances` output
+  int64_t *neighbors_d;
+  float *distances_d;
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&neighbors_d,
+                          sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&distances_d,
+                          sizeof(float) * n_queries * topk));
 
-    DLManagedTensor neighbors_tensor;
-    int64_t neighbors_shape[2] = {n_queries, topk};
-    int_tensor_initialize(neighbors_d, neighbors_shape, &neighbors_tensor);
+  DLManagedTensor neighbors_tensor;
+  int64_t neighbors_shape[2] = {n_queries, topk};
+  int_tensor_initialize(neighbors_d, neighbors_shape, &neighbors_tensor);
 
-    DLManagedTensor distances_tensor;
-    int64_t distances_shape[2] = {n_queries, topk};
-    float_tensor_initialize(distances_d, distances_shape, &distances_tensor);
+  DLManagedTensor distances_tensor;
+  int64_t distances_shape[2] = {n_queries, topk};
+  float_tensor_initialize(distances_d, distances_shape, &distances_tensor);
 
-    // Create default search params
-    cuvsIvfFlatSearchParams_t search_params;
-    CHECK_CUVS(cuvsIvfFlatSearchParamsCreate(&search_params));
-    search_params->n_probes = 50;
+  // Create default search params
+  cuvsIvfFlatSearchParams_t search_params;
+  CHECK_CUVS(cuvsIvfFlatSearchParamsCreate(&search_params));
+  search_params->n_probes = 50;
 
-    // Search the `index` built using `ivfFlatBuild`
-    cuvsFilter filter;
-    filter.type = NO_FILTER;
-    filter.addr = (uintptr_t)NULL;
+  // Search the `index` built using `ivfFlatBuild`
+  cuvsFilter filter;
+  filter.type = NO_FILTER;
+  filter.addr = (uintptr_t)NULL;
 
-    CHECK_CUVS(cuvsIvfFlatSearch(*res, search_params, index,
-     queries_tensor, &neighbors_tensor, &distances_tensor, filter));
+  CHECK_CUVS(cuvsIvfFlatSearch(*res, search_params, index, queries_tensor,
+                               &neighbors_tensor, &distances_tensor, filter));
 
-    int64_t *neighbors = (int64_t *)malloc(n_queries * topk * sizeof(int64_t));
-    float *distances = (float *)malloc(n_queries * topk * sizeof(float));
-    memset(neighbors, 0, n_queries * topk * sizeof(int64_t));
-    memset(distances, 0, n_queries * topk * sizeof(float));
+  int64_t *neighbors = (int64_t *)malloc(n_queries * topk * sizeof(int64_t));
+  float *distances = (float *)malloc(n_queries * topk * sizeof(float));
+  memset(neighbors, 0, n_queries * topk * sizeof(int64_t));
+  memset(distances, 0, n_queries * topk * sizeof(float));
 
-    CHECK_CUDA(cudaMemcpy(neighbors, neighbors_d, sizeof(int64_t) * n_queries * topk,
-    cudaMemcpyDefault));
-    CHECK_CUDA(cudaMemcpy(distances, distances_d, sizeof(float) * n_queries * topk,
-    cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(neighbors, neighbors_d,
+                        sizeof(int64_t) * n_queries * topk, cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(distances, distances_d,
+                        sizeof(float) * n_queries * topk, cudaMemcpyDefault));
 
-    print_results(neighbors, distances, 2, topk);
+  print_results(neighbors, distances, 2, topk);
 
-    free(distances);
-    free(neighbors);
+  free(distances);
+  free(neighbors);
 
-    CHECK_CUVS(cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
-    CHECK_CUVS(cuvsRMMFree(*res, distances_d, sizeof(float) * n_queries * topk));
+  CHECK_CUVS(
+      cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMFree(*res, distances_d, sizeof(float) * n_queries * topk));
 
-    CHECK_CUVS(cuvsIvfFlatSearchParamsDestroy(search_params));
-    CHECK_CUVS(cuvsIvfFlatIndexDestroy(index));
-    CHECK_CUVS(cuvsIvfFlatIndexParamsDestroy(index_params));
+  CHECK_CUVS(cuvsIvfFlatSearchParamsDestroy(search_params));
+  CHECK_CUVS(cuvsIvfFlatIndexDestroy(index));
+  CHECK_CUVS(cuvsIvfFlatIndexParamsDestroy(index_params));
 }
 
-void ivf_flat_build_extend_search(cuvsResources_t *res, DLManagedTensor * trainset_tensor, DLManagedTensor * dataset_tensor, DLManagedTensor * queries_tensor) {
-    int64_t *data_indices_d;
-    int64_t n_dataset = dataset_tensor->dl_tensor.shape[0];
-    CHECK_CUVS(cuvsRMMAlloc(*res, (void**) &data_indices_d, sizeof(int64_t) * n_dataset));
-    DLManagedTensor data_indices_tensor;
-    int64_t data_indices_shape[1] = {n_dataset};
-    int_tensor_initialize(data_indices_d, data_indices_shape, &data_indices_tensor);
-    data_indices_tensor.dl_tensor.ndim = 1;
+void ivf_flat_build_extend_search(cuvsResources_t *res,
+                                  DLManagedTensor *trainset_tensor,
+                                  DLManagedTensor *dataset_tensor,
+                                  DLManagedTensor *queries_tensor) {
+  int64_t *data_indices_d;
+  int64_t n_dataset = dataset_tensor->dl_tensor.shape[0];
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&data_indices_d,
+                          sizeof(int64_t) * n_dataset));
+  DLManagedTensor data_indices_tensor;
+  int64_t data_indices_shape[1] = {n_dataset};
+  int_tensor_initialize(data_indices_d, data_indices_shape,
+                        &data_indices_tensor);
+  data_indices_tensor.dl_tensor.ndim = 1;
 
-    printf("\nRun k-means clustering using the training set\n");
+  printf("\nRun k-means clustering using the training set\n");
 
-    int64_t *data_indices = (int64_t *)malloc(n_dataset * sizeof(int64_t));
-    int64_t * ptr = data_indices;
-    for (int i = 0; i < n_dataset; i++) {
-        *ptr = i;
-        ptr++;
-    }
-    ptr = NULL;
-    cudaMemcpy(data_indices_d, data_indices, sizeof(int64_t) * n_dataset, cudaMemcpyDefault);
+  int64_t *data_indices = (int64_t *)malloc(n_dataset * sizeof(int64_t));
+  int64_t *ptr = data_indices;
+  for (int i = 0; i < n_dataset; i++) {
+    *ptr = i;
+    ptr++;
+  }
+  ptr = NULL;
+  cudaMemcpy(data_indices_d, data_indices, sizeof(int64_t) * n_dataset,
+             cudaMemcpyDefault);
 
-    // Create default index params
-    cuvsIvfFlatIndexParams_t index_params;
-    CHECK_CUVS(cuvsIvfFlatIndexParamsCreate(&index_params));
-    index_params->n_lists                  = 100;
-    index_params->add_data_on_build = false;
-    //index_params->metric default is L2Expanded
+  // Create default index params
+  cuvsIvfFlatIndexParams_t index_params;
+  CHECK_CUVS(cuvsIvfFlatIndexParamsCreate(&index_params));
+  index_params->n_lists = 100;
+  index_params->add_data_on_build = false;
+  // index_params->metric default is L2Expanded
 
-    // Create IVF-Flat index
-    cuvsIvfFlatIndex_t index;
-    CHECK_CUVS(cuvsIvfFlatIndexCreate(&index));
+  // Create IVF-Flat index
+  cuvsIvfFlatIndex_t index;
+  CHECK_CUVS(cuvsIvfFlatIndexCreate(&index));
 
-    // Build the IVF-Flat Index
-    CHECK_CUVS(cuvsIvfFlatBuild(*res, index_params, trainset_tensor, index));
+  // Build the IVF-Flat Index
+  CHECK_CUVS(cuvsIvfFlatBuild(*res, index_params, trainset_tensor, index));
 
-    printf("Filling index with the dataset vectors\n");
-    CHECK_CUVS(cuvsIvfFlatExtend(*res, dataset_tensor, &data_indices_tensor, index));
+  printf("Filling index with the dataset vectors\n");
+  CHECK_CUVS(
+      cuvsIvfFlatExtend(*res, dataset_tensor, &data_indices_tensor, index));
 
-    // Create output arrays.
-    int64_t topk      = 10;
-    int64_t n_queries = queries_tensor->dl_tensor.shape[0];
+  // Create output arrays.
+  int64_t topk = 10;
+  int64_t n_queries = queries_tensor->dl_tensor.shape[0];
 
-    //Allocate memory for `neighbors` and `distances` output
-    int64_t *neighbors_d;
-    float *distances_d;
-    CHECK_CUVS(cuvsRMMAlloc(*res, (void**) &neighbors_d, sizeof(int64_t) * n_queries * topk));
-    CHECK_CUVS(cuvsRMMAlloc(*res, (void**) &distances_d, sizeof(float) * n_queries * topk));
+  // Allocate memory for `neighbors` and `distances` output
+  int64_t *neighbors_d;
+  float *distances_d;
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&neighbors_d,
+                          sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&distances_d,
+                          sizeof(float) * n_queries * topk));
 
-    DLManagedTensor neighbors_tensor;
-    int64_t neighbors_shape[2] = {n_queries, topk};
-    int_tensor_initialize(neighbors_d, neighbors_shape, &neighbors_tensor);
+  DLManagedTensor neighbors_tensor;
+  int64_t neighbors_shape[2] = {n_queries, topk};
+  int_tensor_initialize(neighbors_d, neighbors_shape, &neighbors_tensor);
 
-    DLManagedTensor distances_tensor;
-    int64_t distances_shape[2] = {n_queries, topk};
-    float_tensor_initialize(distances_d, distances_shape, &distances_tensor);
+  DLManagedTensor distances_tensor;
+  int64_t distances_shape[2] = {n_queries, topk};
+  float_tensor_initialize(distances_d, distances_shape, &distances_tensor);
 
-    // Create default search params
-    cuvsIvfFlatSearchParams_t search_params;
-    CHECK_CUVS(cuvsIvfFlatSearchParamsCreate(&search_params));
-    search_params->n_probes = 10;
+  // Create default search params
+  cuvsIvfFlatSearchParams_t search_params;
+  CHECK_CUVS(cuvsIvfFlatSearchParamsCreate(&search_params));
+  search_params->n_probes = 10;
 
-    // Search the `index` built using `ivfFlatBuild`
-    cuvsFilter filter;
-    filter.type = NO_FILTER;
-    filter.addr = (uintptr_t)NULL;
-    CHECK_CUVS(cuvsIvfFlatSearch(*res, search_params, index,
-     queries_tensor, &neighbors_tensor, &distances_tensor, filter));
+  // Search the `index` built using `ivfFlatBuild`
+  cuvsFilter filter;
+  filter.type = NO_FILTER;
+  filter.addr = (uintptr_t)NULL;
+  CHECK_CUVS(cuvsIvfFlatSearch(*res, search_params, index, queries_tensor,
+                               &neighbors_tensor, &distances_tensor, filter));
 
-    int64_t *neighbors = (int64_t *)malloc(n_queries * topk * sizeof(int64_t));
-    float *distances = (float *)malloc(n_queries * topk * sizeof(float));
-    memset(neighbors, 0, n_queries * topk * sizeof(int64_t));
-    memset(distances, 0, n_queries * topk * sizeof(float));
+  int64_t *neighbors = (int64_t *)malloc(n_queries * topk * sizeof(int64_t));
+  float *distances = (float *)malloc(n_queries * topk * sizeof(float));
+  memset(neighbors, 0, n_queries * topk * sizeof(int64_t));
+  memset(distances, 0, n_queries * topk * sizeof(float));
 
-    CHECK_CUDA(cudaMemcpy(neighbors, neighbors_d, sizeof(int64_t) * n_queries * topk,
-    cudaMemcpyDefault));
-    CHECK_CUDA(cudaMemcpy(distances, distances_d, sizeof(float) * n_queries * topk,
-    cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(neighbors, neighbors_d,
+                        sizeof(int64_t) * n_queries * topk, cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(distances, distances_d,
+                        sizeof(float) * n_queries * topk, cudaMemcpyDefault));
 
-    print_results(neighbors, distances, 2, topk);
+  print_results(neighbors, distances, 2, topk);
 
-    free(distances);
-    free(neighbors);
-    free(data_indices);
-    CHECK_CUVS(cuvsRMMFree(*res, data_indices_d, sizeof(int64_t) * n_dataset));
-    CHECK_CUVS(cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
-    CHECK_CUVS(cuvsRMMFree(*res, distances_d, sizeof(float) * n_queries * topk));
+  free(distances);
+  free(neighbors);
+  free(data_indices);
+  CHECK_CUVS(cuvsRMMFree(*res, data_indices_d, sizeof(int64_t) * n_dataset));
+  CHECK_CUVS(
+      cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMFree(*res, distances_d, sizeof(float) * n_queries * topk));
 
-    CHECK_CUVS(cuvsIvfFlatSearchParamsDestroy(search_params));
-    CHECK_CUVS(cuvsIvfFlatIndexDestroy(index));
+  CHECK_CUVS(cuvsIvfFlatSearchParamsDestroy(search_params));
+  CHECK_CUVS(cuvsIvfFlatIndexDestroy(index));
 
-    CHECK_CUVS(cuvsIvfFlatIndexParamsDestroy(index_params));
+  CHECK_CUVS(cuvsIvfFlatIndexParamsDestroy(index_params));
 }
 
 int main() {
-    // Create input arrays.
-    int64_t n_samples = 10000;
-    int64_t n_dim     = 3;
-    int64_t n_queries = 10;
-    float *dataset = (float *)malloc(n_samples * n_dim * sizeof(float));
-    float *queries = (float *)malloc(n_queries * n_dim * sizeof(float));
-    generate_dataset(dataset, n_samples, n_dim, -10.0, 10.0);
-    generate_dataset(queries, n_queries, n_dim, -1.0, 1.0);
+  // Create input arrays.
+  int64_t n_samples = 10000;
+  int64_t n_dim = 3;
+  int64_t n_queries = 10;
+  float *dataset = (float *)malloc(n_samples * n_dim * sizeof(float));
+  float *queries = (float *)malloc(n_queries * n_dim * sizeof(float));
+  generate_dataset(dataset, n_samples, n_dim, -10.0, 10.0);
+  generate_dataset(queries, n_queries, n_dim, -1.0, 1.0);
 
-    // Create a cuvsResources_t object
-    cuvsResources_t res;
-    cuvsResourcesCreate(&res);
+  // Create a cuvsResources_t object
+  cuvsResources_t res;
+  cuvsResourcesCreate(&res);
 
-    // Allocate memory for `queries`
-    float *dataset_d;
-    CHECK_CUVS(cuvsRMMAlloc(res, (void**) &dataset_d, sizeof(float) * n_samples * n_dim));
-    // Use DLPack to represent `dataset_d` as a tensor
-    CHECK_CUDA(cudaMemcpy(dataset_d, dataset, sizeof(float) * n_samples * n_dim,
-    cudaMemcpyDefault));
+  // Allocate memory for `queries`
+  float *dataset_d;
+  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&dataset_d,
+                          sizeof(float) * n_samples * n_dim));
+  // Use DLPack to represent `dataset_d` as a tensor
+  CHECK_CUDA(cudaMemcpy(dataset_d, dataset, sizeof(float) * n_samples * n_dim,
+                        cudaMemcpyDefault));
 
-    DLManagedTensor dataset_tensor;
-    int64_t dataset_shape[2] = {n_samples,n_dim};
-    float_tensor_initialize(dataset_d, dataset_shape, &dataset_tensor);
+  DLManagedTensor dataset_tensor;
+  int64_t dataset_shape[2] = {n_samples, n_dim};
+  float_tensor_initialize(dataset_d, dataset_shape, &dataset_tensor);
 
-    // Allocate memory for `queries`
-    float *queries_d;
-    CHECK_CUVS(cuvsRMMAlloc(res, (void**) &queries_d, sizeof(float) * n_queries * n_dim));
+  // Allocate memory for `queries`
+  float *queries_d;
+  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&queries_d,
+                          sizeof(float) * n_queries * n_dim));
 
-    // Use DLPack to represent `queries` as tensors
-    cudaMemcpy(queries_d, queries, sizeof(float) * n_queries * n_dim, cudaMemcpyDefault);
+  // Use DLPack to represent `queries` as tensors
+  cudaMemcpy(queries_d, queries, sizeof(float) * n_queries * n_dim,
+             cudaMemcpyDefault);
 
-    DLManagedTensor queries_tensor;
-    int64_t queries_shape[2] = {n_queries, n_dim};
-    float_tensor_initialize(queries_d, queries_shape, &queries_tensor);
+  DLManagedTensor queries_tensor;
+  int64_t queries_shape[2] = {n_queries, n_dim};
+  float_tensor_initialize(queries_d, queries_shape, &queries_tensor);
 
-    // Simple build and search example.
-    ivf_flat_build_search_simple(&res, &dataset_tensor, &queries_tensor);
+  // Simple build and search example.
+  ivf_flat_build_search_simple(&res, &dataset_tensor, &queries_tensor);
 
-    float *trainset_d;
-    int64_t n_trainset = n_samples * 0.1;
-    float *trainset = (float *)malloc(n_trainset * n_dim * sizeof(float));
-    for (int i = 0; i < n_trainset; i++) {
-        for (int j = 0; j < n_dim; j++) {
-            *(trainset + i * n_dim + j)  = *(dataset + i * n_dim + j);
-        }
+  float *trainset_d;
+  int64_t n_trainset = n_samples * 0.1;
+  float *trainset = (float *)malloc(n_trainset * n_dim * sizeof(float));
+  for (int i = 0; i < n_trainset; i++) {
+    for (int j = 0; j < n_dim; j++) {
+      *(trainset + i * n_dim + j) = *(dataset + i * n_dim + j);
     }
-    CHECK_CUVS(cuvsRMMAlloc(res, (void**) &trainset_d, sizeof(float) * n_trainset * n_dim));
-    CHECK_CUDA(cudaMemcpy(trainset_d, trainset, sizeof(float) * n_trainset * n_dim,
-    cudaMemcpyDefault));
-    DLManagedTensor trainset_tensor;
-    int64_t trainset_shape[2] = {n_trainset, n_dim};
-    float_tensor_initialize(trainset_d, trainset_shape, &trainset_tensor);
+  }
+  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&trainset_d,
+                          sizeof(float) * n_trainset * n_dim));
+  CHECK_CUDA(cudaMemcpy(trainset_d, trainset,
+                        sizeof(float) * n_trainset * n_dim, cudaMemcpyDefault));
+  DLManagedTensor trainset_tensor;
+  int64_t trainset_shape[2] = {n_trainset, n_dim};
+  float_tensor_initialize(trainset_d, trainset_shape, &trainset_tensor);
 
-    // Build and extend example.
-    ivf_flat_build_extend_search(&res, &trainset_tensor, &dataset_tensor, &queries_tensor);
+  // Build and extend example.
+  ivf_flat_build_extend_search(&res, &trainset_tensor, &dataset_tensor,
+                               &queries_tensor);
 
-    CHECK_CUVS(cuvsRMMFree(res, trainset_d, sizeof(float) * n_trainset * n_dim));
-    CHECK_CUVS(cuvsRMMFree(res, queries_d, sizeof(float) * n_queries * n_dim));
-    CHECK_CUVS(cuvsRMMFree(res, dataset_d, sizeof(float) * n_samples * n_dim));
-    CHECK_CUVS(cuvsResourcesDestroy(res));
-    free(trainset);
-    free(dataset);
-    free(queries);
+  CHECK_CUVS(cuvsRMMFree(res, trainset_d, sizeof(float) * n_trainset * n_dim));
+  CHECK_CUVS(cuvsRMMFree(res, queries_d, sizeof(float) * n_queries * n_dim));
+  CHECK_CUVS(cuvsRMMFree(res, dataset_d, sizeof(float) * n_samples * n_dim));
+  CHECK_CUVS(cuvsResourcesDestroy(res));
+  free(trainset);
+  free(dataset);
+  free(queries);
 }

--- a/examples/c/src/ivf_flat_c_example.c
+++ b/examples/c/src/ivf_flat_c_example.c
@@ -20,14 +20,15 @@
 #include "common.h"
 #include <cuda_runtime.h>
 
-void ivf_flat_build_search_simple(cuvsResources_t *res,
-                                  DLManagedTensor *dataset_tensor,
-                                  DLManagedTensor *queries_tensor) {
+void ivf_flat_build_search_simple(cuvsResources_t* res,
+                                  DLManagedTensor* dataset_tensor,
+                                  DLManagedTensor* queries_tensor)
+{
   // Create default index params
   cuvsIvfFlatIndexParams_t index_params;
   CHECK_CUVS(cuvsIvfFlatIndexParamsCreate(&index_params));
-  index_params->n_lists = 1024;      // default value
-  index_params->kmeans_n_iters = 20; // default value
+  index_params->n_lists                  = 1024;  // default value
+  index_params->kmeans_n_iters           = 20;    // default value
   index_params->kmeans_trainset_fraction = 0.1;
   // index_params->metric default is L2Expanded
 
@@ -40,16 +41,14 @@ void ivf_flat_build_search_simple(cuvsResources_t *res,
   CHECK_CUVS(cuvsIvfFlatBuild(*res, index_params, dataset_tensor, index));
 
   // Create output arrays.
-  int64_t topk = 10;
+  int64_t topk      = 10;
   int64_t n_queries = queries_tensor->dl_tensor.shape[0];
 
   // Allocate memory for `neighbors` and `distances` output
-  int64_t *neighbors_d;
-  float *distances_d;
-  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&neighbors_d,
-                          sizeof(int64_t) * n_queries * topk));
-  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&distances_d,
-                          sizeof(float) * n_queries * topk));
+  int64_t* neighbors_d;
+  float* distances_d;
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void**)&neighbors_d, sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void**)&distances_d, sizeof(float) * n_queries * topk));
 
   DLManagedTensor neighbors_tensor;
   int64_t neighbors_shape[2] = {n_queries, topk};
@@ -69,26 +68,25 @@ void ivf_flat_build_search_simple(cuvsResources_t *res,
   filter.type = NO_FILTER;
   filter.addr = (uintptr_t)NULL;
 
-  CHECK_CUVS(cuvsIvfFlatSearch(*res, search_params, index, queries_tensor,
-                               &neighbors_tensor, &distances_tensor, filter));
+  CHECK_CUVS(cuvsIvfFlatSearch(
+    *res, search_params, index, queries_tensor, &neighbors_tensor, &distances_tensor, filter));
 
-  int64_t *neighbors = (int64_t *)malloc(n_queries * topk * sizeof(int64_t));
-  float *distances = (float *)malloc(n_queries * topk * sizeof(float));
+  int64_t* neighbors = (int64_t*)malloc(n_queries * topk * sizeof(int64_t));
+  float* distances   = (float*)malloc(n_queries * topk * sizeof(float));
   memset(neighbors, 0, n_queries * topk * sizeof(int64_t));
   memset(distances, 0, n_queries * topk * sizeof(float));
 
-  CHECK_CUDA(cudaMemcpy(neighbors, neighbors_d,
-                        sizeof(int64_t) * n_queries * topk, cudaMemcpyDefault));
-  CHECK_CUDA(cudaMemcpy(distances, distances_d,
-                        sizeof(float) * n_queries * topk, cudaMemcpyDefault));
+  CHECK_CUDA(
+    cudaMemcpy(neighbors, neighbors_d, sizeof(int64_t) * n_queries * topk, cudaMemcpyDefault));
+  CHECK_CUDA(
+    cudaMemcpy(distances, distances_d, sizeof(float) * n_queries * topk, cudaMemcpyDefault));
 
   print_results(neighbors, distances, 2, topk);
 
   free(distances);
   free(neighbors);
 
-  CHECK_CUVS(
-      cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
   CHECK_CUVS(cuvsRMMFree(*res, distances_d, sizeof(float) * n_queries * topk));
 
   CHECK_CUVS(cuvsIvfFlatSearchParamsDestroy(search_params));
@@ -96,36 +94,34 @@ void ivf_flat_build_search_simple(cuvsResources_t *res,
   CHECK_CUVS(cuvsIvfFlatIndexParamsDestroy(index_params));
 }
 
-void ivf_flat_build_extend_search(cuvsResources_t *res,
-                                  DLManagedTensor *trainset_tensor,
-                                  DLManagedTensor *dataset_tensor,
-                                  DLManagedTensor *queries_tensor) {
-  int64_t *data_indices_d;
+void ivf_flat_build_extend_search(cuvsResources_t* res,
+                                  DLManagedTensor* trainset_tensor,
+                                  DLManagedTensor* dataset_tensor,
+                                  DLManagedTensor* queries_tensor)
+{
+  int64_t* data_indices_d;
   int64_t n_dataset = dataset_tensor->dl_tensor.shape[0];
-  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&data_indices_d,
-                          sizeof(int64_t) * n_dataset));
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void**)&data_indices_d, sizeof(int64_t) * n_dataset));
   DLManagedTensor data_indices_tensor;
   int64_t data_indices_shape[1] = {n_dataset};
-  int_tensor_initialize(data_indices_d, data_indices_shape,
-                        &data_indices_tensor);
+  int_tensor_initialize(data_indices_d, data_indices_shape, &data_indices_tensor);
   data_indices_tensor.dl_tensor.ndim = 1;
 
   printf("\nRun k-means clustering using the training set\n");
 
-  int64_t *data_indices = (int64_t *)malloc(n_dataset * sizeof(int64_t));
-  int64_t *ptr = data_indices;
+  int64_t* data_indices = (int64_t*)malloc(n_dataset * sizeof(int64_t));
+  int64_t* ptr          = data_indices;
   for (int i = 0; i < n_dataset; i++) {
     *ptr = i;
     ptr++;
   }
   ptr = NULL;
-  cudaMemcpy(data_indices_d, data_indices, sizeof(int64_t) * n_dataset,
-             cudaMemcpyDefault);
+  cudaMemcpy(data_indices_d, data_indices, sizeof(int64_t) * n_dataset, cudaMemcpyDefault);
 
   // Create default index params
   cuvsIvfFlatIndexParams_t index_params;
   CHECK_CUVS(cuvsIvfFlatIndexParamsCreate(&index_params));
-  index_params->n_lists = 100;
+  index_params->n_lists           = 100;
   index_params->add_data_on_build = false;
   // index_params->metric default is L2Expanded
 
@@ -137,20 +133,17 @@ void ivf_flat_build_extend_search(cuvsResources_t *res,
   CHECK_CUVS(cuvsIvfFlatBuild(*res, index_params, trainset_tensor, index));
 
   printf("Filling index with the dataset vectors\n");
-  CHECK_CUVS(
-      cuvsIvfFlatExtend(*res, dataset_tensor, &data_indices_tensor, index));
+  CHECK_CUVS(cuvsIvfFlatExtend(*res, dataset_tensor, &data_indices_tensor, index));
 
   // Create output arrays.
-  int64_t topk = 10;
+  int64_t topk      = 10;
   int64_t n_queries = queries_tensor->dl_tensor.shape[0];
 
   // Allocate memory for `neighbors` and `distances` output
-  int64_t *neighbors_d;
-  float *distances_d;
-  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&neighbors_d,
-                          sizeof(int64_t) * n_queries * topk));
-  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&distances_d,
-                          sizeof(float) * n_queries * topk));
+  int64_t* neighbors_d;
+  float* distances_d;
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void**)&neighbors_d, sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void**)&distances_d, sizeof(float) * n_queries * topk));
 
   DLManagedTensor neighbors_tensor;
   int64_t neighbors_shape[2] = {n_queries, topk};
@@ -169,18 +162,18 @@ void ivf_flat_build_extend_search(cuvsResources_t *res,
   cuvsFilter filter;
   filter.type = NO_FILTER;
   filter.addr = (uintptr_t)NULL;
-  CHECK_CUVS(cuvsIvfFlatSearch(*res, search_params, index, queries_tensor,
-                               &neighbors_tensor, &distances_tensor, filter));
+  CHECK_CUVS(cuvsIvfFlatSearch(
+    *res, search_params, index, queries_tensor, &neighbors_tensor, &distances_tensor, filter));
 
-  int64_t *neighbors = (int64_t *)malloc(n_queries * topk * sizeof(int64_t));
-  float *distances = (float *)malloc(n_queries * topk * sizeof(float));
+  int64_t* neighbors = (int64_t*)malloc(n_queries * topk * sizeof(int64_t));
+  float* distances   = (float*)malloc(n_queries * topk * sizeof(float));
   memset(neighbors, 0, n_queries * topk * sizeof(int64_t));
   memset(distances, 0, n_queries * topk * sizeof(float));
 
-  CHECK_CUDA(cudaMemcpy(neighbors, neighbors_d,
-                        sizeof(int64_t) * n_queries * topk, cudaMemcpyDefault));
-  CHECK_CUDA(cudaMemcpy(distances, distances_d,
-                        sizeof(float) * n_queries * topk, cudaMemcpyDefault));
+  CHECK_CUDA(
+    cudaMemcpy(neighbors, neighbors_d, sizeof(int64_t) * n_queries * topk, cudaMemcpyDefault));
+  CHECK_CUDA(
+    cudaMemcpy(distances, distances_d, sizeof(float) * n_queries * topk, cudaMemcpyDefault));
 
   print_results(neighbors, distances, 2, topk);
 
@@ -188,8 +181,7 @@ void ivf_flat_build_extend_search(cuvsResources_t *res,
   free(neighbors);
   free(data_indices);
   CHECK_CUVS(cuvsRMMFree(*res, data_indices_d, sizeof(int64_t) * n_dataset));
-  CHECK_CUVS(
-      cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
   CHECK_CUVS(cuvsRMMFree(*res, distances_d, sizeof(float) * n_queries * topk));
 
   CHECK_CUVS(cuvsIvfFlatSearchParamsDestroy(search_params));
@@ -198,13 +190,14 @@ void ivf_flat_build_extend_search(cuvsResources_t *res,
   CHECK_CUVS(cuvsIvfFlatIndexParamsDestroy(index_params));
 }
 
-int main() {
+int main()
+{
   // Create input arrays.
   int64_t n_samples = 10000;
-  int64_t n_dim = 3;
+  int64_t n_dim     = 3;
   int64_t n_queries = 10;
-  float *dataset = (float *)malloc(n_samples * n_dim * sizeof(float));
-  float *queries = (float *)malloc(n_queries * n_dim * sizeof(float));
+  float* dataset    = (float*)malloc(n_samples * n_dim * sizeof(float));
+  float* queries    = (float*)malloc(n_queries * n_dim * sizeof(float));
   generate_dataset(dataset, n_samples, n_dim, -10.0, 10.0);
   generate_dataset(queries, n_queries, n_dim, -1.0, 1.0);
 
@@ -213,25 +206,21 @@ int main() {
   cuvsResourcesCreate(&res);
 
   // Allocate memory for `queries`
-  float *dataset_d;
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&dataset_d,
-                          sizeof(float) * n_samples * n_dim));
+  float* dataset_d;
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**)&dataset_d, sizeof(float) * n_samples * n_dim));
   // Use DLPack to represent `dataset_d` as a tensor
-  CHECK_CUDA(cudaMemcpy(dataset_d, dataset, sizeof(float) * n_samples * n_dim,
-                        cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(dataset_d, dataset, sizeof(float) * n_samples * n_dim, cudaMemcpyDefault));
 
   DLManagedTensor dataset_tensor;
   int64_t dataset_shape[2] = {n_samples, n_dim};
   float_tensor_initialize(dataset_d, dataset_shape, &dataset_tensor);
 
   // Allocate memory for `queries`
-  float *queries_d;
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&queries_d,
-                          sizeof(float) * n_queries * n_dim));
+  float* queries_d;
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**)&queries_d, sizeof(float) * n_queries * n_dim));
 
   // Use DLPack to represent `queries` as tensors
-  cudaMemcpy(queries_d, queries, sizeof(float) * n_queries * n_dim,
-             cudaMemcpyDefault);
+  cudaMemcpy(queries_d, queries, sizeof(float) * n_queries * n_dim, cudaMemcpyDefault);
 
   DLManagedTensor queries_tensor;
   int64_t queries_shape[2] = {n_queries, n_dim};
@@ -240,25 +229,23 @@ int main() {
   // Simple build and search example.
   ivf_flat_build_search_simple(&res, &dataset_tensor, &queries_tensor);
 
-  float *trainset_d;
+  float* trainset_d;
   int64_t n_trainset = n_samples * 0.1;
-  float *trainset = (float *)malloc(n_trainset * n_dim * sizeof(float));
+  float* trainset    = (float*)malloc(n_trainset * n_dim * sizeof(float));
   for (int i = 0; i < n_trainset; i++) {
     for (int j = 0; j < n_dim; j++) {
       *(trainset + i * n_dim + j) = *(dataset + i * n_dim + j);
     }
   }
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&trainset_d,
-                          sizeof(float) * n_trainset * n_dim));
-  CHECK_CUDA(cudaMemcpy(trainset_d, trainset,
-                        sizeof(float) * n_trainset * n_dim, cudaMemcpyDefault));
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**)&trainset_d, sizeof(float) * n_trainset * n_dim));
+  CHECK_CUDA(
+    cudaMemcpy(trainset_d, trainset, sizeof(float) * n_trainset * n_dim, cudaMemcpyDefault));
   DLManagedTensor trainset_tensor;
   int64_t trainset_shape[2] = {n_trainset, n_dim};
   float_tensor_initialize(trainset_d, trainset_shape, &trainset_tensor);
 
   // Build and extend example.
-  ivf_flat_build_extend_search(&res, &trainset_tensor, &dataset_tensor,
-                               &queries_tensor);
+  ivf_flat_build_extend_search(&res, &trainset_tensor, &dataset_tensor, &queries_tensor);
 
   CHECK_CUVS(cuvsRMMFree(res, trainset_d, sizeof(float) * n_trainset * n_dim));
   CHECK_CUVS(cuvsRMMFree(res, queries_d, sizeof(float) * n_queries * n_dim));

--- a/examples/c/src/ivf_pq_c_example.c
+++ b/examples/c/src/ivf_pq_c_example.c
@@ -21,16 +21,18 @@
 #include "common.h"
 #include <cuda_runtime.h>
 
-void ivf_pq_build_search(cuvsResources_t *res, DLManagedTensor *dataset_tensor,
-                         DLManagedTensor *queries_tensor) {
+void ivf_pq_build_search(cuvsResources_t* res,
+                         DLManagedTensor* dataset_tensor,
+                         DLManagedTensor* queries_tensor)
+{
   // Create default index params
   cuvsIvfPqIndexParams_t index_params;
   CHECK_CUVS(cuvsIvfPqIndexParamsCreate(&index_params));
-  index_params->n_lists = 1024; // default value
+  index_params->n_lists                  = 1024;  // default value
   index_params->kmeans_trainset_fraction = 0.1;
   // index_params->metric default is L2Expanded
   index_params->pq_bits = 8;
-  index_params->pq_dim = 2;
+  index_params->pq_dim  = 2;
 
   // Create IVF-PQ index
   cuvsIvfPqIndex_t index;
@@ -42,16 +44,14 @@ void ivf_pq_build_search(cuvsResources_t *res, DLManagedTensor *dataset_tensor,
   CHECK_CUVS(cuvsIvfPqBuild(*res, index_params, dataset_tensor, index));
 
   // Create output arrays.
-  int64_t topk = 10;
+  int64_t topk      = 10;
   int64_t n_queries = queries_tensor->dl_tensor.shape[0];
 
   // Allocate memory for `neighbors` and `distances` output
-  int64_t *neighbors_d;
-  float *distances_d;
-  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&neighbors_d,
-                          sizeof(int64_t) * n_queries * topk));
-  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&distances_d,
-                          sizeof(float) * n_queries * topk));
+  int64_t* neighbors_d;
+  float* distances_d;
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void**)&neighbors_d, sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void**)&distances_d, sizeof(float) * n_queries * topk));
 
   DLManagedTensor neighbors_tensor;
   int64_t neighbors_shape[2] = {n_queries, topk};
@@ -64,23 +64,23 @@ void ivf_pq_build_search(cuvsResources_t *res, DLManagedTensor *dataset_tensor,
   // Create default search params
   cuvsIvfPqSearchParams_t search_params;
   CHECK_CUVS(cuvsIvfPqSearchParamsCreate(&search_params));
-  search_params->n_probes = 50;
+  search_params->n_probes                = 50;
   search_params->internal_distance_dtype = CUDA_R_16F;
-  search_params->lut_dtype = CUDA_R_16F;
+  search_params->lut_dtype               = CUDA_R_16F;
 
   // Search the `index` built using `cuvsIvfPqBuild`
-  CHECK_CUVS(cuvsIvfPqSearch(*res, search_params, index, queries_tensor,
-                             &neighbors_tensor, &distances_tensor));
+  CHECK_CUVS(cuvsIvfPqSearch(
+    *res, search_params, index, queries_tensor, &neighbors_tensor, &distances_tensor));
 
-  int64_t *neighbors = (int64_t *)malloc(n_queries * topk * sizeof(int64_t));
-  float *distances = (float *)malloc(n_queries * topk * sizeof(float));
+  int64_t* neighbors = (int64_t*)malloc(n_queries * topk * sizeof(int64_t));
+  float* distances   = (float*)malloc(n_queries * topk * sizeof(float));
   memset(neighbors, 0, n_queries * topk * sizeof(int64_t));
   memset(distances, 0, n_queries * topk * sizeof(float));
 
-  CHECK_CUDA(cudaMemcpy(neighbors, neighbors_d,
-                        sizeof(int64_t) * n_queries * topk, cudaMemcpyDefault));
-  CHECK_CUDA(cudaMemcpy(distances, distances_d,
-                        sizeof(float) * n_queries * topk, cudaMemcpyDefault));
+  CHECK_CUDA(
+    cudaMemcpy(neighbors, neighbors_d, sizeof(int64_t) * n_queries * topk, cudaMemcpyDefault));
+  CHECK_CUDA(
+    cudaMemcpy(distances, distances_d, sizeof(float) * n_queries * topk, cudaMemcpyDefault));
 
   printf("\nOriginal results:\n");
   print_results(neighbors, distances, 2, topk);
@@ -88,40 +88,42 @@ void ivf_pq_build_search(cuvsResources_t *res, DLManagedTensor *dataset_tensor,
   // Re-ranking operation: refine the initial search results by computing exact
   // distances
   int64_t topk_refined = 7;
-  int64_t *neighbors_refined_d;
-  float *distances_refined_d;
-  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&neighbors_refined_d,
-                          sizeof(int64_t) * n_queries * topk_refined));
-  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&distances_refined_d,
-                          sizeof(float) * n_queries * topk_refined));
+  int64_t* neighbors_refined_d;
+  float* distances_refined_d;
+  CHECK_CUVS(
+    cuvsRMMAlloc(*res, (void**)&neighbors_refined_d, sizeof(int64_t) * n_queries * topk_refined));
+  CHECK_CUVS(
+    cuvsRMMAlloc(*res, (void**)&distances_refined_d, sizeof(float) * n_queries * topk_refined));
 
   DLManagedTensor neighbors_refined_tensor;
   int64_t neighbors_refined_shape[2] = {n_queries, topk_refined};
-  int_tensor_initialize(neighbors_refined_d, neighbors_refined_shape,
-                        &neighbors_refined_tensor);
+  int_tensor_initialize(neighbors_refined_d, neighbors_refined_shape, &neighbors_refined_tensor);
 
   DLManagedTensor distances_refined_tensor;
   int64_t distances_refined_shape[2] = {n_queries, topk_refined};
-  float_tensor_initialize(distances_refined_d, distances_refined_shape,
-                          &distances_refined_tensor);
+  float_tensor_initialize(distances_refined_d, distances_refined_shape, &distances_refined_tensor);
 
   // Note, refinement requires the original dataset and the queries.
   // Don't forget to specify the same distance metric as used by the index.
-  CHECK_CUVS(cuvsRefine(*res, dataset_tensor, queries_tensor, &neighbors_tensor,
-                        index_params->metric, &neighbors_refined_tensor,
+  CHECK_CUVS(cuvsRefine(*res,
+                        dataset_tensor,
+                        queries_tensor,
+                        &neighbors_tensor,
+                        index_params->metric,
+                        &neighbors_refined_tensor,
                         &distances_refined_tensor));
 
-  int64_t *neighbors_refine =
-      (int64_t *)malloc(n_queries * topk_refined * sizeof(int64_t));
-  float *distances_refine =
-      (float *)malloc(n_queries * topk_refined * sizeof(float));
+  int64_t* neighbors_refine = (int64_t*)malloc(n_queries * topk_refined * sizeof(int64_t));
+  float* distances_refine   = (float*)malloc(n_queries * topk_refined * sizeof(float));
   memset(neighbors_refine, 0, n_queries * topk_refined * sizeof(int64_t));
   memset(distances_refine, 0, n_queries * topk_refined * sizeof(float));
 
-  CHECK_CUDA(cudaMemcpy(neighbors_refine, neighbors_refined_d,
+  CHECK_CUDA(cudaMemcpy(neighbors_refine,
+                        neighbors_refined_d,
                         sizeof(int64_t) * n_queries * topk_refined,
                         cudaMemcpyDefault));
-  CHECK_CUDA(cudaMemcpy(distances_refine, distances_refined_d,
+  CHECK_CUDA(cudaMemcpy(distances_refine,
+                        distances_refined_d,
                         sizeof(float) * n_queries * topk_refined,
                         cudaMemcpyDefault));
 
@@ -134,13 +136,10 @@ void ivf_pq_build_search(cuvsResources_t *res, DLManagedTensor *dataset_tensor,
   free(distances);
   free(neighbors);
 
-  CHECK_CUVS(cuvsRMMFree(*res, neighbors_refined_d,
-                         sizeof(int64_t) * n_queries * topk_refined));
-  CHECK_CUVS(cuvsRMMFree(*res, distances_refined_d,
-                         sizeof(float) * n_queries * topk_refined));
+  CHECK_CUVS(cuvsRMMFree(*res, neighbors_refined_d, sizeof(int64_t) * n_queries * topk_refined));
+  CHECK_CUVS(cuvsRMMFree(*res, distances_refined_d, sizeof(float) * n_queries * topk_refined));
 
-  CHECK_CUVS(
-      cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
   CHECK_CUVS(cuvsRMMFree(*res, distances_d, sizeof(float) * n_queries * topk));
 
   CHECK_CUVS(cuvsIvfPqSearchParamsDestroy(search_params));
@@ -148,13 +147,14 @@ void ivf_pq_build_search(cuvsResources_t *res, DLManagedTensor *dataset_tensor,
   CHECK_CUVS(cuvsIvfPqIndexParamsDestroy(index_params));
 }
 
-int main() {
+int main()
+{
   // Create input arrays.
   int64_t n_samples = 10000;
-  int64_t n_dim = 3;
+  int64_t n_dim     = 3;
   int64_t n_queries = 10;
-  float *dataset = (float *)malloc(n_samples * n_dim * sizeof(float));
-  float *queries = (float *)malloc(n_queries * n_dim * sizeof(float));
+  float* dataset    = (float*)malloc(n_samples * n_dim * sizeof(float));
+  float* queries    = (float*)malloc(n_queries * n_dim * sizeof(float));
   generate_dataset(dataset, n_samples, n_dim, -10.0, 10.0);
   generate_dataset(queries, n_queries, n_dim, -1.0, 1.0);
 
@@ -163,25 +163,21 @@ int main() {
   CHECK_CUVS(cuvsResourcesCreate(&res));
 
   // Allocate memory for `queries`
-  float *dataset_d;
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&dataset_d,
-                          sizeof(float) * n_samples * n_dim));
+  float* dataset_d;
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**)&dataset_d, sizeof(float) * n_samples * n_dim));
   // Use DLPack to represent `dataset_d` as a tensor
-  CHECK_CUDA(cudaMemcpy(dataset_d, dataset, sizeof(float) * n_samples * n_dim,
-                        cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(dataset_d, dataset, sizeof(float) * n_samples * n_dim, cudaMemcpyDefault));
 
   DLManagedTensor dataset_tensor;
   int64_t dataset_shape[2] = {n_samples, n_dim};
   float_tensor_initialize(dataset_d, dataset_shape, &dataset_tensor);
 
   // Allocate memory for `queries`
-  float *queries_d;
-  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&queries_d,
-                          sizeof(float) * n_queries * n_dim));
+  float* queries_d;
+  CHECK_CUVS(cuvsRMMAlloc(res, (void**)&queries_d, sizeof(float) * n_queries * n_dim));
 
   // Use DLPack to represent `queries` as tensors
-  CHECK_CUDA(cudaMemcpy(queries_d, queries, sizeof(float) * n_queries * n_dim,
-                        cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(queries_d, queries, sizeof(float) * n_queries * n_dim, cudaMemcpyDefault));
 
   DLManagedTensor queries_tensor;
   int64_t queries_shape[2] = {n_queries, n_dim};

--- a/examples/c/src/ivf_pq_c_example.c
+++ b/examples/c/src/ivf_pq_c_example.c
@@ -18,166 +18,181 @@
 #include <cuvs/neighbors/ivf_pq.h>
 #include <cuvs/neighbors/refine.h>
 
-#include <cuda_runtime.h>
 #include "common.h"
+#include <cuda_runtime.h>
 
-void ivf_pq_build_search(cuvsResources_t *res, DLManagedTensor * dataset_tensor, DLManagedTensor * queries_tensor) {
-    // Create default index params
-    cuvsIvfPqIndexParams_t index_params;
-    CHECK_CUVS(cuvsIvfPqIndexParamsCreate(&index_params));
-    index_params->n_lists                  = 1024; // default value
-    index_params->kmeans_trainset_fraction = 0.1;
-    //index_params->metric default is L2Expanded
-    index_params->pq_bits = 8;
-    index_params->pq_dim = 2;
+void ivf_pq_build_search(cuvsResources_t *res, DLManagedTensor *dataset_tensor,
+                         DLManagedTensor *queries_tensor) {
+  // Create default index params
+  cuvsIvfPqIndexParams_t index_params;
+  CHECK_CUVS(cuvsIvfPqIndexParamsCreate(&index_params));
+  index_params->n_lists = 1024; // default value
+  index_params->kmeans_trainset_fraction = 0.1;
+  // index_params->metric default is L2Expanded
+  index_params->pq_bits = 8;
+  index_params->pq_dim = 2;
 
-    // Create IVF-PQ index
-    cuvsIvfPqIndex_t index;
-    CHECK_CUVS(cuvsIvfPqIndexCreate(&index));
+  // Create IVF-PQ index
+  cuvsIvfPqIndex_t index;
+  CHECK_CUVS(cuvsIvfPqIndexCreate(&index));
 
-    printf("Building IVF-PQ index\n");
+  printf("Building IVF-PQ index\n");
 
-    // Build the IVF-PQ Index
-    CHECK_CUVS(cuvsIvfPqBuild(*res, index_params, dataset_tensor, index));
+  // Build the IVF-PQ Index
+  CHECK_CUVS(cuvsIvfPqBuild(*res, index_params, dataset_tensor, index));
 
-    // Create output arrays.
-    int64_t topk      = 10;
-    int64_t n_queries = queries_tensor->dl_tensor.shape[0];
+  // Create output arrays.
+  int64_t topk = 10;
+  int64_t n_queries = queries_tensor->dl_tensor.shape[0];
 
-    //Allocate memory for `neighbors` and `distances` output
-    int64_t *neighbors_d;
-    float *distances_d;
-    CHECK_CUVS(cuvsRMMAlloc(*res, (void**) &neighbors_d, sizeof(int64_t) * n_queries * topk));
-    CHECK_CUVS(cuvsRMMAlloc(*res, (void**) &distances_d, sizeof(float) * n_queries * topk));
+  // Allocate memory for `neighbors` and `distances` output
+  int64_t *neighbors_d;
+  float *distances_d;
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&neighbors_d,
+                          sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&distances_d,
+                          sizeof(float) * n_queries * topk));
 
-    DLManagedTensor neighbors_tensor;
-    int64_t neighbors_shape[2] = {n_queries, topk};
-    int_tensor_initialize(neighbors_d, neighbors_shape, &neighbors_tensor);
+  DLManagedTensor neighbors_tensor;
+  int64_t neighbors_shape[2] = {n_queries, topk};
+  int_tensor_initialize(neighbors_d, neighbors_shape, &neighbors_tensor);
 
-    DLManagedTensor distances_tensor;
-    int64_t distances_shape[2] = {n_queries, topk};
-    float_tensor_initialize(distances_d, distances_shape, &distances_tensor);
+  DLManagedTensor distances_tensor;
+  int64_t distances_shape[2] = {n_queries, topk};
+  float_tensor_initialize(distances_d, distances_shape, &distances_tensor);
 
-    // Create default search params
-    cuvsIvfPqSearchParams_t search_params;
-    CHECK_CUVS(cuvsIvfPqSearchParamsCreate(&search_params));
-    search_params->n_probes = 50;
-    search_params->internal_distance_dtype = CUDA_R_16F;
-    search_params->lut_dtype = CUDA_R_16F;
+  // Create default search params
+  cuvsIvfPqSearchParams_t search_params;
+  CHECK_CUVS(cuvsIvfPqSearchParamsCreate(&search_params));
+  search_params->n_probes = 50;
+  search_params->internal_distance_dtype = CUDA_R_16F;
+  search_params->lut_dtype = CUDA_R_16F;
 
-    // Search the `index` built using `cuvsIvfPqBuild`
-    CHECK_CUVS(cuvsIvfPqSearch(*res, search_params, index,
-     queries_tensor, &neighbors_tensor, &distances_tensor));
+  // Search the `index` built using `cuvsIvfPqBuild`
+  CHECK_CUVS(cuvsIvfPqSearch(*res, search_params, index, queries_tensor,
+                             &neighbors_tensor, &distances_tensor));
 
-    int64_t *neighbors = (int64_t *)malloc(n_queries * topk * sizeof(int64_t));
-    float *distances = (float *)malloc(n_queries * topk * sizeof(float));
-    memset(neighbors, 0, n_queries * topk * sizeof(int64_t));
-    memset(distances, 0, n_queries * topk * sizeof(float));
+  int64_t *neighbors = (int64_t *)malloc(n_queries * topk * sizeof(int64_t));
+  float *distances = (float *)malloc(n_queries * topk * sizeof(float));
+  memset(neighbors, 0, n_queries * topk * sizeof(int64_t));
+  memset(distances, 0, n_queries * topk * sizeof(float));
 
-    CHECK_CUDA(cudaMemcpy(neighbors, neighbors_d, sizeof(int64_t) * n_queries * topk,
-    cudaMemcpyDefault));
-    CHECK_CUDA(cudaMemcpy(distances, distances_d, sizeof(float) * n_queries * topk,
-    cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(neighbors, neighbors_d,
+                        sizeof(int64_t) * n_queries * topk, cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(distances, distances_d,
+                        sizeof(float) * n_queries * topk, cudaMemcpyDefault));
 
-    printf("\nOriginal results:\n");
-    print_results(neighbors, distances, 2, topk);
+  printf("\nOriginal results:\n");
+  print_results(neighbors, distances, 2, topk);
 
-    // Re-ranking operation: refine the initial search results by computing exact distances
-    int64_t topk_refined = 7;
-    int64_t *neighbors_refined_d;
-    float *distances_refined_d;
-    CHECK_CUVS(cuvsRMMAlloc(*res, (void**) &neighbors_refined_d, sizeof(int64_t) * n_queries *
-    topk_refined));
-    CHECK_CUVS(cuvsRMMAlloc(*res, (void**) &distances_refined_d, sizeof(float) * n_queries *
-    topk_refined));
+  // Re-ranking operation: refine the initial search results by computing exact
+  // distances
+  int64_t topk_refined = 7;
+  int64_t *neighbors_refined_d;
+  float *distances_refined_d;
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&neighbors_refined_d,
+                          sizeof(int64_t) * n_queries * topk_refined));
+  CHECK_CUVS(cuvsRMMAlloc(*res, (void **)&distances_refined_d,
+                          sizeof(float) * n_queries * topk_refined));
 
-    DLManagedTensor neighbors_refined_tensor;
-    int64_t neighbors_refined_shape[2] = {n_queries, topk_refined};
-    int_tensor_initialize(neighbors_refined_d, neighbors_refined_shape, &neighbors_refined_tensor);
+  DLManagedTensor neighbors_refined_tensor;
+  int64_t neighbors_refined_shape[2] = {n_queries, topk_refined};
+  int_tensor_initialize(neighbors_refined_d, neighbors_refined_shape,
+                        &neighbors_refined_tensor);
 
-    DLManagedTensor distances_refined_tensor;
-    int64_t distances_refined_shape[2] = {n_queries, topk_refined};
-    float_tensor_initialize(distances_refined_d, distances_refined_shape, &distances_refined_tensor);
+  DLManagedTensor distances_refined_tensor;
+  int64_t distances_refined_shape[2] = {n_queries, topk_refined};
+  float_tensor_initialize(distances_refined_d, distances_refined_shape,
+                          &distances_refined_tensor);
 
-    // Note, refinement requires the original dataset and the queries.
-    // Don't forget to specify the same distance metric as used by the index.
-    CHECK_CUVS(cuvsRefine(*res, dataset_tensor, queries_tensor,
-                       &neighbors_tensor, index_params->metric,
-                       &neighbors_refined_tensor, &distances_refined_tensor));
+  // Note, refinement requires the original dataset and the queries.
+  // Don't forget to specify the same distance metric as used by the index.
+  CHECK_CUVS(cuvsRefine(*res, dataset_tensor, queries_tensor, &neighbors_tensor,
+                        index_params->metric, &neighbors_refined_tensor,
+                        &distances_refined_tensor));
 
-    int64_t *neighbors_refine = (int64_t *)malloc(n_queries * topk_refined * sizeof(int64_t));
-    float *distances_refine = (float *)malloc(n_queries * topk_refined * sizeof(float));
-    memset(neighbors_refine, 0, n_queries * topk_refined * sizeof(int64_t));
-    memset(distances_refine, 0, n_queries * topk_refined * sizeof(float));
+  int64_t *neighbors_refine =
+      (int64_t *)malloc(n_queries * topk_refined * sizeof(int64_t));
+  float *distances_refine =
+      (float *)malloc(n_queries * topk_refined * sizeof(float));
+  memset(neighbors_refine, 0, n_queries * topk_refined * sizeof(int64_t));
+  memset(distances_refine, 0, n_queries * topk_refined * sizeof(float));
 
-    CHECK_CUDA(cudaMemcpy(neighbors_refine, neighbors_refined_d, sizeof(int64_t) * n_queries *
-    topk_refined, cudaMemcpyDefault));
-    CHECK_CUDA(cudaMemcpy(distances_refine, distances_refined_d, sizeof(float) * n_queries *
-    topk_refined, cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(neighbors_refine, neighbors_refined_d,
+                        sizeof(int64_t) * n_queries * topk_refined,
+                        cudaMemcpyDefault));
+  CHECK_CUDA(cudaMemcpy(distances_refine, distances_refined_d,
+                        sizeof(float) * n_queries * topk_refined,
+                        cudaMemcpyDefault));
 
-    printf("\nRefined results:\n");
-    print_results(neighbors, distances, 2, topk_refined);
+  printf("\nRefined results:\n");
+  print_results(neighbors, distances, 2, topk_refined);
 
-    free(distances_refine);
-    free(neighbors_refine);
+  free(distances_refine);
+  free(neighbors_refine);
 
-    free(distances);
-    free(neighbors);
+  free(distances);
+  free(neighbors);
 
-    CHECK_CUVS(cuvsRMMFree(*res, neighbors_refined_d, sizeof(int64_t) * n_queries * topk_refined));
-    CHECK_CUVS(cuvsRMMFree(*res, distances_refined_d, sizeof(float) * n_queries * topk_refined));
+  CHECK_CUVS(cuvsRMMFree(*res, neighbors_refined_d,
+                         sizeof(int64_t) * n_queries * topk_refined));
+  CHECK_CUVS(cuvsRMMFree(*res, distances_refined_d,
+                         sizeof(float) * n_queries * topk_refined));
 
-    CHECK_CUVS(cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
-    CHECK_CUVS(cuvsRMMFree(*res, distances_d, sizeof(float) * n_queries * topk));
+  CHECK_CUVS(
+      cuvsRMMFree(*res, neighbors_d, sizeof(int64_t) * n_queries * topk));
+  CHECK_CUVS(cuvsRMMFree(*res, distances_d, sizeof(float) * n_queries * topk));
 
-    CHECK_CUVS(cuvsIvfPqSearchParamsDestroy(search_params));
-    CHECK_CUVS(cuvsIvfPqIndexDestroy(index));
-    CHECK_CUVS(cuvsIvfPqIndexParamsDestroy(index_params));
+  CHECK_CUVS(cuvsIvfPqSearchParamsDestroy(search_params));
+  CHECK_CUVS(cuvsIvfPqIndexDestroy(index));
+  CHECK_CUVS(cuvsIvfPqIndexParamsDestroy(index_params));
 }
 
 int main() {
-    // Create input arrays.
-    int64_t n_samples = 10000;
-    int64_t n_dim     = 3;
-    int64_t n_queries = 10;
-    float *dataset = (float *)malloc(n_samples * n_dim * sizeof(float));
-    float *queries = (float *)malloc(n_queries * n_dim * sizeof(float));
-    generate_dataset(dataset, n_samples, n_dim, -10.0, 10.0);
-    generate_dataset(queries, n_queries, n_dim, -1.0, 1.0);
+  // Create input arrays.
+  int64_t n_samples = 10000;
+  int64_t n_dim = 3;
+  int64_t n_queries = 10;
+  float *dataset = (float *)malloc(n_samples * n_dim * sizeof(float));
+  float *queries = (float *)malloc(n_queries * n_dim * sizeof(float));
+  generate_dataset(dataset, n_samples, n_dim, -10.0, 10.0);
+  generate_dataset(queries, n_queries, n_dim, -1.0, 1.0);
 
-    // Create a cuvsResources_t object
-    cuvsResources_t res;
-    CHECK_CUVS(cuvsResourcesCreate(&res));
+  // Create a cuvsResources_t object
+  cuvsResources_t res;
+  CHECK_CUVS(cuvsResourcesCreate(&res));
 
-    // Allocate memory for `queries`
-    float *dataset_d;
-    CHECK_CUVS(cuvsRMMAlloc(res, (void**) &dataset_d, sizeof(float) * n_samples * n_dim));
-    // Use DLPack to represent `dataset_d` as a tensor
-    CHECK_CUDA(cudaMemcpy(dataset_d, dataset, sizeof(float) * n_samples * n_dim,
-    cudaMemcpyDefault));
+  // Allocate memory for `queries`
+  float *dataset_d;
+  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&dataset_d,
+                          sizeof(float) * n_samples * n_dim));
+  // Use DLPack to represent `dataset_d` as a tensor
+  CHECK_CUDA(cudaMemcpy(dataset_d, dataset, sizeof(float) * n_samples * n_dim,
+                        cudaMemcpyDefault));
 
-    DLManagedTensor dataset_tensor;
-    int64_t dataset_shape[2] = {n_samples,n_dim};
-    float_tensor_initialize(dataset_d, dataset_shape, &dataset_tensor);
+  DLManagedTensor dataset_tensor;
+  int64_t dataset_shape[2] = {n_samples, n_dim};
+  float_tensor_initialize(dataset_d, dataset_shape, &dataset_tensor);
 
-    // Allocate memory for `queries`
-    float *queries_d;
-    CHECK_CUVS(cuvsRMMAlloc(res, (void**) &queries_d, sizeof(float) * n_queries * n_dim));
+  // Allocate memory for `queries`
+  float *queries_d;
+  CHECK_CUVS(cuvsRMMAlloc(res, (void **)&queries_d,
+                          sizeof(float) * n_queries * n_dim));
 
-    // Use DLPack to represent `queries` as tensors
-    CHECK_CUDA(cudaMemcpy(queries_d, queries, sizeof(float) * n_queries * n_dim,
-    cudaMemcpyDefault));
+  // Use DLPack to represent `queries` as tensors
+  CHECK_CUDA(cudaMemcpy(queries_d, queries, sizeof(float) * n_queries * n_dim,
+                        cudaMemcpyDefault));
 
-    DLManagedTensor queries_tensor;
-    int64_t queries_shape[2] = {n_queries, n_dim};
-    float_tensor_initialize(queries_d, queries_shape, &queries_tensor);
+  DLManagedTensor queries_tensor;
+  int64_t queries_shape[2] = {n_queries, n_dim};
+  float_tensor_initialize(queries_d, queries_shape, &queries_tensor);
 
-    // Simple build and search example.
-    ivf_pq_build_search(&res, &dataset_tensor, &queries_tensor);
+  // Simple build and search example.
+  ivf_pq_build_search(&res, &dataset_tensor, &queries_tensor);
 
-    CHECK_CUVS(cuvsRMMFree(res, queries_d, sizeof(float) * n_queries * n_dim));
-    CHECK_CUVS(cuvsRMMFree(res, dataset_d, sizeof(float) * n_samples * n_dim));
-    CHECK_CUVS(cuvsResourcesDestroy(res));
-    free(dataset);
-    free(queries);
+  CHECK_CUVS(cuvsRMMFree(res, queries_d, sizeof(float) * n_queries * n_dim));
+  CHECK_CUVS(cuvsRMMFree(res, dataset_d, sizeof(float) * n_samples * n_dim));
+  CHECK_CUVS(cuvsResourcesDestroy(res));
+  free(dataset);
+  free(queries);
 }

--- a/examples/cpp/src/brute_force_bitmap.cu
+++ b/examples/cpp/src/brute_force_bitmap.cu
@@ -21,25 +21,24 @@
 #include <raft/core/device_resources.hpp>
 #include <raft/random/make_blobs.cuh>
 
-#include <rmm/mr/device/device_memory_resource.hpp>
 #include <iostream>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 void load_dataset(const raft::device_resources& res, float* data_ptr, int n_vectors, int dim)
 {
   raft::random::RngState rng(1234ULL);
-  raft::random::uniform(
-    res, rng, data_ptr, n_vectors * dim, 0.1f, 2.0f);
+  raft::random::uniform(res, rng, data_ptr, n_vectors * dim, 0.1f, 2.0f);
 }
 
 int main()
 {
   using namespace cuvs::neighbors;
-  using dataset_dtype = float;
+  using dataset_dtype  = float;
   using indexing_dtype = int64_t;
-  auto dim = 128;
-  auto n_vectors = 90;
-  auto n_queries = 100;
-  auto k = 5;
+  auto dim             = 128;
+  auto n_vectors       = 90;
+  auto n_queries       = 100;
+  auto k               = 5;
 
   // ... build index ...
   raft::device_resources res;
@@ -55,16 +54,18 @@ int main()
   // Load a list of all the samples that will get filtered
   std::vector<indexing_dtype> removed_indices_host = {2, 13, 21, 8};
   auto removed_indices_device =
-        raft::make_device_vector<indexing_dtype, indexing_dtype>(res, removed_indices_host.size());
+    raft::make_device_vector<indexing_dtype, indexing_dtype>(res, removed_indices_host.size());
   // Copy this list to device
-  raft::copy(removed_indices_device.data_handle(), removed_indices_host.data(),
-             removed_indices_host.size(), raft::resource::get_cuda_stream(res));
+  raft::copy(removed_indices_device.data_handle(),
+             removed_indices_host.data(),
+             removed_indices_host.size(),
+             raft::resource::get_cuda_stream(res));
 
   // Create a bitmap with the list of samples to filter.
   cuvs::core::bitset<uint32_t, indexing_dtype> removed_indices_bitset(
-      res, removed_indices_device.view(), n_queries * n_vectors);
+    res, removed_indices_device.view(), n_queries * n_vectors);
   cuvs::core::bitmap_view<const uint32_t, indexing_dtype> removed_indices_bitmap(
-      removed_indices_bitset.data(), n_queries, n_vectors);
+    removed_indices_bitset.data(), n_queries, n_vectors);
 
   // Use a `bitmap_filter` in the `brute_force::search` function call.
   auto bitmap_filter = cuvs::neighbors::filtering::bitmap_filter(removed_indices_bitmap);

--- a/examples/cpp/src/common.cuh
+++ b/examples/cpp/src/common.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,36 +33,34 @@
 #include <fstream>
 
 // Fill dataset and queries with synthetic data.
-void generate_dataset(raft::device_resources const &dev_resources,
+void generate_dataset(raft::device_resources const& dev_resources,
                       raft::device_matrix_view<float, int64_t> dataset,
-                      raft::device_matrix_view<float, int64_t> queries) {
-  auto labels = raft::make_device_vector<int64_t, int64_t>(dev_resources,
-                                                           dataset.extent(0));
+                      raft::device_matrix_view<float, int64_t> queries)
+{
+  auto labels = raft::make_device_vector<int64_t, int64_t>(dev_resources, dataset.extent(0));
   raft::random::make_blobs(dev_resources, dataset, labels.view());
   raft::random::RngState r(1234ULL);
-  raft::random::uniform(
-      dev_resources, r,
-      raft::make_device_vector_view(queries.data_handle(), queries.size()),
-      -1.0f, 1.0f);
+  raft::random::uniform(dev_resources,
+                        r,
+                        raft::make_device_vector_view(queries.data_handle(), queries.size()),
+                        -1.0f,
+                        1.0f);
 }
 
 // Copy the results to host and print a few samples
 template <typename IdxT>
-void print_results(raft::device_resources const &dev_resources,
+void print_results(raft::device_resources const& dev_resources,
                    raft::device_matrix_view<IdxT, int64_t> neighbors,
-                   raft::device_matrix_view<float, int64_t> distances) {
-  int64_t topk = neighbors.extent(1);
-  auto neighbors_host =
-      raft::make_host_matrix<IdxT, int64_t>(neighbors.extent(0), topk);
-  auto distances_host =
-      raft::make_host_matrix<float, int64_t>(distances.extent(0), topk);
+                   raft::device_matrix_view<float, int64_t> distances)
+{
+  int64_t topk        = neighbors.extent(1);
+  auto neighbors_host = raft::make_host_matrix<IdxT, int64_t>(neighbors.extent(0), topk);
+  auto distances_host = raft::make_host_matrix<float, int64_t>(distances.extent(0), topk);
 
   cudaStream_t stream = raft::resource::get_cuda_stream(dev_resources);
 
-  raft::copy(neighbors_host.data_handle(), neighbors.data_handle(),
-             neighbors.size(), stream);
-  raft::copy(distances_host.data_handle(), distances.data_handle(),
-             distances.size(), stream);
+  raft::copy(neighbors_host.data_handle(), neighbors.data_handle(), neighbors.size(), stream);
+  raft::copy(distances_host.data_handle(), distances.data_handle(), distances.size(), stream);
 
   // The calls to RAFT algorithms and  raft::copy is asynchronous.
   // We need to sync the stream before accessing the data.
@@ -77,37 +75,35 @@ void print_results(raft::device_resources const &dev_resources,
 }
 
 /** Subsample the dataset to create a training set*/
-raft::device_matrix<float, int64_t>
-subsample(raft::device_resources const &dev_resources,
-          raft::device_matrix_view<const float, int64_t> dataset,
-          raft::device_vector_view<const int64_t, int64_t> data_indices,
-          float fraction) {
+raft::device_matrix<float, int64_t> subsample(
+  raft::device_resources const& dev_resources,
+  raft::device_matrix_view<const float, int64_t> dataset,
+  raft::device_vector_view<const int64_t, int64_t> data_indices,
+  float fraction)
+{
   int64_t n_samples = dataset.extent(0);
-  int64_t n_dim = dataset.extent(1);
-  int64_t n_train = n_samples * fraction;
-  auto trainset =
-      raft::make_device_matrix<float, int64_t>(dev_resources, n_train, n_dim);
+  int64_t n_dim     = dataset.extent(1);
+  int64_t n_train   = n_samples * fraction;
+  auto trainset     = raft::make_device_matrix<float, int64_t>(dev_resources, n_train, n_dim);
 
   int seed = 137;
   raft::random::RngState rng(seed);
-  auto train_indices =
-      raft::make_device_vector<int64_t>(dev_resources, n_train);
+  auto train_indices = raft::make_device_vector<int64_t>(dev_resources, n_train);
 
-  raft::random::sample_without_replacement(dev_resources, rng, data_indices,
-                                           std::nullopt, train_indices.view(),
-                                           std::nullopt);
+  raft::random::sample_without_replacement(
+    dev_resources, rng, data_indices, std::nullopt, train_indices.view(), std::nullopt);
 
-  raft::matrix::copy_rows(dev_resources, dataset, trainset.view(),
-                          raft::make_const_mdspan(train_indices.view()));
+  raft::matrix::copy_rows(
+    dev_resources, dataset, trainset.view(), raft::make_const_mdspan(train_indices.view()));
 
   return trainset;
 }
 
-template<typename T, typename idxT>
-raft::device_matrix<T,idxT> read_bin_dataset(raft::device_resources const &dev_resources,
-		       std::string fname,
-                       int max_N = INT_MAX) {
-
+template <typename T, typename idxT>
+raft::device_matrix<T, idxT> read_bin_dataset(raft::device_resources const& dev_resources,
+                                              std::string fname,
+                                              int max_N = INT_MAX)
+{
   // Read datafile in
   std::ifstream datafile(fname, std::ifstream::binary);
   uint32_t N;
@@ -115,15 +111,18 @@ raft::device_matrix<T,idxT> read_bin_dataset(raft::device_resources const &dev_r
   datafile.read((char*)&N, sizeof(uint32_t));
   datafile.read((char*)&dim, sizeof(uint32_t));
 
-  if(N > max_N) N = max_N;
+  if (N > max_N) N = max_N;
   printf("Read in file - N:%u, dim:%u\n", N, dim);
   std::vector<T> data;
-  data.resize((size_t)N*(size_t)dim);
-  datafile.read(reinterpret_cast<char*>(data.data()), (size_t)N*(size_t)dim*sizeof(T));
+  data.resize((size_t)N * (size_t)dim);
+  datafile.read(reinterpret_cast<char*>(data.data()), (size_t)N * (size_t)dim * sizeof(T));
   datafile.close();
 
   auto dataset = raft::make_device_matrix<T, idxT>(dev_resources, N, dim);
-  raft::copy(dataset.data_handle(), data.data(), data.size(), raft::resource::get_cuda_stream(dev_resources));
+  raft::copy(dataset.data_handle(),
+             data.data(),
+             data.size(),
+             raft::resource::get_cuda_stream(dev_resources));
 
   return dataset;
 }

--- a/examples/cpp/src/dynamic_batching_example.cu
+++ b/examples/cpp/src/dynamic_batching_example.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,29 +35,29 @@
 
 // A helper to split the dataset into chunks
 template <typename DeviceMatrixOrView>
-auto slice_matrix(const DeviceMatrixOrView &source,
+auto slice_matrix(const DeviceMatrixOrView& source,
                   typename DeviceMatrixOrView::index_type offset_rows,
-                  typename DeviceMatrixOrView::index_type count_rows) {
+                  typename DeviceMatrixOrView::index_type count_rows)
+{
   auto n_cols = source.extent(1);
-  return raft::make_device_matrix_view<
-      typename DeviceMatrixOrView::element_type,
-      typename DeviceMatrixOrView::index_type>(
-      const_cast<typename DeviceMatrixOrView::element_type *>(
-          source.data_handle()) +
-          offset_rows * n_cols,
-      count_rows, n_cols);
+  return raft::make_device_matrix_view<typename DeviceMatrixOrView::element_type,
+                                       typename DeviceMatrixOrView::index_type>(
+    const_cast<typename DeviceMatrixOrView::element_type*>(source.data_handle()) +
+      offset_rows * n_cols,
+    count_rows,
+    n_cols);
 }
 
 // A helper to measure the execution time of a function
 template <typename F, typename... Args>
-void time_it(std::string label, F f, Args &&...xs) {
+void time_it(std::string label, F f, Args&&... xs)
+{
   auto start = std::chrono::system_clock::now();
   f(std::forward<Args>(xs)...);
-  auto end = std::chrono::system_clock::now();
-  auto t = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  auto end  = std::chrono::system_clock::now();
+  auto t    = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
   auto t_ms = double(t.count()) / 1000.0;
-  std::cout << "[" << label << "] execution time: " << t_ms << " ms"
-            << std::endl;
+  std::cout << "[" << label << "] execution time: " << t_ms << " ms" << std::endl;
 }
 
 /**
@@ -65,12 +65,11 @@ void time_it(std::string label, F f, Args &&...xs) {
  * This is similar to recording and waiting on CUDA events, but in C++11 API.
  */
 struct cuda_work_completion_promise {
-
-  cuda_work_completion_promise(const raft::resources &res) {
-    auto *promise = new std::promise<void>;
-    RAFT_CUDA_TRY(cudaLaunchHostFunc(raft::resource::get_cuda_stream(res),
-                                     completion_callback,
-                                     reinterpret_cast<void *>(promise)));
+  cuda_work_completion_promise(const raft::resources& res)
+  {
+    auto* promise = new std::promise<void>;
+    RAFT_CUDA_TRY(cudaLaunchHostFunc(
+      raft::resource::get_cuda_stream(res), completion_callback, reinterpret_cast<void*>(promise)));
     value_ = promise->get_future();
   }
 
@@ -79,22 +78,23 @@ struct cuda_work_completion_promise {
    * cudaEventSynchronize if an event was recorded at the time of creation of
    * this promise object.
    */
-  auto get_future() -> std::future<void> && { return std::move(value_); }
+  auto get_future() -> std::future<void>&& { return std::move(value_); }
 
-private:
+ private:
   std::future<void> value_;
 
-  static void completion_callback(void *ptr) {
-    auto *promise = reinterpret_cast<std::promise<void> *>(ptr);
+  static void completion_callback(void* ptr)
+  {
+    auto* promise = reinterpret_cast<std::promise<void>*>(ptr);
     promise->set_value();
     delete promise;
   }
 };
 
-void dynamic_batching_example(
-    raft::resources const &res,
-    raft::device_matrix_view<const float, int64_t> dataset,
-    raft::device_matrix_view<const float, int64_t> queries) {
+void dynamic_batching_example(raft::resources const& res,
+                              raft::device_matrix_view<const float, int64_t> dataset,
+                              raft::device_matrix_view<const float, int64_t> queries)
+{
   using namespace cuvs::neighbors;
 
   // Number of neighbors to search
@@ -114,10 +114,8 @@ void dynamic_batching_example(
   auto queries_b = slice_matrix(queries, n_queries_a, n_queries_b);
 
   // create output arrays
-  auto neighbors =
-      raft::make_device_matrix<uint32_t>(res, queries.extent(0), topk);
-  auto distances =
-      raft::make_device_matrix<float>(res, queries.extent(0), topk);
+  auto neighbors = raft::make_device_matrix<uint32_t>(res, queries.extent(0), topk);
+  auto distances = raft::make_device_matrix<float>(res, queries.extent(0), topk);
   // slice them same as queries
   auto neighbors_a = slice_matrix(neighbors, 0, n_queries_a);
   auto distances_a = slice_matrix(distances, 0, n_queries_a);
@@ -130,33 +128,32 @@ void dynamic_batching_example(
   std::cout << "Building CAGRA index (search graph)" << std::endl;
   auto orig_index = cagra::build(res, orig_index_params, dataset);
 
-  std::cout << "CAGRA index has " << orig_index.size() << " vectors"
+  std::cout << "CAGRA index has " << orig_index.size() << " vectors" << std::endl;
+  std::cout << "CAGRA graph has degree " << orig_index.graph_degree() << ", graph size ["
+            << orig_index.graph().extent(0) << ", " << orig_index.graph().extent(1) << "]"
             << std::endl;
-  std::cout << "CAGRA graph has degree " << orig_index.graph_degree()
-            << ", graph size [" << orig_index.graph().extent(0) << ", "
-            << orig_index.graph().extent(1) << "]" << std::endl;
 
   // use default search parameters
   cagra::search_params orig_search_params;
   // get a decent recall by increasing the internal topk list
   orig_search_params.itopk_size = 512;
-  orig_search_params.algo = cagra::search_algo::SINGLE_CTA;
+  orig_search_params.algo       = cagra::search_algo::SINGLE_CTA;
 
   // Set up dynamic batching parameters
   dynamic_batching::index_params dynb_index_params{
-      /* default-initializing the parent `neighbors::index_params`
-         (not used anyway) */
-      {},
-      /* Set the K in advance (the batcher needs to allocate buffers) */
-      topk,
-      /* Configure the number and the size of IO buffers */
-      64,
-      kNumWorkerStreams};
+    /* default-initializing the parent `neighbors::index_params`
+       (not used anyway) */
+    {},
+    /* Set the K in advance (the batcher needs to allocate buffers) */
+    topk,
+    /* Configure the number and the size of IO buffers */
+    64,
+    kNumWorkerStreams};
 
   // "build" the index (it's a low-cost index wrapping),
   //  that is we need to pass the original index and its search params here
   dynamic_batching::index<float, uint32_t> dynb_index(
-      res, dynb_index_params, orig_index, orig_search_params);
+    res, dynb_index_params, orig_index, orig_search_params);
 
   // You can implement job priorities by varying the deadlines of individual
   // requests
@@ -164,119 +161,104 @@ void dynamic_batching_example(
   dynb_search_params.dispatch_timeout_ms = 0.1;
 
   // Define the big-batch setting as a baseline for measuring the throughput.
-  auto search_batch_orig =
-      [&res, &orig_index, &orig_search_params](
-          raft::device_matrix_view<const float, int64_t> queries,
-          raft::device_matrix_view<uint32_t, int64_t> neighbors,
-          raft::device_matrix_view<float, int64_t> distances) {
-        cagra::search(res, orig_search_params, orig_index, queries, neighbors,
-                      distances);
-        raft::resource::sync_stream(res);
-      };
+  auto search_batch_orig = [&res, &orig_index, &orig_search_params](
+                             raft::device_matrix_view<const float, int64_t> queries,
+                             raft::device_matrix_view<uint32_t, int64_t> neighbors,
+                             raft::device_matrix_view<float, int64_t> distances) {
+    cagra::search(res, orig_search_params, orig_index, queries, neighbors, distances);
+    raft::resource::sync_stream(res);
+  };
 
   // Launch the baseline search: check the big-batch performance
-  time_it("standard/batch A", search_batch_orig, queries_a, neighbors_a,
-          distances_a);
-  time_it("standard/batch B", search_batch_orig, queries_b, neighbors_b,
-          distances_b);
+  time_it("standard/batch A", search_batch_orig, queries_a, neighbors_a, distances_a);
+  time_it("standard/batch B", search_batch_orig, queries_b, neighbors_b, distances_b);
 
   // Streaming scenario: prepare concurrent resources
   rmm::cuda_stream_pool worker_streams{kNumWorkerStreams};
   std::vector<raft::resources> resource_pool(0);
   for (int64_t i = 0; i < kNumWorkerStreams; i++) {
     resource_pool.push_back(res);
-    raft::resource::set_cuda_stream(resource_pool[i],
-                                    worker_streams.get_stream(i));
+    raft::resource::set_cuda_stream(resource_pool[i], worker_streams.get_stream(i));
   }
 
   // Streaming scenario:
   // send queries one-by-one, with a maximum kMaxJobs in-flight
-  auto search_async_orig =
-      [&resource_pool, &orig_index, &orig_search_params](
-          raft::device_matrix_view<const float, int64_t> queries,
-          raft::device_matrix_view<uint32_t, int64_t> neighbors,
-          raft::device_matrix_view<float, int64_t> distances) {
-        auto work_size = queries.extent(0);
-        std::array<std::future<void>, kMaxJobs> futures;
-        for (int64_t i = 0; i < work_size + kMaxJobs; i++) {
-          // wait for previous job in the same slot to finish
-          if (i >= kMaxJobs) {
-            futures[i % kMaxJobs].wait();
-          }
-          // submit a new job
-          if (i < work_size) {
-            auto &res = resource_pool[i % kNumWorkerStreams];
-            cagra::search(res, orig_search_params, orig_index,
-                          slice_matrix(queries, i, 1),
-                          slice_matrix(neighbors, i, 1),
-                          slice_matrix(distances, i, 1));
-            futures[i % kMaxJobs] =
-                cuda_work_completion_promise(res).get_future();
-          }
-        }
-      };
+  auto search_async_orig = [&resource_pool, &orig_index, &orig_search_params](
+                             raft::device_matrix_view<const float, int64_t> queries,
+                             raft::device_matrix_view<uint32_t, int64_t> neighbors,
+                             raft::device_matrix_view<float, int64_t> distances) {
+    auto work_size = queries.extent(0);
+    std::array<std::future<void>, kMaxJobs> futures;
+    for (int64_t i = 0; i < work_size + kMaxJobs; i++) {
+      // wait for previous job in the same slot to finish
+      if (i >= kMaxJobs) { futures[i % kMaxJobs].wait(); }
+      // submit a new job
+      if (i < work_size) {
+        auto& res = resource_pool[i % kNumWorkerStreams];
+        cagra::search(res,
+                      orig_search_params,
+                      orig_index,
+                      slice_matrix(queries, i, 1),
+                      slice_matrix(neighbors, i, 1),
+                      slice_matrix(distances, i, 1));
+        futures[i % kMaxJobs] = cuda_work_completion_promise(res).get_future();
+      }
+    }
+  };
 
   // Streaming scenario with dynamic batching:
   // send queries one-by-one, with a maximum kMaxJobs in-flight,
   // yet allow grouping the sequential requests (subject to deadlines)
-  auto search_async_dynb =
-      [&resource_pool, &dynb_index, &dynb_search_params](
-          raft::device_matrix_view<const float, int64_t> queries,
-          raft::device_matrix_view<uint32_t, int64_t> neighbors,
-          raft::device_matrix_view<float, int64_t> distances) {
-        auto work_size = queries.extent(0);
-        std::array<std::future<void>, kMaxJobs> futures;
-        for (int64_t i = 0; i < work_size + kMaxJobs; i++) {
-          // wait for previous job in the same slot to finish
-          if (i >= kMaxJobs) {
-            futures[i % kMaxJobs].wait();
-          }
-          // submit a new job
-          if (i < work_size) {
-            auto &res = resource_pool[i % kNumWorkerStreams];
-            dynamic_batching::search(res, dynb_search_params, dynb_index,
-                                     slice_matrix(queries, i, 1),
-                                     slice_matrix(neighbors, i, 1),
-                                     slice_matrix(distances, i, 1));
-            futures[i % kMaxJobs] =
-                cuda_work_completion_promise(res).get_future();
-          }
-        }
-      };
+  auto search_async_dynb = [&resource_pool, &dynb_index, &dynb_search_params](
+                             raft::device_matrix_view<const float, int64_t> queries,
+                             raft::device_matrix_view<uint32_t, int64_t> neighbors,
+                             raft::device_matrix_view<float, int64_t> distances) {
+    auto work_size = queries.extent(0);
+    std::array<std::future<void>, kMaxJobs> futures;
+    for (int64_t i = 0; i < work_size + kMaxJobs; i++) {
+      // wait for previous job in the same slot to finish
+      if (i >= kMaxJobs) { futures[i % kMaxJobs].wait(); }
+      // submit a new job
+      if (i < work_size) {
+        auto& res = resource_pool[i % kNumWorkerStreams];
+        dynamic_batching::search(res,
+                                 dynb_search_params,
+                                 dynb_index,
+                                 slice_matrix(queries, i, 1),
+                                 slice_matrix(neighbors, i, 1),
+                                 slice_matrix(distances, i, 1));
+        futures[i % kMaxJobs] = cuda_work_completion_promise(res).get_future();
+      }
+    }
+  };
 
   // Try to handle the same amount of work in the async setting using the
   // standard implementation.
-  time_it("standard/async A", search_async_orig, queries_a, neighbors_a,
-          distances_a);
-  time_it("standard/async B", search_async_orig, queries_b, neighbors_b,
-          distances_b);
+  time_it("standard/async A", search_async_orig, queries_a, neighbors_a, distances_a);
+  time_it("standard/async B", search_async_orig, queries_b, neighbors_b, distances_b);
 
   // Do the same using dynamic batching
-  time_it("dynamic_batching/async A", search_async_dynb, queries_a, neighbors_a,
-          distances_a);
-  time_it("dynamic_batching/async B", search_async_dynb, queries_b, neighbors_b,
-          distances_b);
+  time_it("dynamic_batching/async A", search_async_dynb, queries_a, neighbors_a, distances_a);
+  time_it("dynamic_batching/async B", search_async_dynb, queries_b, neighbors_b, distances_b);
 }
 
-int main() {
+int main()
+{
   raft::device_resources res;
 
   // Set the raft resource to use a pool for internal memory allocations
   // (workspace) and limit the available workspace size.
-  raft::resource::set_workspace_to_pool_resource(res,
-                                                 12ull * 1024 * 1024 * 1024ull);
+  raft::resource::set_workspace_to_pool_resource(res, 12ull * 1024 * 1024 * 1024ull);
 
   // Create input arrays.
   int64_t n_samples = 1000000;
-  int64_t n_dim = 128;
+  int64_t n_dim     = 128;
   int64_t n_queries = 10000;
-  auto dataset =
-      raft::make_device_matrix<float, int64_t>(res, n_samples, n_dim);
-  auto queries =
-      raft::make_device_matrix<float, int64_t>(res, n_queries, n_dim);
+  auto dataset      = raft::make_device_matrix<float, int64_t>(res, n_samples, n_dim);
+  auto queries      = raft::make_device_matrix<float, int64_t>(res, n_queries, n_dim);
   generate_dataset(res, dataset.view(), queries.view());
 
   // run the interesting part of the program
-  dynamic_batching_example(res, raft::make_const_mdspan(dataset.view()),
-                           raft::make_const_mdspan(queries.view()));
+  dynamic_batching_example(
+    res, raft::make_const_mdspan(dataset.view()), raft::make_const_mdspan(queries.view()));
 }

--- a/examples/cpp/src/ivf_flat_example.cu
+++ b/examples/cpp/src/ivf_flat_example.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 #include "common.cuh"
 
+#include <cuvs/neighbors/ivf_flat.hpp>
 #include <raft/core/device_mdarray.hpp>
 #include <raft/core/device_resources.hpp>
 #include <raft/core/resource/thrust_policy.hpp>
-#include <cuvs/neighbors/ivf_flat.hpp>
 #include <raft/util/cudart_utils.hpp>
 
 #include <rmm/mr/device/device_memory_resource.hpp>
@@ -64,7 +64,7 @@ void ivf_flat_build_search_simple(raft::device_resources const& dev_resources,
     dev_resources, search_params, index, queries, neighbors.view(), distances.view());
 
   // The call to ivf_flat::search is asynchronous. Before accessing the data, sync by calling
-   raft::resource::sync_stream(dev_resources);
+  raft::resource::sync_stream(dev_resources);
 
   print_results(dev_resources, neighbors.view(), distances.view());
 }
@@ -121,7 +121,7 @@ void ivf_flat_build_extend_search(raft::device_resources const& dev_resources,
     dev_resources, search_params, index, queries, neighbors.view(), distances.view());
 
   // The call to ivf_flat::search is asynchronous. Before accessing the data, sync using:
-   raft::resource::sync_stream(dev_resources);
+  raft::resource::sync_stream(dev_resources);
 
   print_results(dev_resources, neighbors.view(), distances.view());
 }

--- a/examples/cpp/src/ivf_pq_example.cu
+++ b/examples/cpp/src/ivf_pq_example.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 #include "common.cuh"
 
-#include <raft/core/device_mdarray.hpp>
-#include <raft/core/device_resources.hpp>
 #include <cuvs/neighbors/ivf_pq.hpp>
 #include <cuvs/neighbors/refine.hpp>
+#include <raft/core/device_mdarray.hpp>
+#include <raft/core/device_resources.hpp>
 
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
@@ -60,8 +60,7 @@ void ivf_pq_build_search(raft::device_resources const& dev_resources,
   auto distances    = raft::make_device_matrix<float>(dev_resources, n_queries, topk);
 
   // Search K nearest neighbors for each of the queries.
-  ivf_pq::search(
-    dev_resources, search_params, index, queries, neighbors.view(), distances.view());
+  ivf_pq::search(dev_resources, search_params, index, queries, neighbors.view(), distances.view());
 
   // Re-ranking operation: refine the initial search results by computing exact distances
   int64_t topk_refined = 7;

--- a/examples/cpp/src/vamana_example.cu
+++ b/examples/cpp/src/vamana_example.cu
@@ -28,11 +28,15 @@
 #include "common.cuh"
 
 template <typename T>
-void vamana_build_and_write(raft::device_resources const &dev_resources,
+void vamana_build_and_write(raft::device_resources const& dev_resources,
                             raft::device_matrix_view<const T, int64_t> dataset,
-                            std::string out_fname, int degree, int visited_size,
-                            float max_fraction, int iters,
-                            std::string codebook_prefix) {
+                            std::string out_fname,
+                            int degree,
+                            int visited_size,
+                            float max_fraction,
+                            int iters,
+                            std::string codebook_prefix)
+{
   using namespace cuvs::neighbors;
 
   // use default index parameters
@@ -41,19 +45,18 @@ void vamana_build_and_write(raft::device_resources const &dev_resources,
   index_params.visited_size = visited_size;
   index_params.graph_degree = degree;
   index_params.vamana_iters = iters;
-  index_params.codebooks = vamana::deserialize_codebooks(codebook_prefix, dataset.extent(1));
+  index_params.codebooks    = vamana::deserialize_codebooks(codebook_prefix, dataset.extent(1));
 
   std::cout << "Building Vamana index (search graph)" << std::endl;
 
   auto start = std::chrono::system_clock::now();
   auto index = vamana::build(dev_resources, index_params, dataset);
-  auto end = std::chrono::system_clock::now();
+  auto end   = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end - start;
 
   std::cout << "Vamana index has " << index.size() << " vectors" << std::endl;
-  std::cout << "Vamana graph has degree " << index.graph_degree()
-            << ", graph size [" << index.graph().extent(0) << ", "
-            << index.graph().extent(1) << "]" << std::endl;
+  std::cout << "Vamana graph has degree " << index.graph_degree() << ", graph size ["
+            << index.graph().extent(0) << ", " << index.graph().extent(1) << "]" << std::endl;
 
   std::cout << "Time to build index: " << elapsed_seconds.count() << "s\n";
 
@@ -64,26 +67,32 @@ void vamana_build_and_write(raft::device_resources const &dev_resources,
   serialize(dev_resources, out_fname + ".sector_aligned", index, false, true);
 }
 
-void usage() {
-  printf("Usage: ./vamana_example <data filename> <output filename> <graph "
-         "degree> <visited_size> <max_fraction> <iterations> <(optional) "
-         "codebook prefix>\n");
+void usage()
+{
+  printf(
+    "Usage: ./vamana_example <data filename> <output filename> <graph "
+    "degree> <visited_size> <max_fraction> <iterations> <(optional) "
+    "codebook prefix>\n");
   printf("Input file expected to be binary file of fp32 vectors.\n");
   printf("Graph degree sizes supported: 32, 64, 128, 256\n");
   printf("Visited_size must be > degree and a power of 2.\n");
   printf("max_fraction > 0 and <= 1. Typical values are 0.06 or 0.1.\n");
   printf("Default iterations = 1, increase for better quality graph.\n");
-  printf("Optional path prefix to pq pivots and rotation matrix files. Expects pq pivots file at ${codebook_prefix}_pq_pivots.bin and rotation matrix file at ${codebook_prefix}_pq_pivots.bin_rotation_matrix.bin.\n");
+  printf(
+    "Optional path prefix to pq pivots and rotation matrix files. Expects pq pivots file at "
+    "${codebook_prefix}_pq_pivots.bin and rotation matrix file at "
+    "${codebook_prefix}_pq_pivots.bin_rotation_matrix.bin.\n");
   exit(1);
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[])
+{
   raft::device_resources dev_resources;
 
   // Set pool memory resource with 1 GiB initial pool size. All allocations use
   // the same pool.
   rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr(
-      rmm::mr::get_current_device_resource(), 1024 * 1024 * 1024ull);
+    rmm::mr::get_current_device_resource(), 1024 * 1024 * 1024ull);
   rmm::mr::set_current_device_resource(&pool_mr);
 
   // Alternatively, one could define a pool allocator for temporary arrays (used
@@ -93,25 +102,28 @@ int main(int argc, char *argv[]) {
   // limit. raft::resource::set_workspace_to_pool_resource(dev_resources, 2 *
   // 1024 * 1024 * 1024ull);
 
-  if (argc != 7 && argc != 8)
-    usage();
+  if (argc != 7 && argc != 8) usage();
 
-  std::string data_fname = (std::string)(argv[1]); // Input filename
-  std::string out_fname = (std::string)argv[2];    // Output index filename
-  int degree = atoi(argv[3]);
-  int max_visited = atoi(argv[4]);
-  float max_fraction = atof(argv[5]);
-  int iters = atoi(argv[6]);
+  std::string data_fname      = (std::string)(argv[1]);  // Input filename
+  std::string out_fname       = (std::string)argv[2];    // Output index filename
+  int degree                  = atoi(argv[3]);
+  int max_visited             = atoi(argv[4]);
+  float max_fraction          = atof(argv[5]);
+  int iters                   = atoi(argv[6]);
   std::string codebook_prefix = "";
   if (argc >= 8)
-    codebook_prefix = (std::string)argv[7]; // Path prefix to pq pivots and rotation matrix files
+    codebook_prefix = (std::string)argv[7];  // Path prefix to pq pivots and rotation matrix files
 
   // Read in binary dataset file
-  auto dataset =
-      read_bin_dataset<uint8_t, int64_t>(dev_resources, data_fname, INT_MAX);
+  auto dataset = read_bin_dataset<uint8_t, int64_t>(dev_resources, data_fname, INT_MAX);
 
   // Simple build example to create graph and write to a file
-  vamana_build_and_write<uint8_t>(
-      dev_resources, raft::make_const_mdspan(dataset.view()), out_fname, degree,
-      max_visited, max_fraction, iters, codebook_prefix);
+  vamana_build_and_write<uint8_t>(dev_resources,
+                                  raft::make_const_mdspan(dataset.view()),
+                                  out_fname,
+                                  degree,
+                                  max_visited,
+                                  max_fraction,
+                                  iters,
+                                  codebook_prefix);
 }


### PR DESCRIPTION
We weren't consistently checking the return value of cuda and cuvs functions in our C examples.

This caused problems when we tried to adapt the SQ code to an example, and it was returning invalid results. The root cause was because a function was failing, but we didn't notice because the pattern has been to ignore the error codes.

Enforce best practices and check the result of every cuvs and cuda function call in our c examples.

Also:
* enable -Wall and -Werror to the c examples for extra compile time checks
* add examples to CODEOWNERS
*  ensure that clang-format runs on the example files



