### PR TITLE
Update rapids-build-backend to 0.4.1

### DIFF
--- a/conda/recipes/cuvs-bench-cpu/recipe.yaml
+++ b/conda/recipes/cuvs-bench-cpu/recipe.yaml
@@ -63,7 +63,7 @@ requirements:
     - openblas
     - pip
     - python =${{ py_version }}
-    - rapids-build-backend>=0.3.0,<0.4.0.dev0
+    - rapids-build-backend>=0.4.0,<0.5.0.dev0
     - setuptools >=64.0.0
     - if: linux64
       then:

--- a/conda/recipes/cuvs-bench/recipe.yaml
+++ b/conda/recipes/cuvs-bench/recipe.yaml
@@ -32,7 +32,7 @@ requirements:
     - libcuvs-bench-ann =${{ version }}
     - python =${{ py_version }}
     - pip
-    - rapids-build-backend >=0.3.0,<0.4.0.dev0
+    - rapids-build-backend >=0.4.0,<0.5.0.dev0
     - rmm =${{ minor_version }}
     - setuptools >=64.0.0
   run:

--- a/conda/recipes/cuvs/recipe.yaml
+++ b/conda/recipes/cuvs/recipe.yaml
@@ -56,7 +56,7 @@ requirements:
     - pip
     - pylibraft =${{ minor_version }}
     - python =${{ py_version }}
-    - rapids-build-backend >=0.3.0,<0.4.0.dev0
+    - rapids-build-backend >=0.4.0,<0.5.0.dev0
     - scikit-build-core >=0.10.0
     - cuda-python >=12.6.2,<13.0a0
     - cuda-cudart-dev

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -218,7 +218,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - rapids-build-backend>=0.3.0,<0.4.0.dev0
+          - rapids-build-backend>=0.4.0,<0.5.0.dev0
       - output_types: [conda]
         packages:
           - scikit-build-core>=0.10.0


### PR DESCRIPTION
This PR updates rapids-build-backend to 0.4.1, and errors out if any MANIFEST.in file is present.
