### PR TITLE
Spectral Embedding precomputed graph api

### DIFF
--- a/cpp/include/cuvs/preprocessing/spectral_embedding.hpp
+++ b/cpp/include/cuvs/preprocessing/spectral_embedding.hpp
@@ -48,4 +48,9 @@ void transform(raft::resources const& handle,
                raft::device_matrix_view<float, int, raft::row_major> dataset,
                raft::device_matrix_view<float, int, raft::col_major> embedding);
 
+void transform_precomputed(raft::resources const& handle,
+                           params config,
+                           raft::device_coo_matrix<float, int, int, int>& connectivity_graph,
+                           raft::device_matrix_view<float, int, raft::col_major> embedding);
+
 }  // namespace cuvs::preprocessing::spectral_embedding

--- a/cpp/include/cuvs/preprocessing/spectral_embedding.hpp
+++ b/cpp/include/cuvs/preprocessing/spectral_embedding.hpp
@@ -48,9 +48,9 @@ void transform(raft::resources const& handle,
                raft::device_matrix_view<float, int, raft::row_major> dataset,
                raft::device_matrix_view<float, int, raft::col_major> embedding);
 
-void transform_precomputed(raft::resources const& handle,
-                           params config,
-                           raft::device_coo_matrix<float, int, int, int>& connectivity_graph,
-                           raft::device_matrix_view<float, int, raft::col_major> embedding);
+void transform(raft::resources const& handle,
+               params config,
+               raft::device_coo_matrix<float, int, int, int>& connectivity_graph,
+               raft::device_matrix_view<float, int, raft::col_major> embedding);
 
 }  // namespace cuvs::preprocessing::spectral_embedding

--- a/cpp/include/cuvs/preprocessing/spectral_embedding.hpp
+++ b/cpp/include/cuvs/preprocessing/spectral_embedding.hpp
@@ -50,7 +50,7 @@ void transform(raft::resources const& handle,
 
 void transform(raft::resources const& handle,
                params config,
-               raft::device_coo_matrix<float, int, int, int>& connectivity_graph,
+               raft::device_coo_matrix_view<float, int, int, int> connectivity_graph,
                raft::device_matrix_view<float, int, raft::col_major> embedding);
 
 }  // namespace cuvs::preprocessing::spectral_embedding

--- a/cpp/src/preprocessing/spectral/spectral_embedding.cu
+++ b/cpp/src/preprocessing/spectral/spectral_embedding.cu
@@ -234,9 +234,6 @@ void compute_eigenpairs(raft::resources const& handle,
     raft::make_const_mdspan(col_indices.view()),     // Column indices to gather
     embedding_row_view                               // Destination matrix (as row-major view)
   );
-
-  // raft::print_device_vector("embedding", embedding.data_handle(), embedding.extent(0) *
-  // embedding.extent(1), std::cout);
 }
 
 void transform(raft::resources const& handle,
@@ -260,10 +257,10 @@ void transform(raft::resources const& handle,
     handle, spectral_embedding_config, n_samples, laplacian, diagonal.view(), embedding);
 }
 
