### PR TITLE
[Java] Make `cudaGetDeviceProperties` compatible with CUDA 12 and 13 based on symbol presence

### DIFF
--- a/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/Util.java
+++ b/java/cuvs-java/src/main/java22/com/nvidia/cuvs/internal/common/Util.java
@@ -65,15 +65,11 @@ public class Util {
       LINKER.downcallHandle(
           cudaMemcpyAsync$address(), cudaMemcpyAsync$descriptor(), Linker.Option.critical(true));
 
-  private static final String cudaGetDevicePropertiesSymbolName =
-      "12".equals(System.getenv("RAPIDS_CUDA_MAJOR"))
-          ? "cudaGetDeviceProperties_v2"
-          : "cudaGetDeviceProperties";
-
   private static final MethodHandle cudaGetDeviceProperties$mh =
       LINKER.downcallHandle(
           SYMBOL_LOOKUP
-              .find(cudaGetDevicePropertiesSymbolName)
+              .find("cudaGetDeviceProperties") // CUDA 13+ symbol name
+              .or(() -> SYMBOL_LOOKUP.find("cudaGetDeviceProperties_v2")) // CUDA 12 symbol name
               .orElseThrow(UnsatisfiedLinkError::new),
           FunctionDescriptor.of(headers_h.C_INT, headers_h.C_POINTER, headers_h.C_INT));
 


### PR DESCRIPTION
In #1273 we addressed a signature change in CUDA 13 by binding different symbols based on a environment variable, `RAPIDS_CUDA_MAJOR`. That works, but forces users of cuvs-java with CUDA 12 to define this environment variable.

This PR improves on it by making the symbol lookup dynamic, looking for the CUDA 13 symbol name, and falling back to the CUDA 12 exported name if we fail to locate the first.
