### PR TITLE
eigen_solvers header

### DIFF
--- a/cpp/include/cuvs/sparse/cluster/eigen_solvers.hpp
+++ b/cpp/include/cuvs/sparse/cluster/eigen_solvers.hpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/core/resources.hpp>
+#include <raft/spectral/matrix_wrappers.hpp>
+
+namespace cuvs {
+namespace spectral {
+
+/**
+ * @brief Configuration parameters for eigen solver
+ *
+ * @tparam index_type_t Type for indices
+ * @tparam value_type_t Type for values (float/double)
+ * @tparam size_type_t Type for sizes (defaults to index_type_t)
+ */
+template <typename index_type_t, typename value_type_t, typename size_type_t = index_type_t>
+struct eigen_solver_config_t {
+  /** Number of eigenvectors to compute */
+  size_type_t n_eigVecs;
+
+  /** Maximum number of iterations */
+  size_type_t maxIter;
+
+  /** Number of iterations before restart */
+  size_type_t restartIter;
+
+  /** Tolerance for convergence */
+  value_type_t tol;
+
+  /** Whether to reorthogonalize eigenvectors */
+  bool reorthogonalize = false;
+
+  /**
+   * Random seed for initialization
+   * CAVEAT: this default value is now common to all instances of using seed in
+   * Lanczos; was not the case before: there were places where a default seed = 123456
+   * was used; this may trigger slightly different # solver iterations
+   */
+  unsigned long long seed = 1234567;
+};
+
+/**
+ * @brief Lanczos solver for computing eigenvectors and eigenvalues
+ *
+ * This class provides methods to compute the smallest or largest eigenvectors
+ * and eigenvalues of a sparse matrix using the Lanczos algorithm.
+ *
+ * @tparam index_type_t Type for indices
+ * @tparam value_type_t Type for values (float/double)
+ * @tparam size_type_t Type for sizes (defaults to index_type_t)
+ */
+template <typename index_type_t, typename value_type_t, typename size_type_t = index_type_t>
+class lanczos_solver_t {
+ public:
+  /**
+   * @brief Construct a new Lanczos solver
+   *
+   * @param config Configuration parameters for the solver
+   */
+  explicit lanczos_solver_t(
+    eigen_solver_config_t<index_type_t, value_type_t, size_type_t> const& config);
+
+  /**
+   * @brief Compute the smallest eigenvectors and eigenvalues
+   *
+   * @param handle RAFT resource handle
+   * @param A Sparse matrix for which to compute eigenvectors
+   * @param eigVals Output buffer for eigenvalues (size: n_eigVecs)
+   * @param eigVecs Output buffer for eigenvectors (size: n_rows * n_eigVecs)
+   * @return Number of iterations performed
+   */
+  index_type_t solve_smallest_eigenvectors(
+    raft::resources const& handle,
+    raft::spectral::matrix::sparse_matrix_t<index_type_t, value_type_t, size_type_t> const& A,
+    value_type_t* __restrict__ eigVals,
+    value_type_t* __restrict__ eigVecs) const;
+
+  /**
+   * @brief Compute the largest eigenvectors and eigenvalues
+   *
+   * @param handle RAFT resource handle
+   * @param A Sparse matrix for which to compute eigenvectors
+   * @param eigVals Output buffer for eigenvalues (size: n_eigVecs)
+   * @param eigVecs Output buffer for eigenvectors (size: n_rows * n_eigVecs)
+   * @return Number of iterations performed
+   */
+  index_type_t solve_largest_eigenvectors(
+    raft::resources const& handle,
+    raft::spectral::matrix::sparse_matrix_t<index_type_t, value_type_t, size_type_t> const& A,
+    value_type_t* __restrict__ eigVals,
+    value_type_t* __restrict__ eigVecs) const;
+
+  /**
+   * @brief Get the configuration object
+   *
+   * @return const reference to the configuration
+   */
+  auto const& get_config() const;
+
+ private:
+  eigen_solver_config_t<index_type_t, value_type_t, size_type_t> config_;
+};
+
+}  // namespace spectral
+}  // namespace cuvs

