### PR TITLE
fix(ci): remove unsupported `name` parameter from custom job def

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,6 @@ jobs:
       date: ${{ inputs.date }}
       container_image: "rapidsai/ci-wheel:25.12-cuda${{ matrix.cuda_version }}-rockylinux8-py3.10"
       node_type: "cpu16"
-      name:  "${{ matrix.cuda_version }}, amd64, rockylinux8"
       # requires_license_builder: false
       script: "ci/build_standalone_c.sh"
       artifact-name: "libcuvs_c_${{ matrix.cuda_version }}.tar.gz"


### PR DESCRIPTION
CI isn't running because of this undefined parameter
