### PR TITLE
Update Cython lower bound pin to 3.2.2

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cuda-version=12.9
 - cupy>=13.6.0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dlpack>=0.8,<1.0
 - doxygen>=1.8.20
 - gcc_linux-aarch64=14.*

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cuda-version=12.9
 - cupy>=13.6.0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dlpack>=0.8,<1.0
 - doxygen>=1.8.20
 - gcc_linux-64=14.*

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cuda-version=13.1
 - cupy>=13.6.0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dlpack>=0.8,<1.0
 - doxygen>=1.8.20
 - gcc_linux-aarch64=14.*

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cuda-version=13.1
 - cupy>=13.6.0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dlpack>=0.8,<1.0
 - doxygen>=1.8.20
 - gcc_linux-64=14.*

--- a/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dlpack>=0.8,<1.0
 - gcc_linux-aarch64=14.*
 - glog>=0.6.0

--- a/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dlpack>=0.8,<1.0
 - gcc_linux-64=14.*
 - glog>=0.6.0

--- a/conda/environments/bench_ann_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-131_arch-aarch64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dlpack>=0.8,<1.0
 - gcc_linux-aarch64=14.*
 - glog>=0.6.0

--- a/conda/environments/bench_ann_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-131_arch-x86_64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dlpack>=0.8,<1.0
 - gcc_linux-64=14.*
 - glog>=0.6.0

--- a/conda/recipes/cuvs/recipe.yaml
+++ b/conda/recipes/cuvs/recipe.yaml
@@ -69,7 +69,7 @@ requirements:
     - ${{ stdlib("c") }}
   host:
     - cuda-version =${{ cuda_version }}
-    - cython >=3.0.0,<3.2.0
+    - cython >=3.2.2
     - dlpack >=0.8
     - libcuvs =${{ version }}
     - pip

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -233,7 +233,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - cython>=3.0.0,<3.2.0
+          - cython>=3.2.2
   rapids_build:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/cuvs/pyproject.toml
+++ b/python/cuvs/pyproject.toml
@@ -107,7 +107,7 @@ regex = "(?P<value>.*)"
 requires = [
     "cmake>=3.30.4",
     "cuda-python>=13.0.1,<14.0",
-    "cython>=3.0.0,<3.2.0",
+    "cython>=3.2.2",
     "libcuvs==26.4.*,>=0.0.0a0",
     "libraft==26.4.*,>=0.0.0a0",
     "librmm==26.4.*,>=0.0.0a0",


### PR DESCRIPTION
## Summary

Refs https://github.com/rapidsai/build-planning/issues/229

Updates the Cython lower bound pin to `>=3.2.2`. The `<3.2.0` upper bound was added as a workaround for a code-generation bug introduced in Cython 3.2.0. That bug was fixed in Cython 3.2.1 (https://github.com/cython/cython/pull/7313) and additional related fixes landed in Cython 3.2.2 (https://github.com/cython/cython/pull/7320). Cython 3.2.2 has been released, so we can now raise the lower bound and remove the upper bound cap.

Changes:
- Update `dependencies.yaml`: set `cython>=3.2.2` (no upper bound), remove the old workaround comment
- Update `conda/recipes/*/recipe.yaml`: same pin change (not managed by `rapids-dependency-file-generator`)
- Regenerate all derived files via `rapids-dependency-file-generator`