### PR TITLE
[Java] Add decorator for synchronized CuVSResource access

### DIFF
--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/SynchronizedCuVSResources.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/SynchronizedCuVSResources.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.cuvs;
+
+import java.nio.file.Path;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A decorator for CuVSResources that guarantees synchronized (blocking) access to the wrapped CuVSResource
+ */
+public class SynchronizedCuVSResources implements CuVSResources {
+
+  private final CuVSResources inner;
+  private final ReentrantLock lock;
+
+  private SynchronizedCuVSResources(CuVSResources inner) {
+    this.inner = inner;
+    this.lock = new ReentrantLock();
+  }
+
+  static CuVSResources create() throws Throwable {
+    return new SynchronizedCuVSResources(CuVSResources.create());
+  }
+
+  @Override
+  public ScopedAccess access() {
+    lock.lock();
+    return new ScopedAccess() {
+      @Override
+      public long handle() {
+        return inner.access().handle();
+      }
+
+      @Override
+      public void close() {
+        lock.unlock();
+      }
+    };
+  }
+
+  @Override
+  public void close() {
+    inner.close();
+  }
+
+  @Override
+  public Path tempDirectory() {
+    return inner.tempDirectory();
+  }
+}

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraMultiThreadStabilityIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraMultiThreadStabilityIT.java
@@ -16,9 +16,7 @@
 package com.nvidia.cuvs;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeTrue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
