### PR TITLE
Add NN.extend and kmeans to Python doc

### DIFF
--- a/docs/source/python_api.rst
+++ b/docs/source/python_api.rst
@@ -7,6 +7,7 @@ Python API Documentation
 .. toctree::
    :maxdepth: 4
 
+   python_api/cluster.rst
    python_api/distance.rst
    python_api/neighbors.rst
    python_api/preprocessing.rst

--- a/docs/source/python_api/cluster.rst
+++ b/docs/source/python_api/cluster.rst
@@ -1,0 +1,12 @@
+Cluster
+========
+
+.. role:: py(code)
+   :language: python
+   :class: highlight
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   cluster_kmeans.rst

--- a/docs/source/python_api/cluster_kmeans.rst
+++ b/docs/source/python_api/cluster_kmeans.rst
@@ -1,0 +1,27 @@
+K-Means
+=======
+
+.. role:: py(code)
+   :language: python
+   :class: highlight
+
+K-Means Parameters
+##################
+
+.. autoclass:: cuvs.cluster.kmeans.KMeansParams
+    :members:
+
+K-Means Fit
+###########
+
+.. autofunction:: cuvs.cluster.kmeans.fit
+
+K-Means Predict
+###############
+
+.. autofunction:: cuvs.cluster.kmeans.predict
+
+K-Means Cluster Cost
+####################
+
+.. autofunction:: cuvs.cluster.kmeans.cluster_cost

--- a/docs/source/python_api/neighbors_cagra.rst
+++ b/docs/source/python_api/neighbors_cagra.rst
@@ -44,3 +44,8 @@ Index load
 ##########
 
 .. autofunction:: cuvs.neighbors.cagra.load
+
+Index extend
+###########
+
+.. autofunction:: cuvs.neighbors.cagra.extend

--- a/docs/source/python_api/neighbors_hnsw.rst
+++ b/docs/source/python_api/neighbors_hnsw.rst
@@ -38,3 +38,8 @@ Index load
 ##########
 
 .. autofunction:: cuvs.neighbors.hnsw.load
+
+Index extend
+###########
+
+.. autofunction:: cuvs.neighbors.hnsw.extend

--- a/docs/source/python_api/neighbors_ivf_flat.rst
+++ b/docs/source/python_api/neighbors_ivf_flat.rst
@@ -42,3 +42,8 @@ Index load
 ##########
 
 .. autofunction:: cuvs.neighbors.ivf_flat.load
+
+Index extend
+############
+
+.. autofunction:: cuvs.neighbors.ivf_flat.extend

--- a/docs/source/python_api/neighbors_ivf_pq.rst
+++ b/docs/source/python_api/neighbors_ivf_pq.rst
@@ -42,3 +42,8 @@ Index load
 ##########
 
 .. autofunction:: cuvs.neighbors.ivf_pq.load
+
+Index extend
+############
+
+.. autofunction:: cuvs.neighbors.ivf_pq.extend


### PR DESCRIPTION
All the nearest neighbors `extend` functions were missing.