### PR TITLE
Better `ncv` param spectral embedding edge case

### DIFF
--- a/cpp/src/preprocessing/spectral/detail/spectral_embedding.cuh
+++ b/cpp/src/preprocessing/spectral/detail/spectral_embedding.cuh
@@ -63,7 +63,8 @@ void compute_eigenpairs(raft::resources const& handle,
   auto config           = raft::sparse::solver::lanczos_solver_config<DataT>();
   config.n_components   = spectral_embedding_config.n_components;
   config.max_iterations = 10 * n_samples;
-  RAFT_EXPECTS(n_samples - config.n_components > 0, "Please set `ncv` to a value in (0, n_samples)");
+  RAFT_EXPECTS(n_samples - config.n_components > 0,
+               "Please set `ncv` to a value in (0, n_samples)");
   config.ncv = std::min(n_samples - config.n_components, std::max(2 * config.n_components + 1, 20));
   config.tolerance = spectral_embedding_config.tolerance;
   config.which     = raft::sparse::solver::LANCZOS_WHICH::LA;


### PR DESCRIPTION
It is possible that `ncv`, Krylov subspace dimensions `ncv x ncv`, could be the same as the affinity matrix size if the matrix size is really small for spectral embedding. This causes instabilities during the lanczos restart method. This PR changes the `ncv` to be `ncv<n_samples`. Context: this solves some sklearn upstream Spectral Clustering test on the cuml side.