### PR TITLE
WIP: use CUDA 13.0.1 CI images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,8 +51,8 @@ jobs:
       fail-fast: false
       matrix:
         cuda_version:
-          - '12.9.1'
-          - '13.0.0'
+          - &latest_cuda12 '12.9.1'
+          - &latest_cuda13 '13.0.1'
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -72,8 +72,8 @@ jobs:
       fail-fast: false
       matrix:
         cuda_version:
-          - '12.9.1'
-          - '13.0.0'
+          - *latest_cuda12
+          - *latest_cuda13
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -93,8 +93,8 @@ jobs:
       fail-fast: false
       matrix:
         cuda_version:
-          - '12.9.1'
-          - '13.0.0'
+          - *latest_cuda12
+          - *latest_cuda13
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -159,8 +159,8 @@ jobs:
       fail-fast: false
       matrix:
         cuda_version:
-          - '12.9.1'
-          - '13.0.0'
+          - &latest_cuda12 '12.9.1'
+          - &latest_cuda13 '13.0.1'
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"
@@ -189,8 +189,8 @@ jobs:
       fail-fast: false
       matrix:
         cuda_version:
-          - '12.9.1'
-          - '13.0.0'
+          - *latest_cuda12
+          - *latest_cuda13
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"
@@ -207,8 +207,8 @@ jobs:
       fail-fast: false
       matrix:
         cuda_version:
-          - '12.9.1'
-          - '13.0.0'
+          - *latest_cuda12
+          - *latest_cuda13
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         cuda_version:
           - '12.9.1'
-          - '13.0.0'
+          - '13.0.1'
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}

--- a/java/docker-build/README.md
+++ b/java/docker-build/README.md
@@ -26,7 +26,7 @@ This builds using the defaults:
 ### Building for CUDA 13, All GPU Architectures
 
 ```bash
-CUDA_VERSION=13.0.0 ./build-in-docker
+CUDA_VERSION=13.0.1 ./build-in-docker
 ```
 
 ### Building for Local GPU Architecture Only
@@ -90,7 +90,7 @@ OS_VERSION=8 ./build-in-docker
 ### Build with Custom Maven Repository and ccache
 
 ```bash
-LOCAL_MAVEN_REPO=/custom/maven/repo LOCAL_CCACHE_DIR=/custom/ccache CUDA_VERSION=13.0.0 ./build-in-docker
+LOCAL_MAVEN_REPO=/custom/maven/repo LOCAL_CCACHE_DIR=/custom/ccache CUDA_VERSION=13.0.1 ./build-in-docker
 ```
 
 ### Build with Additional Docker Arguments


### PR DESCRIPTION
RAPIDS recently started building and testing against CUDA 13.0.1:

* https://github.com/rapidsai/ci-imgs/pull/304
* https://github.com/rapidsai/shared-workflows/pull/423

This updates hard-coded `13.0.0` references in some CI jobs to `13.0.1`.