### PR TITLE
Use current system architecture in conda environment creation command

### DIFF
--- a/docs/source/build.rst
+++ b/docs/source/build.rst
@@ -98,7 +98,7 @@ Conda environment scripts are provided for installing the necessary dependencies
 
 .. code-block:: bash
 
-    conda env create --name cuvs -f conda/environments/all_cuda-130_arch-$(arch).yaml
+    conda env create --name cuvs -f conda/environments/all_cuda-130_arch-$(uname -m).yaml
     conda activate cuvs
 
 The recommended way to build and install cuVS from source is to use the `build.sh` script in the root of the repository. This script can build both the C++ and Python artifacts and provides CMake options for building and installing the headers, tests, benchmarks, and the pre-compiled shared library.

--- a/docs/source/cuvs_bench/build.rst
+++ b/docs/source/cuvs_bench/build.rst
@@ -23,7 +23,7 @@ The easiest (and most reproducible) way to install the dependencies needed to bu
 
 .. code-block:: bash
 
-    conda env create --name cuvs_benchmarks -f conda/environments/cuvs_bench_cuda-118_arch-$(arch).yaml
+    conda env create --name cuvs_benchmarks -f conda/environments/cuvs_bench_cuda-118_arch-$(uname -m).yaml
     conda activate cuvs_benchmarks
 
 The above conda environment will also reduce the compile times as dependencies like FAISS will already be installed and not need to be compiled with `rapids-cmake`.

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -7,7 +7,7 @@ This package provides Go bindings for the cuVS (CUDA Vector Search) library.
 The required dependencies can be installed with a simple command (which creates your build environment):
 
 ```bash
-conda env create --name go -f conda/environments/go_cuda-130_arch-$(arch).yaml
+conda env create --name go -f conda/environments/go_cuda-130_arch-$(uname -m).yaml
 conda activate go
 ```
 You may prefer to use `mamba`, as it provides significant speedup over `conda`.

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -9,7 +9,7 @@ Once the minimum requirements are satisfied, this example template application c
 You may follow these steps to quickly get set up:
 
 ```bash
-conda env create --name rust -f conda/environments/rust_cuda-130_arch-$(arch).yaml
+conda env create --name rust -f conda/environments/rust_cuda-130_arch-$(uname -m).yaml
 conda activate rust
 ```
 You may prefer to use `mamba`, as it provides significant speedup over `conda`.


### PR DESCRIPTION
This fixes a conda environment creation command to support both `x86_64` and `aarch64` systems.