### PR TITLE
Fix hanging pytests

### DIFF
--- a/python/cuvs/cuvs/tests/test_cagra_ace.py
+++ b/python/cuvs/cuvs/tests/test_cagra_ace.py
@@ -190,7 +190,6 @@ def test_cagra_ace_hierarchy(hierarchy):
     )
 
 
-@pytest.mark.skip(reason="Disk mode can cause pytest to hang")
 def test_cagra_ace_tiny_memory_limit_triggers_disk_mode():
     """Test that setting tiny memory limits triggers disk mode automatically."""
     n_rows = 5000

--- a/python/cuvs/cuvs/tests/test_hnsw_ace.py
+++ b/python/cuvs/cuvs/tests/test_hnsw_ace.py
@@ -223,7 +223,6 @@ def test_hnsw_ace_disk_serialize_deserialize():
         assert recall >= 0.7, f"Recall {recall:.3f} is below expected 0.7"
 
 
-@pytest.mark.skip(reason="Disk mode can cause pytest to hang")
 def test_hnsw_ace_tiny_memory_limit_triggers_disk_mode():
     """Test that setting tiny memory limits triggers disk mode automatically."""
     n_rows = 5000


### PR DESCRIPTION
This PR attempts to fix the hanging pytest issues we are seeing in CI.
From my investigations there are two issues.

One is the `test_cagra_ace_tiny_memory_limit_triggers_disk_mode` and `test_hnsw_ace_tiny_memory_limit_triggers_disk_mode` tests which I have seen locally to hang. ~~At the moment, I am skipping these pytests in CI.~~
**Update**: After testing here 20 times https://github.com/rapidsai/cuvs/actions/runs/23182916436?pr=1893, I don't think we need to skip these tests.

Second is a memory out of bounds error in `device_matrix_view_from_host` , first revealed by compute-sanitizer. This is likely a HMM issue. I have added more specific checks in the constructor so a copy is used when necessary.

See this CI run from my test PR where I run 10 times to ensure that CI works with these fixes.
https://github.com/rapidsai/cuvs/actions/runs/23131230353
I also reran CI on that test PR again. So all the pytests were run 20 times.