### PR TITLE
Drop log level for CAGRA trace messages

### DIFF
--- a/cpp/src/neighbors/detail/cagra/cagra_build.cuh
+++ b/cpp/src/neighbors/detail/cagra/cagra_build.cuh
@@ -769,14 +769,14 @@ index<T, IdxT> build(
 
     cagra_graph = raft::make_host_matrix<IdxT, int64_t>(dataset.extent(0), graph_degree);
 
-    RAFT_LOG_INFO("optimizing graph");
+    RAFT_LOG_TRACE("optimizing graph");
     optimize<IdxT>(res, knn_graph->view(), cagra_graph.view(), params.guarantee_connectivity);
 
     // free intermediate graph before trying to create the index
     knn_graph.reset();
   }
 
-  RAFT_LOG_INFO("Graph optimized, creating index");
+  RAFT_LOG_TRACE("Graph optimized, creating index");
 
   // Construct an index from dataset and optimized knn graph.
   if (params.compression.has_value()) {

--- a/cpp/src/neighbors/detail/cagra/cagra_serialize.cuh
+++ b/cpp/src/neighbors/detail/cagra/cagra_serialize.cuh
@@ -74,7 +74,7 @@ void serialize(raft::resources const& res,
 
   raft::serialize_scalar(res, os, include_dataset);
   if (include_dataset) {
-    RAFT_LOG_INFO("Saving CAGRA index with dataset");
+    RAFT_LOG_DEBUG("Saving CAGRA index with dataset");
     neighbors::detail::serialize(res, os, index_.data());
   } else {
     RAFT_LOG_DEBUG("Saving CAGRA index WITHOUT dataset");


### PR DESCRIPTION
This is a follow-up to #1226, which aims to reduce the amount of noise in the Java test logs.

In the course of making the changes in #1226, one observes that there exist some TRACE messages from `libcuvs` that are being logged at the INFO level.  Thousands of these fill up the Java logs, obscuring some legitimate warnings. For instance:
1. "Graph optimized, creating index" and "optimizing graph" appear 4574 times.
2. "Saving CAGRA index with dataset" appears 1025 times.

There isn't any further information in the messages, beyond indicating that position in code.

This commit changes the level of the first message to "TRACE", and the second to "DEBUG" (to match the logs around it).

AFAICT, this shouldn't have an effect on the tests, or have impact on user-logs, beyond reducing log volume.
