### PR TITLE
[WIP][DO NOT MERGE] Using `all_neighbors` for mutual reachability

### DIFF
--- a/cpp/include/cuvs/cluster/agglomerative.hpp
+++ b/cpp/include/cuvs/cluster/agglomerative.hpp
@@ -163,15 +163,15 @@ struct mutual_reachability_params {
  */
 void build_linkage(
   raft::resources const& handle,
-  raft::device_matrix_view<const float, int, raft::row_major> X,
+  raft::device_matrix_view<const float, int64_t, raft::row_major> X,
   std::variant<linkage_graph_params::distance_params,
                linkage_graph_params::mutual_reachability_params> linkage_graph_params,
   cuvs::distance::DistanceType metric,
-  raft::device_coo_matrix_view<float, int, int, size_t> out_mst,
-  raft::device_matrix_view<int, int> dendrogram,
-  raft::device_vector_view<float, int> out_distances,
-  raft::device_vector_view<int, int> out_sizes,
-  std::optional<raft::device_vector_view<float, int>> core_dists);
+  raft::device_coo_matrix_view<float, int64_t, int64_t, size_t> out_mst,
+  raft::device_matrix_view<int64_t, int64_t> dendrogram,
+  raft::device_vector_view<float, int64_t> out_distances,
+  raft::device_vector_view<int64_t, int64_t> out_sizes,
+  std::optional<raft::device_vector_view<float, int64_t>> core_dists);
 }  // namespace helpers
 /**
  * @}

--- a/cpp/include/cuvs/neighbors/all_neighbors.hpp
+++ b/cpp/include/cuvs/neighbors/all_neighbors.hpp
@@ -126,13 +126,19 @@ struct all_neighbors_params {
  *                in host memory
  * @param[out] indices nearest neighbor indices of shape [n_row x k]
  * @param[out] distances nearest neighbor distances [n_row x k]
+ * @param[out] core_distances array for core distances of size [n_row]. Requires distances matrix to
+ * compute core_distances. If core_distances is given, the resulting indices and distances will be
+ * mutual reachability space.
+ * @param[in] alpha distance scaling parameter as used in robust single linkage.
  */
 void build(
   const raft::resources& handle,
   const all_neighbors_params& params,
   raft::host_matrix_view<const float, int64_t, row_major> dataset,
   raft::device_matrix_view<int64_t, int64_t, row_major> indices,
-  std::optional<raft::device_matrix_view<float, int64_t, row_major>> distances = std::nullopt);
+  std::optional<raft::device_matrix_view<float, int64_t, row_major>> distances      = std::nullopt,
+  std::optional<raft::device_vector_view<float, int64_t, row_major>> core_distances = std::nullopt,
+  float alpha                                                                       = 1.0);
 
 /**
  * @brief Builds an approximate all-neighbors knn graph (find nearest neighbors for all the training
@@ -156,13 +162,19 @@ void build(
  *                in device memory
  * @param[out] indices nearest neighbor indices of shape [n_row x k]
  * @param[out] distances nearest neighbor distances [n_row x k]
+ * @param[out] core_distances array for core distances of size [n_row]. Requires distances matrix to
+ * compute core_distances. If core_distances is given, the resulting indices and distances will be
+ * mutual reachability space.
+ * @param[in] alpha distance scaling parameter as used in robust single linkage.
  */
 void build(
   const raft::resources& handle,
   const all_neighbors_params& params,
   raft::device_matrix_view<const float, int64_t, row_major> dataset,
   raft::device_matrix_view<int64_t, int64_t, row_major> indices,
-  std::optional<raft::device_matrix_view<float, int64_t, row_major>> distances = std::nullopt);
+  std::optional<raft::device_matrix_view<float, int64_t, row_major>> distances      = std::nullopt,
+  std::optional<raft::device_vector_view<float, int64_t, row_major>> core_distances = std::nullopt,
+  float alpha                                                                       = 1.0);
 
 /** @} */
 }  // namespace cuvs::neighbors::all_neighbors

