### PR TITLE
[REVIEW] rename small_hash_size in single-CTA.

### DIFF
--- a/cpp/src/neighbors/detail/cagra/search_single_cta.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_single_cta.cuh
@@ -258,7 +258,7 @@ struct search : search_plan_impl<DataT, IndexT, DistanceT, SAMPLE_FILTER_T, Outp
                    smem_size,
                    hash_bitlen,
                    hashmap.data(),
-                   (small_hash_bitlen > 0 ? 1u : 0u),  // 转换为uint32_t
+                   (small_hash_bitlen > 0 ? 1u : 0u),
                    small_hash_reset_interval,
                    num_seeds,
                    sample_filter,

--- a/cpp/src/neighbors/detail/cagra/search_single_cta.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_single_cta.cuh
@@ -258,7 +258,7 @@ struct search : search_plan_impl<DataT, IndexT, DistanceT, SAMPLE_FILTER_T, Outp
                    smem_size,
                    hash_bitlen,
                    hashmap.data(),
-                   small_hash_bitlen,
+                   (small_hash_bitlen > 0 ? 1u : 0u),  // 转换为uint32_t
                    small_hash_reset_interval,
                    num_seeds,
                    sample_filter,

--- a/cpp/src/neighbors/detail/cagra/search_single_cta_inst.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_single_cta_inst.cuh
@@ -38,7 +38,7 @@ namespace cuvs::neighbors::cagra::detail::single_cta_search {
     uint32_t smem_size,                                                       \
     int64_t hash_bitlen,                                                      \
     IndexT* hashmap_ptr,                                                      \
-    size_t small_hash_bitlen,                                                 \
+    uint32_t use_small_hash,                                                  \
     size_t small_hash_reset_interval,                                         \
     uint32_t num_seeds,                                                       \
     SampleFilterT sample_filter,                                              \

--- a/cpp/src/neighbors/detail/cagra/search_single_cta_kernel.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_single_cta_kernel.cuh
@@ -37,7 +37,7 @@ void select_and_run(const dataset_descriptor_host<DataT, IndexT, DistanceT>& dat
                     uint32_t smem_size,
                     int64_t hash_bitlen,
                     IndexT* hashmap_ptr,
-                    size_t small_hash_bitlen,
+                    uint32_t use_small_hash,
                     size_t small_hash_reset_interval,
                     uint32_t num_seeds,
                     SampleFilterT sample_filter,


### PR DESCRIPTION
In the implementation of the single-cta algorithm in CAGRA, the naming of the variable `small_hash_bitlen` is inappropriate.
Both `single_cta_search::search` and `multi_cta_search::search` inherit from `search_plan_impl` , which in turn includes the member variable `small_hash_bitlen` . However, while in the multi-cta algorithm this parameter represents the bit length of the local hash, in the single-cta algorithm it is mainly used to determine whether the small hash method is being used. Even when the small hash method is used in single-cta, the hash length is still passed using `hash_bitlen` instead of `small_hash_bitlen` , which leads to potential confusion. Since it is used as a boolean flag in this context, `use_small_hash` is a more appropriate name.

This PR introduces the following changes:
1. Renames `small_hash_bitlen` to `use_small_hash` in the single-cta algorithm, and maps `small_hash_bitlen` to either 1 or 0.
2. The shared memory layout, which was previously determined by `small_hash_bitlen` , is now determined by the `hash_bitlen` parameter.
3. The check for whether the small hash method is used, which was previously done via `small_hash_bitlen` , is now handled by the `use_small_hash` parameter.

These changes do not affect program logic.