### PR TITLE
[Review][C] Export the ability to get/set the log level to the C API

### DIFF
--- a/cpp/include/cuvs/core/c_api.h
+++ b/cpp/include/cuvs/core/c_api.h
@@ -20,6 +20,7 @@
 #include <dlpack/dlpack.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <rapids_logger/log_levels.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,6 +46,35 @@ const char* cuvsGetLastErrorText();
  *        clears any previously seen error message.
  */
 void cuvsSetLastErrorText(const char* error);
+
+/** @} */
+
+/**
+ * @defgroup log_c cuVS Logging
+ * @{
+ */
+
+ /**
+  * @brief An enum denoting log levels
+  *
+  */
+typedef enum {
+   CUVS_LOG_LEVEL_TRACE = RAPIDS_LOGGER_LOG_LEVEL_TRACE,
+   CUVS_LOG_LEVEL_DEBUG = RAPIDS_LOGGER_LOG_LEVEL_DEBUG,
+   CUVS_LOG_LEVEL_INFO = RAPIDS_LOGGER_LOG_LEVEL_INFO,
+   CUVS_LOG_LEVEL_WARN = RAPIDS_LOGGER_LOG_LEVEL_WARN,
+   CUVS_LOG_LEVEL_ERROR = RAPIDS_LOGGER_LOG_LEVEL_ERROR,
+   CUVS_LOG_LEVEL_CRITICAL = RAPIDS_LOGGER_LOG_LEVEL_CRITICAL,
+   CUVS_LOG_LEVEL_OFF = RAPIDS_LOGGER_LOG_LEVEL_OFF
+} cuvsLogLevel_t
+
+/** @brief Returns the current log level
+ */
+cuvsLogLevel_t cuvsGetLogLevel();
+
+/** @brief Sets the log level
+ */
+void cuvsSetLogLevel(cuvsLogLevel_t);
 
 /** @} */
 

--- a/cpp/include/cuvs/core/c_api.h
+++ b/cpp/include/cuvs/core/c_api.h
@@ -66,7 +66,7 @@ typedef enum {
    CUVS_LOG_LEVEL_ERROR = RAPIDS_LOGGER_LOG_LEVEL_ERROR,
    CUVS_LOG_LEVEL_CRITICAL = RAPIDS_LOGGER_LOG_LEVEL_CRITICAL,
    CUVS_LOG_LEVEL_OFF = RAPIDS_LOGGER_LOG_LEVEL_OFF
-} cuvsLogLevel_t
+} cuvsLogLevel_t;
 
 /** @brief Returns the current log level
  */

--- a/cpp/src/core/c_api.cpp
+++ b/cpp/src/core/c_api.cpp
@@ -24,6 +24,7 @@
 #include <raft/core/resource/resource_types.hpp>
 #include <raft/core/resources.hpp>
 #include <raft/util/cudart_utils.hpp>
+#include <rapids_logger/logger.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
@@ -210,6 +211,16 @@ thread_local std::string last_error_text = "";
 extern "C" const char* cuvsGetLastErrorText()
 {
   return last_error_text.empty() ? NULL : last_error_text.c_str();
+}
+
+extern "C" void cuvsSetLogLevel(cuvsLogLevel_t verbosity)
+{
+  raft::default_logger().set_level(reinterpret_cast<rapids_logger::level_enum>(verbosity));
+}
+
+extern "C" cuvsLogLevel_t cuvsGetLogLevel()
+{
+  return reinterpret_cast<cuvsLogLevel_t>(raft::default_logger().level());
 }
 
 extern "C" void cuvsSetLastErrorText(const char* error) { last_error_text = error ? error : ""; }

--- a/cpp/src/core/c_api.cpp
+++ b/cpp/src/core/c_api.cpp
@@ -215,12 +215,12 @@ extern "C" const char* cuvsGetLastErrorText()
 
 extern "C" void cuvsSetLogLevel(cuvsLogLevel_t verbosity)
 {
-  raft::default_logger().set_level(reinterpret_cast<rapids_logger::level_enum>(verbosity));
+  raft::default_logger().set_level(static_cast<rapids_logger::level_enum>(verbosity));
 }
 
 extern "C" cuvsLogLevel_t cuvsGetLogLevel()
 {
-  return reinterpret_cast<cuvsLogLevel_t>(raft::default_logger().level());
+  return static_cast<cuvsLogLevel_t>(raft::default_logger().level());
 }
 
 extern "C" void cuvsSetLastErrorText(const char* error) { last_error_text = error ? error : ""; }


### PR DESCRIPTION
CuVS uses raft underneath, which in turns uses `rapids_logger`. Users of the C++ API can access directly the logger used by raft via `raft::default_logger()`, and use it to get and set the log level. 
This is not possible for users of the C API (and of any API based on it, like the C API).
This PR adds specific C functions to close this gap.

Closes #1310 
