### PR TITLE
check-nightly-ci: remove testing config

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,7 +49,6 @@ jobs:
       id-token: write
     env:
       GH_TOKEN: ${{ github.token }}
-      SHARED_ACTIONS_REF: 'check-nightly-success'
     steps:
       - name: Get PR Info
         id: get-pr-info


### PR DESCRIPTION
## Description

Follow-up to #1813 

Removes some testing configuration left behind in that PR.