### PR TITLE
Skip Python Multi-GPU Doctests

### DIFF
--- a/python/cuvs/cuvs/tests/test_doctests.py
+++ b/python/cuvs/cuvs/tests/test_doctests.py
@@ -90,12 +90,9 @@ DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.cluster))
 DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.distance))
 DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.preprocessing.quantize))
 
-# Skip doctests that are known to cause sporadic segfaults (pending triage)
+# Filter out multi-GPU (mg) doctests since they are known to cause sporadic segfaults
 # See: https://github.com/rapidsai/cuvs/issues/1647
-SKIP_DOCTESTS = {
-    "cuvs.neighbors.cagra.cagra.build",
-}
-DOC_STRINGS = [ds for ds in DOC_STRINGS if ds.name not in SKIP_DOCTESTS]
+DOC_STRINGS = [ds for ds in DOC_STRINGS if ".mg." not in ds.name]
 
 
 def _test_name_from_docstring(docstring):

--- a/python/cuvs/cuvs/tests/test_doctests.py
+++ b/python/cuvs/cuvs/tests/test_doctests.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
@@ -89,6 +89,13 @@ DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.common))
 DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.cluster))
 DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.distance))
 DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.preprocessing.quantize))
+
+# Skip doctests that are known to cause sporadic segfaults (pending triage)
+# See: https://github.com/rapidsai/cuvs/issues/1647
+SKIP_DOCTESTS = {
+    "cuvs.neighbors.cagra.cagra.build",
+}
+DOC_STRINGS = [ds for ds in DOC_STRINGS if ds.name not in SKIP_DOCTESTS]
 
 
 def _test_name_from_docstring(docstring):

--- a/python/cuvs/cuvs/tests/test_doctests.py
+++ b/python/cuvs/cuvs/tests/test_doctests.py
@@ -19,6 +19,10 @@ import cuvs.preprocessing.quantize
 
 
 def _name_in_all(parent, name):
+    # Skip multi-GPU (mg) modules - they require special multi-GPU setup
+    # See: https://github.com/rapidsai/cuvs/issues/1647
+    if name == "mg" or name == "mg_resources" or name == "MultiGpuResources":
+        return False
     return name in getattr(parent, "__all__", [])
 
 
@@ -89,10 +93,6 @@ DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.common))
 DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.cluster))
 DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.distance))
 DOC_STRINGS.extend(_find_doctests_in_obj(cuvs.preprocessing.quantize))
-
-# Filter out multi-GPU (mg) doctests since they are known to cause sporadic segfaults
-# See: https://github.com/rapidsai/cuvs/issues/1647
-DOC_STRINGS = [ds for ds in DOC_STRINGS if ".mg." not in ds.name]
 
 
 def _test_name_from_docstring(docstring):


### PR DESCRIPTION
This test is flaky and difficult to reproduce. Disable until fully triaged. See https://github.com/rapidsai/cuvs/issues/1647.