### PR TITLE
clang-tidy: remove AnalyzeTemporaryDtors key

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -4,7 +4,6 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*,-modernize-make-*,-modernize-raw-string-literal,google-*,-google-default-arguments,-clang-diagnostic-#pragma-messages,readability-identifier-naming,-*,modernize-*,-modernize-make-*,-modernize-raw-string-literal,google-*,-google-default-arguments,-clang-diagnostic-#pragma-messages,readability-identifier-naming'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 User:            snanditale
 CheckOptions:


### PR DESCRIPTION
The `AnalyzeTemporaryDtors` was removed from clang-tidy since around ver 18.
This PR removes the option to make clang-tidy not crash on our codebase.

Reference: https://prereleases.llvm.org/16.0.0/rc3/tools/clang/tools/extra/docs/ReleaseNotes.html#improvements-to-clang-tidy