--- a/cpp/include/cuvs/neighbors/graph_build_types.hpp
+++ b/cpp/include/cuvs/neighbors/graph_build_types.hpp
@@ -27,7 +27,7 @@ namespace cuvs::neighbors {
  * @{
  */
 
-enum GRAPH_BUILD_ALGO { BRUTE_FORCE = 0, IVF_PQ = 1, NN_DESCENT = 1 };
+enum GRAPH_BUILD_ALGO { BRUTE_FORCE = 0, IVF_PQ = 1, NN_DESCENT = 2 };
 
 namespace graph_build_params {
 

--- a/cpp/src/cluster/single_linkage_float.cu
+++ b/cpp/src/cluster/single_linkage_float.cu
@@ -43,15 +43,15 @@ void single_linkage(raft::resources const& handle,
 namespace helpers {
 void build_linkage(
   raft::resources const& handle,
-  raft::device_matrix_view<const float, int, raft::row_major> X,
+  raft::device_matrix_view<const float, int64_t, raft::row_major> X,
   std::variant<linkage_graph_params::distance_params,
                linkage_graph_params::mutual_reachability_params> linkage_graph_params,
   cuvs::distance::DistanceType metric,
-  raft::device_coo_matrix_view<float, int, int, size_t> out_mst,
-  raft::device_matrix_view<int, int> out_dendrogram,
-  raft::device_vector_view<float, int> out_distances,
-  raft::device_vector_view<int, int> out_sizes,
-  std::optional<raft::device_vector_view<float, int>> core_dists)
+  raft::device_coo_matrix_view<float, int64_t, int64_t, size_t> out_mst,
+  raft::device_matrix_view<int64_t, int64_t> out_dendrogram,
+  raft::device_vector_view<float, int64_t> out_distances,
+  raft::device_vector_view<int64_t, int64_t> out_sizes,
+  std::optional<raft::device_vector_view<float, int64_t>> core_dists)
 {
   /**
    * Construct MST sorted by weights
@@ -68,27 +68,29 @@ void build_linkage(
     auto mr_params = std::get<
       cuvs::cluster::agglomerative::helpers::linkage_graph_params::mutual_reachability_params>(
       linkage_graph_params);
-    detail::build_mr_linkage<float, int>(handle,
-                                         X,
-                                         mr_params.min_samples,
-                                         mr_params.alpha,
-                                         metric,
-                                         core_dists_mdspan,
-                                         out_mst,
-                                         out_dendrogram,
-                                         out_distances,
-                                         out_sizes);
+    detail::build_mr_linkage<float, int64_t>(handle,
+                                             X,
+                                             mr_params.min_samples,
+                                             mr_params.alpha,
+                                             metric,
+                                             core_dists_mdspan,
+                                             out_mst,
+                                             out_dendrogram,
+                                             out_distances,
+                                             out_sizes);
   } else {
     auto dist_params =
       std::get<cuvs::cluster::agglomerative::helpers::linkage_graph_params::distance_params>(
         linkage_graph_params);
     if (dist_params.dist_type == cuvs::cluster::agglomerative::Linkage::KNN_GRAPH) {
-      detail::
-        build_dist_linkage<float, int, size_t, cuvs::cluster::agglomerative::Linkage::KNN_GRAPH>(
-          handle, X, dist_params.c, metric, out_mst, out_dendrogram, out_distances, out_sizes);
+      detail::build_dist_linkage<float,
+                                 int64_t,
+                                 size_t,
+                                 cuvs::cluster::agglomerative::Linkage::KNN_GRAPH>(
+        handle, X, dist_params.c, metric, out_mst, out_dendrogram, out_distances, out_sizes);
     } else {
       detail::
-        build_dist_linkage<float, int, size_t, cuvs::cluster::agglomerative::Linkage::PAIRWISE>(
+        build_dist_linkage<float, int64_t, size_t, cuvs::cluster::agglomerative::Linkage::PAIRWISE>(
           handle, X, dist_params.c, metric, out_mst, out_dendrogram, out_distances, out_sizes);
     }
   }

--- a/cpp/src/neighbors/all_neighbors/all_neighbors.cu
+++ b/cpp/src/neighbors/all_neighbors/all_neighbors.cu
@@ -18,23 +18,29 @@
 
 namespace cuvs::neighbors::all_neighbors {
 
-#define CUVS_INST_ALL_NEIGHBORS(T, IdxT)                                                       \
-  void build(const raft::resources& handle,                                                    \
-             const all_neighbors_params& params,                                               \
-             raft::host_matrix_view<const T, IdxT, row_major> dataset,                         \
-             raft::device_matrix_view<IdxT, IdxT, row_major> indices,                          \
-             std::optional<raft::device_matrix_view<T, IdxT, row_major>> distances)            \
-  {                                                                                            \
-    return all_neighbors::detail::build<T, IdxT>(handle, params, dataset, indices, distances); \
-  }                                                                                            \
-                                                                                               \
-  void build(const raft::resources& handle,                                                    \
-             const all_neighbors_params& params,                                               \
-             raft::device_matrix_view<const T, IdxT, row_major> dataset,                       \
-             raft::device_matrix_view<IdxT, IdxT, row_major> indices,                          \
-             std::optional<raft::device_matrix_view<T, IdxT, row_major>> distances)            \
-  {                                                                                            \
-    return all_neighbors::detail::build<T, IdxT>(handle, params, dataset, indices, distances); \
+#define CUVS_INST_ALL_NEIGHBORS(T, IdxT)                                                 \
+  void build(const raft::resources& handle,                                              \
+             const all_neighbors_params& params,                                         \
+             raft::host_matrix_view<const T, IdxT, row_major> dataset,                   \
+             raft::device_matrix_view<IdxT, IdxT, row_major> indices,                    \
+             std::optional<raft::device_matrix_view<T, IdxT, row_major>> distances,      \
+             std::optional<raft::device_vector_view<T, IdxT, row_major>> core_distances, \
+             T alpha)                                                                    \
+  {                                                                                      \
+    return all_neighbors::detail::build<T, IdxT>(                                        \
+      handle, params, dataset, indices, distances, core_distances, alpha);               \
+  }                                                                                      \
+                                                                                         \
+  void build(const raft::resources& handle,                                              \
+             const all_neighbors_params& params,                                         \
+             raft::device_matrix_view<const T, IdxT, row_major> dataset,                 \
+             raft::device_matrix_view<IdxT, IdxT, row_major> indices,                    \
+             std::optional<raft::device_matrix_view<T, IdxT, row_major>> distances,      \
+             std::optional<raft::device_vector_view<T, IdxT, row_major>> core_distances, \
+             T alpha)                                                                    \
+  {                                                                                      \
+    return all_neighbors::detail::build<T, IdxT>(                                        \
+      handle, params, dataset, indices, distances, core_distances, alpha);               \
   }
 
 CUVS_INST_ALL_NEIGHBORS(float, int64_t);

--- a/cpp/src/neighbors/all_neighbors/all_neighbors.cuh
+++ b/cpp/src/neighbors/all_neighbors/all_neighbors.cuh
@@ -15,71 +15,104 @@
  */
 
 #pragma once
+#include "../detail/reachability.cuh"
 #include "all_neighbors_batched.cuh"
 #include <cuvs/neighbors/all_neighbors.hpp>
+#include <cuvs/neighbors/graph_build_types.hpp>
+#include <raft/matrix/shift.cuh>
 #include <raft/util/cudart_utils.hpp>
 
 namespace cuvs::neighbors::all_neighbors::detail {
 using namespace cuvs::neighbors;
 
-void check_metric(const all_neighbors_params& params)
+GRAPH_BUILD_ALGO check_params_validity(const all_neighbors_params& params,
+                                       bool do_mutual_reachability_dist)
 {
   if (std::holds_alternative<graph_build_params::brute_force_params>(params.graph_build_params)) {
-    auto allowed_metrics_batch = params.metric == cuvs::distance::DistanceType::L2Expanded ||
-                                 params.metric == cuvs::distance::DistanceType::L2SqrtExpanded;
-    auto allowed_metrics_single = allowed_metrics_batch ||
-                                  params.metric == cuvs::distance::DistanceType::CosineExpanded ||
-                                  params.metric == cuvs::distance::DistanceType::InnerProduct;
-    // related issue: https://github.com/rapidsai/cuvs/issues/1056
-    RAFT_EXPECTS((params.n_clusters <= 1 && allowed_metrics_single) || allowed_metrics_batch,
-                 "Distance metric supported for for all-neighbors build with brute force depends "
-                 "on params.n_clusters. When params.n_clusters <= 1, supported metrics are "
-                 "L2Expanded, L2SqrtExpanded, CosineExpanded, or InnerProduct. When "
-                 "params.n_clusters > 1, supported metrics are L2Expanded, L2SqrtExpanded.");
+    if (do_mutual_reachability_dist) {
+      // InnerProduct is not supported for mutual reachability distance, because mutual reachability
+      // distance takes "max" of core distances and pairwise distance.
+      auto allowed_metrics = params.metric == cuvs::distance::DistanceType::L2Expanded ||
+                             params.metric == cuvs::distance::DistanceType::L2SqrtExpanded ||
+                             params.metric == cuvs::distance::DistanceType::CosineExpanded;
+      RAFT_EXPECTS(
+        allowed_metrics,
+        "Distance metric for all-neighbors build with brute force for computing mutual "
+        "reachability distance should be L2Expanded, L2SqrtExpanded, or CosineExpanded.");
+    } else {
+      auto allowed_metrics = params.metric == cuvs::distance::DistanceType::L2Expanded ||
+                             params.metric == cuvs::distance::DistanceType::L2SqrtExpanded ||
+                             params.metric == cuvs::distance::DistanceType::CosineExpanded ||
+                             params.metric == cuvs::distance::DistanceType::InnerProduct;
+      RAFT_EXPECTS(allowed_metrics,
+                   "Distance metric for all-neighbors build with brute force should be L2Expanded, "
+                   "L2SqrtExpanded, CosineExpanded, or InnerProduct.");
+    }
+    return GRAPH_BUILD_ALGO::BRUTE_FORCE;
   } else if (std::holds_alternative<graph_build_params::nn_descent_params>(
                params.graph_build_params)) {
-    auto allowed_metrics = params.metric == cuvs::distance::DistanceType::L2Expanded ||
-                           params.metric == cuvs::distance::DistanceType::L2SqrtExpanded ||
-                           params.metric == cuvs::distance::DistanceType::CosineExpanded ||
-                           params.metric == cuvs::distance::DistanceType::InnerProduct;
-    RAFT_EXPECTS(allowed_metrics,
-                 "Distance metric for all-neighbors build with NN Descent should be L2Expanded, "
-                 "L2SqrtExpanded, CosineExpanded, or InnerProduct");
+    if (do_mutual_reachability_dist) {
+      // InnerProduct is not supported for mutual reachability distance, because mutual reachability
+      // distance takes "max" of core distances and pairwise distance.
+      auto allowed_metrics = params.metric == cuvs::distance::DistanceType::L2Expanded ||
+                             params.metric == cuvs::distance::DistanceType::L2SqrtExpanded ||
+                             params.metric == cuvs::distance::DistanceType::CosineExpanded;
+      RAFT_EXPECTS(
+        allowed_metrics,
+        "Distance metric for all-neighbors build with NN Descent for computing mutual reachability "
+        "distance should be L2Expanded, L2SqrtExpanded, or CosineExpanded.");
+    } else {
+      auto allowed_metrics = params.metric == cuvs::distance::DistanceType::L2Expanded ||
+                             params.metric == cuvs::distance::DistanceType::L2SqrtExpanded ||
+                             params.metric == cuvs::distance::DistanceType::CosineExpanded ||
+                             params.metric == cuvs::distance::DistanceType::InnerProduct;
+      RAFT_EXPECTS(allowed_metrics,
+                   "Distance metric for all-neighbors build with NN Descent should be L2Expanded, "
+                   "L2SqrtExpanded, CosineExpanded, or InnerProduct.");
+    }
+    return GRAPH_BUILD_ALGO::NN_DESCENT;
   } else if (std::holds_alternative<graph_build_params::ivf_pq_params>(params.graph_build_params)) {
     RAFT_EXPECTS(params.metric == cuvs::distance::DistanceType::L2Expanded,
                  "Distance metric for all-neighbors build with IVFPQ should be L2Expanded");
+    RAFT_EXPECTS(!do_mutual_reachability_dist,
+                 "mutual reachability distance cannot be calculated using IVFPQ");
+    return GRAPH_BUILD_ALGO::IVF_PQ;
   } else {
     RAFT_FAIL("Invalid all-neighbors build algo");
   }
 }
 
 // Single build (i.e. no batching) supports both host and device datasets
-template <typename T, typename IdxT, typename Accessor>
+template <typename T, typename IdxT, typename Accessor, typename DistEpilogueT = raft::identity_op>
 void single_build(
   const raft::resources& handle,
   const all_neighbors_params& params,
   mdspan<const T, matrix_extent<IdxT>, row_major, Accessor> dataset,
   raft::device_matrix_view<IdxT, IdxT, row_major> indices,
-  std::optional<raft::device_matrix_view<T, IdxT, row_major>> distances = std::nullopt)
+  std::optional<raft::device_matrix_view<T, IdxT, row_major>> distances = std::nullopt,
+  DistEpilogueT dist_epilogue                                           = DistEpilogueT{})
 {
   size_t num_rows = static_cast<size_t>(dataset.extent(0));
   size_t num_cols = static_cast<size_t>(dataset.extent(1));
 
   auto knn_builder = get_knn_builder<T, IdxT>(
-    handle, params, num_rows, num_rows, indices.extent(1), indices, distances);
+    handle, params, num_rows, num_rows, indices.extent(1), indices, distances, dist_epilogue);
 
   knn_builder->prepare_build(dataset);
   knn_builder->build_knn(dataset);
 }
 
 template <typename T, typename IdxT>
-void build(const raft::resources& handle,
-           const all_neighbors_params& params,
-           raft::host_matrix_view<const T, IdxT, row_major> dataset,
-           raft::device_matrix_view<IdxT, IdxT, row_major> indices,
-           std::optional<raft::device_matrix_view<T, IdxT, row_major>> distances = std::nullopt)
+void build(
+  const raft::resources& handle,
+  const all_neighbors_params& params,
+  raft::host_matrix_view<const T, IdxT, row_major> dataset,
+  raft::device_matrix_view<IdxT, IdxT, row_major> indices,
+  std::optional<raft::device_matrix_view<T, IdxT, row_major>> distances      = std::nullopt,
+  std::optional<raft::device_vector_view<T, IdxT, row_major>> core_distances = std::nullopt,
+  T alpha                                                                    = 1.0)
 {
-  check_metric(params);
+  auto build_algo = check_params_validity(params, core_distances.has_value());
 
   RAFT_EXPECTS(dataset.extent(0) == indices.extent(0),
                "number of rows in dataset should be the same as number of rows in indices matrix");
@@ -90,21 +123,75 @@ void build(const raft::resources& handle,
                  "indices matrix and distances matrix has to be the same shape.");
   }
 
+  if (core_distances.has_value()) {
+    RAFT_EXPECTS(distances.has_value(),
+                 "distances matrix should be allocated to get mutual reachability distance.");
+  }
+
+  std::unique_ptr<BatchBuildAux<IdxT>> aux_vectors;
   if (params.n_clusters == 1) {
     single_build(handle, params, dataset, indices, distances);
   } else {
-    batch_build(handle, params, dataset, indices, distances);
+    if (core_distances.has_value()) {
+      aux_vectors = std::make_unique<BatchBuildAux<IdxT>>(
+        params.n_clusters, dataset.extent(0), params.overlap_factor);
+      batch_build(handle, params, dataset, indices, distances, aux_vectors.get());
+    } else {
+      batch_build(handle, params, dataset, indices, distances);
+    }
+  }
+
+  // NN Descent doesn't include self loops. Shifted to keep it consistent with brute force and ivfpq
+  bool need_shift = (build_algo == GRAPH_BUILD_ALGO::NN_DESCENT) &&
+                    (params.metric != cuvs::distance::DistanceType::InnerProduct);
+
+  if (need_shift) {
+    raft::matrix::shift(handle, indices, 1);
+    if (distances.has_value()) {
+      raft::matrix::shift(handle, distances.value(), 1, std::make_optional<T>(0.0));
+    }
+  }
+
+  if (core_distances.has_value()) {  // calculate mutual reachability distances
+    size_t k        = indices.extent(1);
+    size_t num_rows = core_distances.value().size();
+    cuvs::neighbors::detail::reachability::core_distances<IdxT, T>(
+      distances.value().data_handle(),
+      k,
+      k,
+      num_rows,
+      core_distances.value().data_handle(),
+      raft::resource::get_cuda_stream(handle));
+
+    using ReachabilityPP = cuvs::neighbors::detail::reachability::ReachabilityPostProcess<IdxT, T>;
+    auto dist_epilogue   = ReachabilityPP{core_distances.value().data_handle(), alpha, num_rows};
+    if (params.n_clusters == 1) {
+      single_build(handle, params, dataset, indices, distances, dist_epilogue);
+    } else {
+      batch_build(handle, params, dataset, indices, distances, aux_vectors.get(), dist_epilogue);
+    }
+
+    if (need_shift) {
+      raft::matrix::shift(handle, indices, 1);
+      raft::matrix::shift(handle,
+                          distances.value(),
+                          raft::make_device_matrix_view<const T, IdxT>(
+                            core_distances.value().data_handle(), num_rows, 1));
+    }
   }
 }
 
 template <typename T, typename IdxT>
-void build(const raft::resources& handle,
-           const all_neighbors_params& params,
-           raft::device_matrix_view<const T, IdxT, row_major> dataset,
-           raft::device_matrix_view<IdxT, IdxT, row_major> indices,
-           std::optional<raft::device_matrix_view<T, IdxT, row_major>> distances = std::nullopt)
+void build(
+  const raft::resources& handle,
+  const all_neighbors_params& params,
+  raft::device_matrix_view<const T, IdxT, row_major> dataset,
+  raft::device_matrix_view<IdxT, IdxT, row_major> indices,
+  std::optional<raft::device_matrix_view<T, IdxT, row_major>> distances      = std::nullopt,
+  std::optional<raft::device_vector_view<T, IdxT, row_major>> core_distances = std::nullopt,
+  T alpha                                                                    = 1.0)
 {
-  check_metric(params);
+  auto build_algo = check_params_validity(params, core_distances.has_value());
 
   RAFT_EXPECTS(dataset.extent(0) == indices.extent(0),
                "number of rows in dataset should be the same as number of rows in indices matrix");
@@ -113,6 +200,11 @@ void build(const raft::resources& handle,
     RAFT_EXPECTS(indices.extent(0) == distances.value().extent(0) &&
                    indices.extent(1) == distances.value().extent(1),
                  "indices matrix and distances matrix has to be the same shape.");
+  }
+
+  if (core_distances.has_value()) {
+    RAFT_EXPECTS(distances.has_value(),
+                 "distances matrix should be allocated to get mutual reachability distance.");
   }
 
   if (params.n_clusters > 1) {
@@ -121,6 +213,41 @@ void build(const raft::resources& handle,
       "batch build.");
   } else {
     single_build(handle, params, dataset, indices, distances);
+  }
+
+  // NN Descent doesn't include self loops. Shifted to keep it consistent with brute force and ivfpq
+  bool need_shift = (build_algo == GRAPH_BUILD_ALGO::NN_DESCENT) &&
+                    (params.metric != cuvs::distance::DistanceType::InnerProduct);
+
+  if (need_shift) {
+    raft::matrix::shift(handle, indices, 1);
+    if (distances.has_value()) {
+      raft::matrix::shift(handle, distances.value(), 1, std::make_optional<T>(0.0));
+    }
+  }
+
+  if (core_distances.has_value()) {
+    size_t k        = indices.extent(1);
+    size_t num_rows = core_distances.value().size();
+    cuvs::neighbors::detail::reachability::core_distances<IdxT, T>(
+      distances.value().data_handle(),
+      k,
+      k,
+      num_rows,
+      core_distances.value().data_handle(),
+      raft::resource::get_cuda_stream(handle));
+
+    using ReachabilityPP = cuvs::neighbors::detail::reachability::ReachabilityPostProcess<IdxT, T>;
+    auto dist_epilogue   = ReachabilityPP{core_distances.value().data_handle(), alpha, num_rows};
+    single_build(handle, params, dataset, indices, distances, dist_epilogue);
+
+    if (need_shift) {
+      raft::matrix::shift(handle, indices, 1);
+      raft::matrix::shift(handle,
+                          distances.value(),
+                          raft::make_device_matrix_view<const T, IdxT>(
+                            core_distances.value().data_handle(), num_rows, 1));
+    }
   }
 }
 }  // namespace cuvs::neighbors::all_neighbors::detail

--- a/cpp/tests/neighbors/all_neighbors.cuh
+++ b/cpp/tests/neighbors/all_neighbors.cuh
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include "../../src/neighbors/detail/knn_brute_force.cuh"
+#include "../../src/neighbors/detail/reachability.cuh"
 #include "../test_utils.cuh"
 #include "ann_utils.cuh"
 #include "naive_knn.cuh"
@@ -52,6 +54,7 @@ struct AllNeighborsInputs {
   int dim;
   int k;
   bool data_on_host;
+  bool mutual_reach;
 };
 
 inline ::std::ostream& operator<<(::std::ostream& os, const AllNeighborsInputs& p)
@@ -101,6 +104,7 @@ void get_graphs(raft::resources& handle,
     params.graph_build_params = ivfpq_build_params;
   }
 
+  auto metric      = std::get<1>(ps.build_algo_metric_recall);
   auto cuda_stream = raft::resource::get_cuda_stream(handle);
   {
     rmm::device_uvector<DistanceT> distances_naive_dev(queries_size, cuda_stream);
@@ -115,6 +119,46 @@ void get_graphs(raft::resources& handle,
                                       ps.dim,
                                       ps.k,
                                       std::get<1>(ps.build_algo_metric_recall));
+
+    if (ps.mutual_reach) {
+      rmm::device_uvector<DistanceT> core_dists_dev(ps.n_rows, cuda_stream);
+
+      cuvs::neighbors::detail::reachability::core_distances<IdxT, DistanceT>(
+        distances_naive_dev.data(),
+        ps.k,
+        ps.k,
+        ps.n_rows,
+        core_dists_dev.data(),
+        raft::resource::get_cuda_stream(handle));
+
+      auto epilogue =
+        cuvs::neighbors::detail::reachability::ReachabilityPostProcess<IdxT, DistanceT>{
+          core_dists_dev.data(), 1.0, static_cast<size_t>(ps.n_rows)};
+
+      cuvs::neighbors::detail::tiled_brute_force_knn<
+        DataT,
+        IdxT,
+        DistanceT,
+        cuvs::neighbors::detail::reachability::ReachabilityPostProcess<IdxT, DistanceT>>(
+        handle,
+        database.data(),
+        database.data(),
+        ps.n_rows,
+        ps.n_rows,
+        ps.dim,
+        ps.k,
+        distances_naive_dev.data(),
+        indices_naive_dev.data(),
+        metric,
+        2.0,
+        0,
+        0,
+        nullptr,
+        nullptr,
+        nullptr,
+        epilogue);
+    }
+
     raft::update_host(indices_bf.data(), indices_naive_dev.data(), queries_size, cuda_stream);
     raft::update_host(distances_bf.data(), distances_naive_dev.data(), queries_size, cuda_stream);
 
@@ -134,7 +178,10 @@ void get_graphs(raft::resources& handle,
         params,
         raft::make_const_mdspan(database_h.view()),
         raft::make_device_matrix_view<IdxT>(indices_allNN_dev.data(), ps.n_rows, ps.k),
-        raft::make_device_matrix_view<DistanceT>(distances_allNN_dev.data(), ps.n_rows, ps.k));
+        raft::make_device_matrix_view<DistanceT>(distances_allNN_dev.data(), ps.n_rows, ps.k),
+        ps.mutual_reach
+          ? std::make_optional(raft::make_device_vector<DistanceT>(handle, ps.n_rows).view())
+          : std::nullopt);
 
     } else {
       all_neighbors::build(
@@ -142,7 +189,10 @@ void get_graphs(raft::resources& handle,
         params,
         raft::make_device_matrix_view<const DataT, IdxT>(database.data(), ps.n_rows, ps.dim),
         raft::make_device_matrix_view<IdxT>(indices_allNN_dev.data(), ps.n_rows, ps.k),
-        raft::make_device_matrix_view<DistanceT>(distances_allNN_dev.data(), ps.n_rows, ps.k));
+        raft::make_device_matrix_view<DistanceT>(distances_allNN_dev.data(), ps.n_rows, ps.k),
+        ps.mutual_reach
+          ? std::make_optional(raft::make_device_vector<DistanceT>(handle, ps.n_rows).view())
+          : std::nullopt);
     }
 
     raft::copy(indices_allNN.data(), indices_allNN_dev.data(), queries_size, cuda_stream);
@@ -223,13 +273,16 @@ const std::vector<AllNeighborsInputs> inputsSingle =
     {5000, 7151},                 // n_rows
     {64, 137},                    // dim
     {16, 23},                     // graph_degree
-    {false, true}                 // data on host
+    {false, true},                // data on host
+    {false}                       // mutual_reach
   );
 
 const std::vector<AllNeighborsInputs> inputsBatch =
   raft::util::itertools::product<AllNeighborsInputs>(
     {std::make_tuple(BRUTE_FORCE, cuvs::distance::DistanceType::L2Expanded, 0.9),
      std::make_tuple(BRUTE_FORCE, cuvs::distance::DistanceType::L2SqrtExpanded, 0.9),
+     std::make_tuple(BRUTE_FORCE, cuvs::distance::DistanceType::CosineExpanded, 0.9),
+     std::make_tuple(BRUTE_FORCE, cuvs::distance::DistanceType::InnerProduct, 0.9),
      std::make_tuple(IVF_PQ, cuvs::distance::DistanceType::L2Expanded, 0.9),
      std::make_tuple(NN_DESCENT, cuvs::distance::DistanceType::L2Expanded, 0.9),
      std::make_tuple(NN_DESCENT, cuvs::distance::DistanceType::L2SqrtExpanded, 0.9),
@@ -243,7 +296,44 @@ const std::vector<AllNeighborsInputs> inputsBatch =
     {5000, 7151},  // n_rows
     {64, 137},     // dim
     {16, 23},      // graph_degree
-    {true}         // data on host
+    {true},        // data on host
+    {false}        // mutual_reach
+  );
+
+const std::vector<AllNeighborsInputs> mutualReachSingle =
+  raft::util::itertools::product<AllNeighborsInputs>(
+    {std::make_tuple(BRUTE_FORCE, cuvs::distance::DistanceType::L2Expanded, 0.9),
+     std::make_tuple(BRUTE_FORCE, cuvs::distance::DistanceType::L2SqrtExpanded, 0.9),
+     std::make_tuple(BRUTE_FORCE, cuvs::distance::DistanceType::CosineExpanded, 0.9),
+     std::make_tuple(NN_DESCENT, cuvs::distance::DistanceType::L2Expanded, 0.9),
+     std::make_tuple(NN_DESCENT, cuvs::distance::DistanceType::L2SqrtExpanded, 0.9),
+     std::make_tuple(NN_DESCENT, cuvs::distance::DistanceType::CosineExpanded, 0.9)},
+    {std::make_tuple(1lu, 2lu)},  // n_clusters, overlap_factor
+    {5000, 7151},                 // n_rows
+    {64, 137},                    // dim
+    {16, 23},                     // graph_degree
+    {false, true},                // data on host
+    {true}                        // mutual_reach
+  );
+
+const std::vector<AllNeighborsInputs> mutualReachBatch =
+  raft::util::itertools::product<AllNeighborsInputs>(
+    {std::make_tuple(BRUTE_FORCE, cuvs::distance::DistanceType::L2Expanded, 0.9),
+     std::make_tuple(BRUTE_FORCE, cuvs::distance::DistanceType::L2SqrtExpanded, 0.9),
+     std::make_tuple(BRUTE_FORCE, cuvs::distance::DistanceType::CosineExpanded, 0.9),
+     std::make_tuple(NN_DESCENT, cuvs::distance::DistanceType::L2Expanded, 0.9),
+     std::make_tuple(NN_DESCENT, cuvs::distance::DistanceType::L2SqrtExpanded, 0.9),
+     std::make_tuple(NN_DESCENT, cuvs::distance::DistanceType::CosineExpanded, 0.9)},
+    {
+      std::make_tuple(4lu, 2lu),
+      std::make_tuple(7lu, 2lu),
+      std::make_tuple(10lu, 2lu),
+    },             // n_clusters, overlap_factor
+    {5000, 7151},  // n_rows
+    {64, 137},     // dim
+    {16, 23},      // graph_degree
+    {true},        // data on host
+    {true}         // mutual_reach
   );
 
 }  // namespace cuvs::neighbors::all_neighbors

