### PR TITLE
Add arm64 builds to the libcuvs_c build.yaml matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,16 +53,19 @@ jobs:
         cuda_version:
           - &latest_cuda12 '12.9.1'
           - &latest_cuda13 '13.1.0'
+        arch:
+          - amd64
+          - arm64
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
-      arch: "amd64"
+      arch: "${{matrix.arch}}"
       date: ${{ inputs.date }}
       container_image: "rapidsai/ci-wheel:26.02-cuda${{ matrix.cuda_version }}-rockylinux8-py3.10"
       node_type: "cpu16"
       # requires_license_builder: false
       script: "ci/build_standalone_c.sh"
-      artifact-name: "libcuvs_c_${{ matrix.cuda_version }}.tar.gz"
+      artifact-name: "libcuvs_c_${{ matrix.cuda_version }}_${{ matrix.arch }}.tar.gz"
       file_to_upload: "libcuvs_c.tar.gz"
       sha: ${{ inputs.sha }}
       sccache-dist-token-secret-name: GIST_REPO_READ_ORG_GITHUB_TOKEN


### PR DESCRIPTION
Extend the rocky8-clib-standalone-build to include arm64 builds for build.yaml

Ports the changes of https://github.com/rapidsai/cuvs/pull/1570 over to build.yaml