--- a/cpp/src/sparse/cluster/eigen_solvers.cu
+++ b/cpp/src/sparse/cluster/eigen_solvers.cu
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "eigen_solvers.cuh"
+
+namespace cuvs::spectral {
+
+#define CUVS_INST_LANCZOS_SOLVER(index_type, value_type, size_type)                      \
+  template class lanczos_solver_t<index_type, value_type, size_type>;                    \
+  template lanczos_solver_t<index_type, value_type, size_type>::lanczos_solver_t(        \
+    eigen_solver_config_t<index_type, value_type, size_type> const& config);             \
+  template index_type                                                                    \
+  lanczos_solver_t<index_type, value_type, size_type>::solve_smallest_eigenvectors(      \
+    raft::resources const& handle,                                                       \
+    raft::spectral::matrix::sparse_matrix_t<index_type, value_type, size_type> const& A, \
+    value_type* __restrict__ eigVals,                                                    \
+    value_type* __restrict__ eigVecs) const;                                             \
+  template index_type                                                                    \
+  lanczos_solver_t<index_type, value_type, size_type>::solve_largest_eigenvectors(       \
+    raft::resources const& handle,                                                       \
+    raft::spectral::matrix::sparse_matrix_t<index_type, value_type, size_type> const& A, \
+    value_type* __restrict__ eigVals,                                                    \
+    value_type* __restrict__ eigVecs) const;                                             \
+  template auto const& lanczos_solver_t<index_type, value_type, size_type>::get_config() const;
+
+// Instantiate for common type combinations
+CUVS_INST_LANCZOS_SOLVER(int, float, int);
+CUVS_INST_LANCZOS_SOLVER(int, double, int);
+CUVS_INST_LANCZOS_SOLVER(int64_t, float, int64_t);
+CUVS_INST_LANCZOS_SOLVER(int64_t, double, int64_t);
+
+#undef CUVS_INST_LANCZOS_SOLVER
+
+}  // namespace cuvs::spectral

--- a/cpp/src/sparse/cluster/eigen_solvers.cuh
+++ b/cpp/src/sparse/cluster/eigen_solvers.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,88 +18,74 @@
 
 #pragma once
 