-void transform_precomputed(raft::resources const& handle,
-                           params spectral_embedding_config,
-                           raft::device_coo_matrix<float, int, int, int>& connectivity_graph,
-                           raft::device_matrix_view<float, int, raft::col_major> embedding)
+void transform(raft::resources const& handle,
+               params spectral_embedding_config,
+               raft::device_coo_matrix<float, int, int, int>& connectivity_graph,
+               raft::device_matrix_view<float, int, raft::col_major> embedding)
 {
   const int n_samples = connectivity_graph.structure_view().get_n_rows();
 
@@ -274,15 +271,6 @@ void transform_precomputed(raft::resources const& handle,
     coo_to_csr_matrix(handle, n_samples, sym_coo_row_ind.view(), connectivity_graph);
   auto laplacian =
     create_laplacian(handle, spectral_embedding_config, csr_matrix_view, diagonal.view());
-
-  // raft::print_device_vector("laplacian.get_elements().data", laplacian.get_elements().data(),
-  // laplacian.structure_view().get_nnz(), std::cout);
-  // raft::print_device_vector("laplacian.get_indptr().data",
-  // laplacian.structure_view().get_indptr().data(), laplacian.structure_view().get_n_rows() + 1,
-  // std::cout); raft::print_device_vector("laplacian.get_indices().data",
-  // laplacian.structure_view().get_indices().data(), laplacian.structure_view().get_nnz(),
-  // std::cout);
-
   compute_eigenpairs(
     handle, spectral_embedding_config, n_samples, laplacian, diagonal.view(), embedding);
 }

--- a/cpp/src/preprocessing/spectral/spectral_embedding.cu
+++ b/cpp/src/preprocessing/spectral/spectral_embedding.cu
@@ -112,35 +112,35 @@ raft::device_csr_matrix_view<float, int, int, int> coo_to_csr_matrix(
   raft::resources const& handle,
   const int n_samples,
   raft::device_vector_view<int> sym_coo_row_ind,
-  raft::device_coo_matrix<float, int, int, int>& sym_coo_matrix)
+  raft::device_coo_matrix_view<float, int, int, int> sym_coo_matrix_view)
 {
   auto stream = raft::resource::get_cuda_stream(handle);
 
   raft::sparse::op::coo_sort<float>(n_samples,
                                     n_samples,
-                                    sym_coo_matrix.structure_view().get_nnz(),
-                                    sym_coo_matrix.structure_view().get_rows().data(),
-                                    sym_coo_matrix.structure_view().get_cols().data(),
-                                    sym_coo_matrix.get_elements().data(),
+                                    sym_coo_matrix_view.structure_view().get_nnz(),
+                                    sym_coo_matrix_view.structure_view().get_rows().data(),
+                                    sym_coo_matrix_view.structure_view().get_cols().data(),
+                                    sym_coo_matrix_view.get_elements().data(),
                                     stream);
 
-  raft::sparse::convert::sorted_coo_to_csr(sym_coo_matrix.structure_view().get_rows().data(),
-                                           sym_coo_matrix.structure_view().get_nnz(),
+  raft::sparse::convert::sorted_coo_to_csr(sym_coo_matrix_view.structure_view().get_rows().data(),
+                                           sym_coo_matrix_view.structure_view().get_nnz(),
                                            sym_coo_row_ind.data_handle(),
                                            n_samples,
                                            stream);
 
-  auto sym_coo_nnz = sym_coo_matrix.structure_view().get_nnz();
+  auto sym_coo_nnz = sym_coo_matrix_view.structure_view().get_nnz();
   raft::copy(sym_coo_row_ind.data_handle() + sym_coo_row_ind.size() - 1, &sym_coo_nnz, 1, stream);
 
   auto csr_matrix_view = raft::make_device_csr_matrix_view<float, int, int, int>(
-    const_cast<float*>(sym_coo_matrix.get_elements().data()),
+    const_cast<float*>(sym_coo_matrix_view.get_elements().data()),
     raft::make_device_compressed_structure_view<int, int, int>(
       const_cast<int*>(sym_coo_row_ind.data_handle()),
-      const_cast<int*>(sym_coo_matrix.structure_view().get_cols().data()),
+      const_cast<int*>(sym_coo_matrix_view.structure_view().get_cols().data()),
       n_samples,
       n_samples,
-      sym_coo_matrix.structure_view().get_nnz()));
+      sym_coo_matrix_view.structure_view().get_nnz()));
   return csr_matrix_view;
 }
 
@@ -250,7 +250,7 @@ void transform(raft::resources const& handle,
 
   create_connectivity_graph(handle, spectral_embedding_config, dataset, embedding, sym_coo_matrix);
   auto csr_matrix_view =
-    coo_to_csr_matrix(handle, n_samples, sym_coo_row_ind.view(), sym_coo_matrix);
+    coo_to_csr_matrix(handle, n_samples, sym_coo_row_ind.view(), sym_coo_matrix.view());
   auto laplacian =
     create_laplacian(handle, spectral_embedding_config, csr_matrix_view, diagonal.view());
   compute_eigenpairs(
@@ -259,7 +259,7 @@ void transform(raft::resources const& handle,
 
 void transform(raft::resources const& handle,
                params spectral_embedding_config,
-               raft::device_coo_matrix<float, int, int, int>& connectivity_graph,
+               raft::device_coo_matrix_view<float, int, int, int> connectivity_graph,
                raft::device_matrix_view<float, int, raft::col_major> embedding)
 {
   const int n_samples = connectivity_graph.structure_view().get_n_rows();


### PR DESCRIPTION
Resolves #1184

This API is needed so that we have the option to pass in a precomputed connectivity graph. This allows users to build a connectivity graph using their preferred method whether it is through brute_force or other means and then pass the input to the spectral embedding computation.