### PR TITLE
FAISS patch for removed raft headers

### DIFF
--- a/cpp/cmake/patches/faiss-1.13-cuvs-26.02.diff
+++ b/cpp/cmake/patches/faiss-1.13-cuvs-26.02.diff
@@ -1,0 +1,24 @@
+diff --git a/faiss/gpu/GpuDistance.cu b/faiss/gpu/GpuDistance.cu
+index c82c73e7d..65ed8a1d4 100644
+--- a/faiss/gpu/GpuDistance.cu
++++ b/faiss/gpu/GpuDistance.cu
+@@ -43,7 +43,6 @@
+ #include <raft/core/operators.hpp>
+ #include <raft/core/temporary_device_buffer.hpp>
+ #include <raft/linalg/unary_op.cuh>
+-#include <raft/neighbors/brute_force.cuh>
+ #endif
+
+ namespace faiss {
+diff --git a/faiss/gpu/impl/CuvsFlatIndex.cu b/faiss/gpu/impl/CuvsFlatIndex.cu
+index 15cf427cf..efc66ea94 100644
+--- a/faiss/gpu/impl/CuvsFlatIndex.cu
++++ b/faiss/gpu/impl/CuvsFlatIndex.cu
+@@ -31,7 +31,6 @@
+ #include <cuvs/neighbors/brute_force.hpp>
+ #include <raft/core/device_mdspan.hpp>
+ #include <raft/core/logger.hpp>
+-#include <raft/distance/distance_types.hpp>
+ #include <raft/linalg/unary_op.cuh>
+
+ namespace faiss {

--- a/cpp/cmake/patches/faiss_override.json
+++ b/cpp/cmake/patches/faiss_override.json
@@ -9,6 +9,11 @@
           "file" : "${current_json_dir}/faiss-1.13-cuvs-25.12.diff",
           "issue" : "Multiple fixes for cuVS and RMM compatibility",
           "fixed_in" : ""
+        },
+        {
+          "file" : "${current_json_dir}/faiss-1.13-cuvs-26.02.diff",
+          "issue" : "Multiple fixes for RAFT compatibility",
+          "fixed_in" : ""
         }
       ]
     }


### PR DESCRIPTION
Removes unused raft headers from faiss which have now been removed from raft altogether.

xref: https://github.com/rapidsai/raft/pull/2885