### PR TITLE
Update to CUDA 13.0.2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         cuda_version:
           - &latest_cuda12 '12.9.1'
-          - &latest_cuda13 '13.0.1'
+          - &latest_cuda13 '13.0.2'
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -160,7 +160,7 @@ jobs:
       matrix:
         cuda_version:
           - &latest_cuda12 '12.9.1'
-          - &latest_cuda13 '13.0.1'
+          - &latest_cuda13 '13.0.2'
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         cuda_version:
           - '12.9.1'
-          - '13.0.1'
+          - '13.0.2'
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}


### PR DESCRIPTION
CUDA 13.0.2 images are now available. This updates our CI workflows to use them.

Depends on https://github.com/rapidsai/shared-workflows/pull/440.
