### PR TITLE
Fix missing sync_stream in ScaNN build

### DIFF
--- a/cpp/src/neighbors/scann/detail/scann_build.cuh
+++ b/cpp/src/neighbors/scann/detail/scann_build.cuh
@@ -173,6 +173,9 @@ index<T, IdxT> build(
       res, kmeans_params, batch_view, raft::make_const_mdspan(centroids_view), batch_labels_view);
 
     dataset_vec_batches.prefetch_next_batch();
+
+    // Make sure work on device is finished before swapping buffers
+    raft::resource::sync_stream(res);
   }
 
   // AVQ update of KMeans centroids
@@ -304,18 +307,9 @@ index<T, IdxT> build(
     // quantize dataset to bfloat16, if enabled. Similar to SOAR, quantization
     // is performed in this loop to improve locality
     // TODO (rmaschal): Might be more efficient to do on CPU, to avoid DtoH copy
-
     auto bf16_dataset = raft::make_device_matrix<int16_t, int64_t>(res, batch_view.extent(0), dim);
 
     if (params.bf16_enabled) {
-      // raft::linalg::map_offset(res, bf16_dataset.view(), [batch_view, dim] __device__(size_t i) {
-      //   int64_t row_idx = i / dim;
-      //   int64_t col_idx = i % dim;
-
-      //  nv_bfloat16 val = __float2bfloat16(batch_view(row_idx, col_idx));
-
-      //  return reinterpret_cast<int16_t&>(val);
-      //});
       raft::linalg::unaryOp(
         bf16_dataset.data_handle(),
         batch_view.data_handle(),
@@ -348,6 +342,9 @@ index<T, IdxT> build(
                  bf16_dataset.size(),
                  stream);
     }
+
+    // Make sure work on device is finished before swapping buffers
+    raft::resource::sync_stream(res);
   }
 
   // Codebooks from VPQ have the shape [subspace idx, subspace dim, code]


### PR DESCRIPTION
As title. For larger number of clusters (or faster PCI-E), the work required to find cluster assignments would take longer than the HtoD copy for each batch. This would lead to overwriting of one of the batch_load_iterator device buffers before kmeans predict completed, and thus lower recall.

This adds a raft::resource::sync_stream at the end of the kmeans predict loop to avoid this. Although not technically necessary (as the prior DtoH copy into pageable memory is synchronous), sync_stream is also added to the end of the quantization loop for consistency/correctness. 

Also removed one unused comment. 