### PR TITLE
[Review] [Java] Disable flaky Java tests to reduce CI churn

### DIFF
--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraBuildAndSearchIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraBuildAndSearchIT.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.LongToIntFunction;
 import java.util.function.Supplier;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -210,6 +211,7 @@ public class CagraBuildAndSearchIT extends CuVSTestCase {
             });
   }
 
+  @Ignore // https://github.com/rapidsai/cuvs/issues/1467
   @Test
   public void testFloatIndexing() throws Throwable {
     testIndexing(

--- a/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraRandomizedIT.java
+++ b/java/cuvs-java/src/test/java/com/nvidia/cuvs/CagraRandomizedIT.java
@@ -11,6 +11,7 @@ import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
 import java.util.BitSet;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -34,6 +35,7 @@ public class CagraRandomizedIT extends CuVSTestCase {
     DEVICE
   }
 
+  @Ignore // https://github.com/rapidsai/cuvs/issues/1468
   @Test
   public void testResultsTopKWithRandomValues() throws Throwable {
     TestDatasetMemoryKind[] testDatasetMemoryKinds = {


### PR DESCRIPTION
This commit disables two flaky Java tests:
1. `CagraBuildAndSearchIT.testFloatIndexing`: Per #1467.
2. `CagraRandomizedIT.testResultsTopKWithRandomValues`: Per #1468.

This is a temporary step, to reduce churn in CI runs.  These tests will be enabled after they're fixed properly.
