### PR TITLE
Make duplicate removal in all neighbors robust to distance drift across batches

### DIFF
--- a/cpp/src/neighbors/all_neighbors/all_neighbors_merge.cuh
+++ b/cpp/src/neighbors/all_neighbors/all_neighbors_merge.cuh
@@ -119,7 +119,21 @@ RAFT_KERNEL merge_subgraphs_kernel(IdxT* cluster_data_indices,
     for (int i = 0; i < ITEMS_PER_THREAD; i++) {
       size_t colId = idxBase + i;
       if (colId > 0 && colId < 2 * graph_degree) {
-        uniqueMask[colId] = static_cast<int16_t>(blockValues[colId] != blockValues[colId - 1]);
+        // this assumes same distance between vector from two different batches, which should be
+        // true. however, currently there are subtle differences in the result based on the matrix
+        // size used to call gemm. This makes it difficult to remove duplicates, because they might
+        // no longer be right next to each other after sorting by distances. Thus, for now we sweep
+        // the whole row to check for duplicates, and keep the first occurrence only.
+        // related issue: https://github.com/rapidsai/cuvs/issues/1056
+        // uniqueMask[colId] = static_cast<int16_t>(blockValues[colId] != blockValues[colId - 1]);
+        int is_unique = 1;
+        for (int j = 0; j < 2 * graph_degree; ++j) {
+          if (j < colId && blockValues[j] == blockValues[colId]) {
+            is_unique = 0;
+            break;
+          }
+        }
+        uniqueMask[colId] = static_cast<int16_t>(is_unique);
       }
     }
 


### PR DESCRIPTION
This is to fix an edge case that happens and the root cause is in issue: https://github.com/rapidsai/cuvs/issues/1056, which is about different distance results from `raft::linalg::gemm` based on the input sizes.

Right now, when merging two knn graphs from different batches, we sort by distances (i.e. keys), and if the distances are same we sort by indices (i.e. values). After doing so, we compare indices right next to each other to check for duplicates under assumption that same vectors end up with same distances.

However, due to the problem stated in issue 1056, distance for same index can be slightly different based on the size of the input matrix to gemm (or where the vector is in the entire matrix).

For example, say we are calculating nearest neighbors for vector 0.
we could end up with
```
indices = [1, 2, 3, 2, ....]
distances = [0.023, 0.02355981, 0.02355983, 0.02355987]
```
because distance between vector 0 and vector 2 is calculated as 0.02355981 in the first batch, and 0.02355987 in the second batch.

This PR fixes this issue by sweeping the entire row for duplicates, instead of checking the one right next to itself.