+#include <cuvs/sparse/cluster/eigen_solvers.hpp>
+
 #include <raft/sparse/solver/lanczos.cuh>
 #include <raft/spectral/matrix_wrappers.hpp>
 
 namespace cuvs {
 namespace spectral {
 
-// aggregate of control params for Eigen Solver:
-//
-template <typename index_type_t, typename value_type_t, typename size_type_t = index_type_t>
-struct eigen_solver_config_t {
-  size_type_t n_eigVecs;
-  size_type_t maxIter;
+template <typename index_type_t, typename value_type_t, typename size_type_t>
+lanczos_solver_t<index_type_t, value_type_t, size_type_t>::lanczos_solver_t(
+  eigen_solver_config_t<index_type_t, value_type_t, size_type_t> const& config)
+  : config_(config)
+{
+}
 
-  size_type_t restartIter;
-  value_type_t tol;
+template <typename index_type_t, typename value_type_t, typename size_type_t>
+index_type_t lanczos_solver_t<index_type_t, value_type_t, size_type_t>::solve_smallest_eigenvectors(
+  raft::resources const& handle,
+  raft::spectral::matrix::sparse_matrix_t<index_type_t, value_type_t, size_type_t> const& A,
+  value_type_t* __restrict__ eigVals,
+  value_type_t* __restrict__ eigVecs) const
+{
+  RAFT_EXPECTS(eigVals != nullptr, "Null eigVals buffer.");
+  RAFT_EXPECTS(eigVecs != nullptr, "Null eigVecs buffer.");
+  index_type_t iters{};
+  raft::sparse::solver::computeSmallestEigenvectors(handle,
+                                                    A,
+                                                    config_.n_eigVecs,
+                                                    config_.maxIter,
+                                                    config_.restartIter,
+                                                    config_.tol,
+                                                    config_.reorthogonalize,
+                                                    iters,
+                                                    eigVals,
+                                                    eigVecs,
+                                                    config_.seed);
+  return iters;
+}
 
-  bool reorthogonalize{false};
-  unsigned long long seed{
-    1234567};  // CAVEAT: this default value is now common to all instances of using seed in
-               // Lanczos; was not the case before: there were places where a default seed = 123456
-               // was used; this may trigger slightly different # solver iterations
-};
+template <typename index_type_t, typename value_type_t, typename size_type_t>
+index_type_t lanczos_solver_t<index_type_t, value_type_t, size_type_t>::solve_largest_eigenvectors(
+  raft::resources const& handle,
+  raft::spectral::matrix::sparse_matrix_t<index_type_t, value_type_t, size_type_t> const& A,
+  value_type_t* __restrict__ eigVals,
+  value_type_t* __restrict__ eigVecs) const
+{
+  RAFT_EXPECTS(eigVals != nullptr, "Null eigVals buffer.");
+  RAFT_EXPECTS(eigVecs != nullptr, "Null eigVecs buffer.");
+  index_type_t iters{};
+  raft::sparse::solver::computeLargestEigenvectors(handle,
+                                                   A,
+                                                   config_.n_eigVecs,
+                                                   config_.maxIter,
+                                                   config_.restartIter,
+                                                   config_.tol,
+                                                   config_.reorthogonalize,
+                                                   iters,
+                                                   eigVals,
+                                                   eigVecs,
+                                                   config_.seed);
+  return iters;
+}
 
-template <typename index_type_t, typename value_type_t, typename size_type_t = index_type_t>
-struct lanczos_solver_t {
-  explicit lanczos_solver_t(
-    eigen_solver_config_t<index_type_t, value_type_t, size_type_t> const& config)
-    : config_(config)
-  {
-  }
-
-  index_type_t solve_smallest_eigenvectors(
-    raft::resources const& handle,
-    raft::spectral::matrix::sparse_matrix_t<index_type_t, value_type_t, size_type_t> const& A,
-    value_type_t* __restrict__ eigVals,
-    value_type_t* __restrict__ eigVecs) const
-  {
-    RAFT_EXPECTS(eigVals != nullptr, "Null eigVals buffer.");
-    RAFT_EXPECTS(eigVecs != nullptr, "Null eigVecs buffer.");
-    index_type_t iters{};
-    raft::sparse::solver::computeSmallestEigenvectors(handle,
-                                                      A,
-                                                      config_.n_eigVecs,
-                                                      config_.maxIter,
-                                                      config_.restartIter,
-                                                      config_.tol,
-                                                      config_.reorthogonalize,
-                                                      iters,
-                                                      eigVals,
-                                                      eigVecs,
-                                                      config_.seed);
-    return iters;
-  }
-
-  index_type_t solve_largest_eigenvectors(
-    raft::resources const& handle,
-    raft::spectral::matrix::sparse_matrix_t<index_type_t, value_type_t, size_type_t> const& A,
-    value_type_t* __restrict__ eigVals,
-    value_type_t* __restrict__ eigVecs) const
-  {
-    RAFT_EXPECTS(eigVals != nullptr, "Null eigVals buffer.");
-    RAFT_EXPECTS(eigVecs != nullptr, "Null eigVecs buffer.");
-    index_type_t iters{};
-    raft::sparse::solver::computeLargestEigenvectors(handle,
-                                                     A,
-                                                     config_.n_eigVecs,
-                                                     config_.maxIter,
-                                                     config_.restartIter,
-                                                     config_.tol,
-                                                     config_.reorthogonalize,
-                                                     iters,
-                                                     eigVals,
-                                                     eigVecs,
-                                                     config_.seed);
-    return iters;
-  }
-
-  auto const& get_config(void) const { return config_; }
-
- private:
-  eigen_solver_config_t<index_type_t, value_type_t, size_type_t> config_;
-};
+template <typename index_type_t, typename value_type_t, typename size_type_t>
+auto const& lanczos_solver_t<index_type_t, value_type_t, size_type_t>::get_config() const
+{
+  return config_;
+}
 
 }  // namespace spectral
 }  // namespace cuvs

--- a/cpp/tests/sparse/cluster/eigen_solvers.cu
+++ b/cpp/tests/sparse/cluster/eigen_solvers.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "../../../src/sparse/cluster/eigen_solvers.cuh"
 #include "../../../src/sparse/cluster/partition.cuh"
+#include <cuvs/sparse/cluster/eigen_solvers.hpp>
 #include <raft/core/nvtx.hpp>
 #include <raft/core/resource/device_id.hpp>
 #include <raft/core/resources.hpp>


### PR DESCRIPTION
Cugraph can't include the current `.cuh` implementation, so we need to add a header `.hpp`.
@jnke2016 