### PR TITLE
Spectral Embedding with `all_neighbors`

### DIFF
--- a/cpp/src/preprocessing/spectral/detail/spectral_embedding.cuh
+++ b/cpp/src/preprocessing/spectral/detail/spectral_embedding.cuh
@@ -147,8 +147,8 @@ void create_connectivity_graph(
 
   auto stream = raft::resource::get_cuda_stream(handle);
 
-  auto d_indices   = raft::make_device_matrix<int64_t>(handle, n_samples, k_search);
-  auto d_distances = raft::make_device_matrix<float>(handle, n_samples, k_search);
+  auto d_indices   = raft::make_device_matrix<int64_t, int64_t>(handle, n_samples, k_search);
+  auto d_distances = raft::make_device_matrix<float, int64_t>(handle, n_samples, k_search);
 
   cuvs::neighbors::all_neighbors::all_neighbors_params all_neighbors_params{
     .graph_build_params =


### PR DESCRIPTION
Instead of using `cuvs::neighbors::brute_force::build` and `cuvs::neighbors::brute_force::search` we can consolidate to use the `cuvs::neighbors::all_neighbors::build` API.