### PR TITLE
Null JIT kernel launch config

### DIFF
--- a/cpp/src/detail/jit_lto/AlgorithmLauncher.cpp
+++ b/cpp/src/detail/jit_lto/AlgorithmLauncher.cpp
@@ -37,12 +37,13 @@ AlgorithmLauncher& AlgorithmLauncher::operator=(AlgorithmLauncher&& other) noexc
 void AlgorithmLauncher::call(
   cudaStream_t stream, dim3 grid, dim3 block, std::size_t shared_mem, void** kernel_args)
 {
-  cudaLaunchConfig_t config;
+  cudaLaunchConfig_t config{};
   config.gridDim          = grid;
   config.blockDim         = block;
   config.stream           = stream;
   config.dynamicSmemBytes = shared_mem;
   config.numAttrs         = 0;
+  config.attrs            = NULL;
 
   RAFT_CUDA_TRY(cudaLaunchKernelExC(&config, kernel, kernel_args));
 }


### PR DESCRIPTION
This is to ensure the config does not accidentally get corrupted or start with garbage values. Furthermore, the CUDA [docs](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EXECUTION.html#group__CUDART__EXECUTION_1ge236ecdbbaf7cf47a806bba71c1d03c4) recommend setting `config.attrs = nullptr` even if `config.numAttrs = 0`.

The need of this update comes from https://github.com/rapidsai/cuml/issues/7906, where in cuML nightly wheel tests we are intermittently observing CUDA context corruption from the JIT path. While I am not sure if this PR will resolve them, it is still a step in the right direction.