--- a/cpp/tests/neighbors/all_neighbors/test_float.cu
+++ b/cpp/tests/neighbors/all_neighbors/test_float.cu
@@ -28,4 +28,12 @@ INSTANTIATE_TEST_CASE_P(AllNeighborsSingleTest,
                         ::testing::ValuesIn(inputsSingle));
 
 INSTANTIATE_TEST_CASE_P(AllNeighborsBatchTest, AllNeighborsTestF, ::testing::ValuesIn(inputsBatch));
+
+INSTANTIATE_TEST_CASE_P(AllNeighborsSingleMutualTest,
+                        AllNeighborsTestF,
+                        ::testing::ValuesIn(mutualReachSingle));
+
+INSTANTIATE_TEST_CASE_P(AllNeighborsBatchMutualTest,
+                        AllNeighborsTestF,
+                        ::testing::ValuesIn(mutualReachBatch));
 }  // namespace cuvs::neighbors::all_neighbors


### PR DESCRIPTION
Using `all_neighbors` mutual reachability feature to work towards deprecating `cuvs::neighbors::detail::reachability::mutual_reachability_graph` (related issue: https://github.com/rapidsai/cuvs/issues/982).

Also, changes `build_linkage` to use `int64_t`, because `all_neighbors::build` only supports `int64_t` types, and we will change HDBSCAN to use `int64_t` types in cuML as well.

**This PR will break cuML**

Waiting for https://github.com/rapidsai/cuvs/pull/1016 to be merged.