### PR TITLE
Fix inadvertent uses of copy constructor in mdarrays across cuVS

### DIFF
--- a/cpp/bench/ann/src/cuvs/cuvs_ann_bench_utils.h
+++ b/cpp/bench/ann/src/cuvs/cuvs_ann_bench_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -192,9 +192,9 @@ inline auto configured_raft_resources::operator=(configured_raft_resources&&)
 /** A helper to refine the neighbors when the data is on device or on host. */
 template <typename DatasetT, typename QueriesT, typename CandidatesT>
 void refine_helper(const raft::resources& res,
-                   DatasetT dataset,
-                   QueriesT queries,
-                   CandidatesT candidates,
+                   const DatasetT& dataset,
+                   const QueriesT& queries,
+                   const CandidatesT& candidates,
                    int k,
                    algo_base::index_type* neighbors,
                    float* distances,

--- a/cpp/src/neighbors/ivf_pq_index.cu
+++ b/cpp/src/neighbors/ivf_pq_index.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -302,7 +302,7 @@ uint32_t index<IdxT>::get_list_size_in_bytes(uint32_t label)
 {
   RAFT_EXPECTS(label < this->n_lists(),
                "Expected label to be less than number of lists in the index");
-  auto list_data = this->lists()[label]->data;
+  auto& list_data = this->lists()[label]->data;
   return list_data.size();
 }
 

--- a/cpp/src/preprocessing/spectral/spectral_embedding.cu
+++ b/cpp/src/preprocessing/spectral/spectral_embedding.cu
@@ -168,7 +168,7 @@ raft::device_csr_matrix<float, int, int, int> create_laplacian(
 void compute_eigenpairs(raft::resources const& handle,
                         params spectral_embedding_config,
                         const int n_samples,
-                        raft::device_csr_matrix<float, int, int, int> laplacian,
+                        raft::device_csr_matrix<float, int, int, int>& laplacian,
                         raft::device_vector_view<float, int> diagonal,
                         raft::device_matrix_view<float, int, raft::col_major> embedding)
 {

--- a/cpp/tests/distance/masked_nn.cu
+++ b/cpp/tests/distance/masked_nn.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,10 +89,10 @@ RAFT_KERNEL init_adj(AdjacencyPattern pattern,
 
 template <typename DataT, typename ReduceOpT, int NWARPS>
 __launch_bounds__(32 * NWARPS, 2) RAFT_KERNEL referenceKernel(raft::KeyValuePair<int, DataT>* min,
-                                                              DataT* x,
-                                                              DataT* y,
-                                                              bool* adj,
-                                                              int* group_idxs,
+                                                              const DataT* x,
+                                                              const DataT* y,
+                                                              const bool* adj,
+                                                              const int* group_idxs,
                                                               int m,
                                                               int n,
                                                               int k,
@@ -196,7 +196,7 @@ struct Inputs {
 };
 
 template <typename DataT, typename OutT = raft::KeyValuePair<int, DataT>>
-auto reference(const raft::handle_t& handle, Inputs<DataT> inp, const Params& p)
+auto reference(const raft::handle_t& handle, const Inputs<DataT>& inp, const Params& p)
   -> raft::device_vector<OutT, int>
 {
   int m          = inp.x.extent(0);
@@ -244,7 +244,7 @@ auto reference(const raft::handle_t& handle, Inputs<DataT> inp, const Params& p)
 }
 
 template <typename DataT, typename OutT = raft::KeyValuePair<int, DataT>>
-auto run_masked_nn(const raft::handle_t& handle, Inputs<DataT> inp, const Params& p)
+auto run_masked_nn(const raft::handle_t& handle, const Inputs<DataT>& inp, const Params& p)
   -> raft::device_vector<OutT, int>
 {
   // Compute norms:

--- a/cpp/tests/neighbors/ann_ivf_flat.cuh
+++ b/cpp/tests/neighbors/ann_ivf_flat.cuh
@@ -314,8 +314,8 @@ class AnnIVFFlatTest : public ::testing::TestWithParam<AnnIvfFlatInputs<IdxT>> {
       if (list_size > 0) {
         uint32_t padded_list_size = interleaved_group::roundUp(list_size);
         uint32_t n_elems          = padded_list_size * idx.dim();
-        auto list_data            = lists[label]->data;
-        auto list_inds            = extend_index.lists()[label]->indices;
+        auto& list_data           = lists[label]->data;
+        auto& list_inds           = extend_index.lists()[label]->indices;
 
         // fetch the flat codes
         auto flat_codes = raft::make_device_matrix<DataT, uint32_t>(handle_, list_size, idx.dim());
@@ -364,7 +364,7 @@ class AnnIVFFlatTest : public ::testing::TestWithParam<AnnIvfFlatInputs<IdxT>> {
                                      return DataT{0};
                                    });
 
-          auto extend_data          = extend_index.lists()[label]->data;
+          auto& extend_data         = extend_index.lists()[label]->data;
           auto extend_data_filtered = raft::make_device_vector<DataT, uint32_t>(handle_, n_elems);
           raft::linalg::map_offset(
             handle_,

--- a/examples/cpp/src/cagra_persistent_example.cu
+++ b/examples/cpp/src/cagra_persistent_example.cu
@@ -30,7 +30,7 @@
 
 // A helper to split the dataset into chunks
 template <typename DeviceMatrixOrView>
-auto slice_matrix(DeviceMatrixOrView source,
+auto slice_matrix(DeviceMatrixOrView& source,
                   typename DeviceMatrixOrView::index_type offset_rows,
                   typename DeviceMatrixOrView::index_type count_rows)
 {


### PR DESCRIPTION
As of current date, raft's device mdarray is copy-constructible. This has resulted in cuVS doing accidental mdarray (and its data) copies in a few places across cuVS codebase. In some cases, this leads to segfaults (use-after-destruction of the temporary copy). In other cases, this leads to unnecessary copying of data.

This PR fixes the problematic occurrences (found by removing the copy constructor in a local copy of raft and following the compiler errors).

Fixes https://github.com/rapidsai/cuvs/pull/1263
