### PR TITLE
Update FAISS from 1.12.0 to 1.13.0

### DIFF
--- a/cpp/cmake/patches/faiss-1.13-cuvs-25.12.diff
+++ b/cpp/cmake/patches/faiss-1.13-cuvs-25.12.diff
@@ -120,34 +120,6 @@ index f23ca19d8..3ba606606 100644
  #endif
 
      /// Pinned memory allocation for use with this GPU
-diff --git a/faiss/gpu/impl/BinaryCuvsCagra.cu b/faiss/gpu/impl/BinaryCuvsCagra.cu
-index 0ca21dc5f..b331fdc8f 100644
---- a/faiss/gpu/impl/BinaryCuvsCagra.cu
-+++ b/faiss/gpu/impl/BinaryCuvsCagra.cu
-@@ -32,6 +32,9 @@
- #include <raft/core/resource/thrust_policy.hpp>
- #include <raft/linalg/map.cuh>
-
-+#include <thrust/copy.h>
-+#include <thrust/device_ptr.h>
-+
- namespace faiss {
- namespace gpu {
-
-diff --git a/faiss/gpu/impl/CuvsCagra.cu b/faiss/gpu/impl/CuvsCagra.cu
-index 482e4d672..4246776e8 100644
---- a/faiss/gpu/impl/CuvsCagra.cu
-+++ b/faiss/gpu/impl/CuvsCagra.cu
-@@ -31,6 +31,9 @@
- #include <raft/core/device_resources.hpp>
- #include <raft/core/resource/thrust_policy.hpp>
-
-+#include <thrust/copy.h>
-+#include <thrust/device_ptr.h>
-+
- namespace faiss {
- namespace gpu {
-
 diff --git a/faiss/gpu/impl/CuvsFlatIndex.cu b/faiss/gpu/impl/CuvsFlatIndex.cu
 index 15cf427cf..d877e766d 100644
 --- a/faiss/gpu/impl/CuvsFlatIndex.cu

--- a/cpp/cmake/patches/faiss_override.json
+++ b/cpp/cmake/patches/faiss_override.json
@@ -1,12 +1,12 @@
 {
   "packages" : {
     "faiss" : {
-      "version": "1.12.0",
+      "version": "1.13.0",
       "git_url": "https://github.com/facebookresearch/faiss.git",
-      "git_tag": "v1.12.0",
+      "git_tag": "v1.13.0",
       "patches" : [
         {
-          "file" : "${current_json_dir}/faiss-25.12.diff",
+          "file" : "${current_json_dir}/faiss-1.13-cuvs-25.12.diff",
           "issue" : "Multiple fixes for cuVS and RMM compatibility",
           "fixed_in" : ""
         }


### PR DESCRIPTION
## Summary
- Update FAISS dependency from 1.12.0 to 1.13.0
- Remove thrust include patches already present in FAISS 1.13.0
- All other RMM API compatibility patches still apply cleanly

Verified that updated patches apply cleanly to FAISS v1.13.0.

Follow-up to https://github.com/rapidsai/cuvs/pull/1566.