@@ -45,6 +43,16 @@ public class CagraMultiThreadStabilityIT extends CuVSTestCase {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  private final int dimensions = 256;
+  private final int queriesPerThread = 500;
+  private final int queryBatchSize = 1; // Small batch size to increase frequency of calls
+  private final int topK = 10;
+
+  @FunctionalInterface
+  private interface QueryAction {
+    void run(CagraIndex index) throws Throwable;
+  }
+
   @Before
   public void setup() {
     assumeTrue("not supported on " + System.getProperty("os.name"), isLinuxAmd64());
@@ -53,18 +61,27 @@ public class CagraMultiThreadStabilityIT extends CuVSTestCase {
   }
 
   @Test
-  public void testQueryingUsingMultipleThreads() throws Throwable {
+  public void testQueryingUsingMultipleThreadsWithSharedSynchronizedResources() throws Throwable {
+    try (CuVSResources sharedResources = SynchronizedCuVSResources.create()) {
+      testQueryingUsingMultipleThreads(
+          index -> performQueryWithSharedSynchronizedResource(sharedResources, index));
+    }
+  }
+
+  @Test
+  public void testQueryingUsingMultipleThreadsWithPrivateResources() throws Throwable {
+    testQueryingUsingMultipleThreads(this::performQueryWithPrivateResource);
+  }
+
+  private void testQueryingUsingMultipleThreads(QueryAction queryAction) throws Throwable {
     final int dataSize = 10000;
-    final int dimensions = 256;
-    final int numThreads = 16; // High thread count to increase contention
-    final int queriesPerThread = 500;
-    final int queryBatchSize = 1; // Small batch size to increase frequency of calls
-    final int topK = 10;
+    final int numThreads = 16;
 
     log.info("  Dataset: {}x{}", dataSize, dimensions);
+    // High thread count to increase contention
     log.info("  Threads: {}, Queries per thread: {}", numThreads, queriesPerThread);
 
-    float[][] dataset = generateRandomDataset(dataSize, dimensions);
+    float[][] dataset = generateRandomDataset(dataSize);
 
     try (CuVSResources resources = CheckedCuVSResources.create()) {
       log.info("Creating CAGRA index for MultiThreaded stability test...");
@@ -86,105 +103,125 @@ public class CagraMultiThreadStabilityIT extends CuVSTestCase {
 
       log.info("CAGRA index created, starting high-contention multi-threaded search...");
 
-      // Create high contention scenario that would fail without using separate resources in every thread
-      ExecutorService executor = Executors.newFixedThreadPool(numThreads);
-      List<Future<?>> futures = new ArrayList<>();
-      CountDownLatch startLatch = new CountDownLatch(1);
-      AtomicInteger successfulQueries = new AtomicInteger(0);
-      AtomicReference<Throwable> firstError = new AtomicReference<>();
+      // Create high contention scenario that would fail without using separate resources in every
+      // thread
+      try (ExecutorService executor = Executors.newFixedThreadPool(numThreads)) {
+        List<Future<?>> futures = new ArrayList<>();
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicInteger successfulQueries = new AtomicInteger(0);
+        AtomicReference<Throwable> firstError = new AtomicReference<>();
 
-      for (int threadId = 0; threadId < numThreads; threadId++) {
-        final int finalThreadId = threadId;
+        for (int threadId = 0; threadId < numThreads; threadId++) {
+          final int finalThreadId = threadId;
 
-        Future<?> future =
-            executor.submit(
-                () -> {
-                  try {
-                    // Wait for all threads to start simultaneously
-                    startLatch.await();
+          Future<?> future =
+              executor.submit(
+                  () -> {
+                    try {
+                      // Wait for all threads to start simultaneously
+                      startLatch.await();
 
-                    for (int queryId = 0; queryId < queriesPerThread; queryId++) {
-                      float[][] queries = generateRandomDataset(queryBatchSize, dimensions);
-
-                      try (CuVSResources threadResources = CheckedCuVSResources.create()) {
-                        CagraSearchParams searchParams = new CagraSearchParams.Builder().build();
-                        CagraQuery query =
-                            new CagraQuery.Builder(threadResources)
-                                .withTopK(topK)
-                                .withSearchParams(searchParams)
-                                .withQueryVectors(queries)
-                                .build();
-
-                        // This call should now work with per-thread resources
-                        SearchResults results = index.search(query);
-                        assertNotNull("Query should return results", results);
-                        assertTrue(
-                            "Query should return some results", !results.getResults().isEmpty());
-
+                      for (int queryId = 0; queryId < queriesPerThread; queryId++) {
+                        queryAction.run(index);
                         successfulQueries.incrementAndGet();
+
+                        // No Thread.yield() - maximize contention
                       }
 
-                      // No Thread.yield() - maximize contention
+                      log.info("Thread {} completed successfully", finalThreadId);
+
+                    } catch (Throwable t) {
+                      log.error("Thread {} failed: {}", finalThreadId, t.getMessage(), t);
+                      firstError.compareAndSet(null, t);
+                      throw new RuntimeException("Thread failed", t);
                     }
+                  });
 
-                    log.info("Thread {} completed successfully", finalThreadId);
+          futures.add(future);
+        }
 
-                  } catch (Throwable t) {
-                    log.error("Thread {} failed: {}", finalThreadId, t.getMessage(), t);
-                    firstError.compareAndSet(null, t);
-                    throw new RuntimeException("Thread failed", t);
-                  }
-                });
+        // Start all threads simultaneously to maximize contention
+        log.info("Starting all {} threads simultaneously...", numThreads);
+        startLatch.countDown();
 
-        futures.add(future);
-      }
-
-      // Start all threads simultaneously to maximize contention
-      log.info("Starting all {} threads simultaneously...", numThreads);
-      startLatch.countDown();
-
-      // Wait for all threads to complete
-      boolean allCompleted = true;
-      for (Future<?> future : futures) {
-        try {
-          future.get(120, TimeUnit.SECONDS); // Longer timeout for stress test
-        } catch (Exception e) {
-          allCompleted = false;
-          log.error("Thread failed: {}", e.getMessage(), e);
-          if (firstError.get() == null) {
-            firstError.set(e);
+        // Wait for all threads to complete
+        boolean allCompleted = true;
+        for (Future<?> future : futures) {
+          try {
+            future.get(120, TimeUnit.SECONDS); // Longer timeout for stress test
+          } catch (Exception e) {
+            allCompleted = false;
+            log.error("Thread failed: {}", e.getMessage(), e);
+            if (firstError.get() == null) {
+              firstError.set(e);
+            }
           }
         }
+
+        executor.shutdown();
+        if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+          executor.shutdownNow();
+        }
+
+        // Verify results
+        int expectedTotalQueries = numThreads * queriesPerThread;
+        int actualSuccessfulQueries = successfulQueries.get();
+
+        log.info("  Successful queries: {} / {}", actualSuccessfulQueries, expectedTotalQueries);
+
+        if (firstError.get() != null) {
+          fail("MultiThreaded stablity test failed:" + " " + firstError.get().getMessage());
+        }
+
+        assertTrue("All threads should complete successfully", allCompleted);
+        assertEquals(
+            "All queries should complete successfully",
+            expectedTotalQueries,
+            actualSuccessfulQueries);
       }
-
-      executor.shutdown();
-      if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
-        executor.shutdownNow();
-      }
-
-      // Verify results
-      int expectedTotalQueries = numThreads * queriesPerThread;
-      int actualSuccessfulQueries = successfulQueries.get();
-
-      log.info("  Successful queries: {} / {}", actualSuccessfulQueries, expectedTotalQueries);
-
-      if (firstError.get() != null) {
-        fail(
-            "MultiThreaded stablity test failed:"
-                + " "
-                + firstError.get().getMessage());
-      }
-
-      assertTrue("All threads should complete successfully", allCompleted);
-      assertTrue(
-          "All queries should complete successfully",
-          actualSuccessfulQueries == expectedTotalQueries);
 
       index.destroyIndex();
     }
   }
 
-  private float[][] generateRandomDataset(int size, int dimensions) {
+  private void performQueryWithPrivateResource(CagraIndex index) throws Throwable {
+    float[][] queries = generateRandomDataset(queryBatchSize);
+
+    try (CuVSResources threadResources = CheckedCuVSResources.create()) {
+      CagraSearchParams searchParams = new CagraSearchParams.Builder().build();
+      CagraQuery query =
+          new CagraQuery.Builder(threadResources)
+              .withTopK(topK)
+              .withSearchParams(searchParams)
+              .withQueryVectors(queries)
+              .build();
+
+      // This call should now work with per-thread resources
+      SearchResults results = index.search(query);
+      assertNotNull("Query should return results", results);
+      assertFalse("Query should return some results", results.getResults().isEmpty());
+    }
+  }
+
+  private void performQueryWithSharedSynchronizedResource(
+      CuVSResources threadResources, CagraIndex index) throws Throwable {
+    float[][] queries = generateRandomDataset(queryBatchSize);
+
+    CagraSearchParams searchParams = new CagraSearchParams.Builder().build();
+    CagraQuery query =
+        new CagraQuery.Builder(threadResources)
+            .withTopK(topK)
+            .withSearchParams(searchParams)
+            .withQueryVectors(queries)
+            .build();
+
+    // This call should now work with per-thread resources
+    SearchResults results = index.search(query);
+    assertNotNull("Query should return results", results);
+    assertFalse("Query should return some results", results.getResults().isEmpty());
+  }
+
+  private float[][] generateRandomDataset(int size) {
     Random random = new Random(42 + System.nanoTime());
     float[][] data = new float[size][dimensions];
 


### PR DESCRIPTION
As a follow up to #1089 and #1082, this PR introduces a decorator to ensure that access to a shared CuVSResource is synchronized. This could be useful in cases where application logic is complex and it's not easy to efficiently and cleanly guarantee that access to a CuVSResources is done by at most one thread at each given time. 