### PR TITLE
Use pinned_host_memory_resource instead of pinned_memory_resource.

### DIFF
--- a/c/src/core/c_api.cpp
+++ b/c/src/core/c_api.cpp
@@ -29,7 +29,7 @@
 #include <rmm/mr/device/owning_wrapper.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
-#include <rmm/mr/host/pinned_memory_resource.hpp>
+#include <rmm/mr/pinned_host_memory_resource.hpp>
 
 #include "../core/exceptions.hpp"
 
@@ -191,12 +191,12 @@ extern "C" cuvsError_t cuvsRMMMemoryResourceReset()
   });
 }
 
-thread_local std::unique_ptr<rmm::mr::pinned_memory_resource> pinned_mr;
+thread_local std::unique_ptr<rmm::mr::pinned_host_memory_resource> pinned_mr;
 
 extern "C" cuvsError_t cuvsRMMHostAlloc(void** ptr, size_t bytes)
 {
   return cuvs::core::translate_exceptions([=] {
-    if (pinned_mr == nullptr) { pinned_mr = std::make_unique<rmm::mr::pinned_memory_resource>(); }
+    if (pinned_mr == nullptr) { pinned_mr = std::make_unique<rmm::mr::pinned_host_memory_resource>(); }
     *ptr = pinned_mr->allocate(bytes);
   });
 }

--- a/cpp/src/neighbors/detail/ann_utils.cuh
+++ b/cpp/src/neighbors/detail/ann_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
-#include <rmm/mr/host/pinned_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda_fp16.hpp>

--- a/cpp/src/neighbors/detail/dynamic_batching.cuh
+++ b/cpp/src/neighbors/detail/dynamic_batching.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,6 @@
 #include <cooperative_groups.h>
 #include <cuda/atomic>
 #include <cuda/std/atomic>
-#include <rmm/mr/pinned_host_memory_resource.hpp>
-#include <rmm/resource_ref.hpp>
 
 #include <chrono>
 #include <limits>


### PR DESCRIPTION
We want to remove RMM's `pinned_memory_resource` in favor of `pinned_host_memory_resource`, because the latter aligns with CCCL's MR design that we will be adopting throughout RAPIDS/RMM.

This PR transitions cuVS to use `pinned_host_memory_resource`.

See https://github.com/rapidsai/rmm/issues/2090 for more information.
