### PR TITLE
ANN_BENCH: Don't throw in noexcept do_deallocate

### DIFF
--- a/cpp/bench/ann/src/common/cuda_huge_page_resource.hpp
+++ b/cpp/bench/ann/src/common/cuda_huge_page_resource.hpp
@@ -15,8 +15,6 @@
  */
 #pragma once
 
-#include "util.hpp"
-
 #include <raft/core/error.hpp>
 #include <raft/core/logger_macros.hpp>
 


### PR DESCRIPTION
A follow-up fix for https://github.com/rapidsai/cuvs/pull/1416