### PR TITLE
Update to clang 20.1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
                 additional_dependencies: [toml]
                 args: ["--config=pyproject.toml"]
       - repo: https://github.com/pre-commit/mirrors-clang-format
-        rev: v20.1.4
+        rev: v20.1.8
         hooks:
               - id: clang-format
                 types_or: [c, c++, cuda]
@@ -96,7 +96,7 @@ repos:
                 name: clang-format-with-cmake-placeholders
                 entry: python3 ci/checks/clang_format_with_cmake_placeholders.py
                 language: python
-                additional_dependencies: [clang_format==20.1.4]
+                additional_dependencies: [clang_format==20.1.8]
                 files: |
                   (?x)
                     [.](cpp|cu|hpp|cuh)[.]in$

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -8,8 +8,8 @@ dependencies:
 - _go_select *=cgo
 - breathe>=4.35.0
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-nvtx-dev
@@ -25,7 +25,7 @@ dependencies:
 - go
 - graphviz
 - ipython
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -8,8 +8,8 @@ dependencies:
 - _go_select *=cgo
 - breathe>=4.35.0
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-nvtx-dev
@@ -25,7 +25,7 @@ dependencies:
 - go
 - graphviz
 - ipython
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -8,8 +8,8 @@ dependencies:
 - _go_select *=cgo
 - breathe>=4.35.0
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-nvtx-dev
@@ -25,7 +25,7 @@ dependencies:
 - go
 - graphviz
 - ipython
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -8,8 +8,8 @@ dependencies:
 - _go_select *=cgo
 - breathe>=4.35.0
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-nvtx-dev
@@ -25,7 +25,7 @@ dependencies:
 - go
 - graphviz
 - ipython
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
@@ -6,8 +6,8 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - click
 - cmake>=3.30.4
 - cuda-nvcc
@@ -23,7 +23,7 @@ dependencies:
 - gcc_linux-aarch64=14.*
 - glog>=0.6.0
 - h5py>=3.8.0
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
@@ -6,8 +6,8 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - click
 - cmake>=3.30.4
 - cuda-nvcc
@@ -25,7 +25,7 @@ dependencies:
 - h5py>=3.8.0
 - libaio
 - libboost-devel=1.87
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/bench_ann_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-131_arch-aarch64.yaml
@@ -6,8 +6,8 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - click
 - cmake>=3.30.4
 - cuda-nvcc
@@ -23,7 +23,7 @@ dependencies:
 - gcc_linux-aarch64=14.*
 - glog>=0.6.0
 - h5py>=3.8.0
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/bench_ann_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-131_arch-x86_64.yaml
@@ -6,8 +6,8 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - click
 - cmake>=3.30.4
 - cuda-nvcc
@@ -25,7 +25,7 @@ dependencies:
 - h5py>=3.8.0
 - libaio
 - libboost-devel=1.87
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/go_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/go_cuda-129_arch-aarch64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - _go_select *=cgo
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
@@ -19,7 +19,7 @@ dependencies:
 - dlpack>=0.8,<1.0
 - gcc_linux-aarch64=14.*
 - go
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/go_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/go_cuda-129_arch-x86_64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - _go_select *=cgo
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
@@ -19,7 +19,7 @@ dependencies:
 - dlpack>=0.8,<1.0
 - gcc_linux-64=14.*
 - go
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/go_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/go_cuda-131_arch-aarch64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - _go_select *=cgo
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
@@ -19,7 +19,7 @@ dependencies:
 - dlpack>=0.8,<1.0
 - gcc_linux-aarch64=14.*
 - go
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/go_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/go_cuda-131_arch-x86_64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - _go_select *=cgo
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
@@ -19,7 +19,7 @@ dependencies:
 - dlpack>=0.8,<1.0
 - gcc_linux-64=14.*
 - go
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/rust_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/rust_cuda-129_arch-aarch64.yaml
@@ -6,8 +6,8 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
@@ -16,7 +16,7 @@ dependencies:
 - cuda-version=12.9
 - cxx-compiler
 - gcc_linux-aarch64=14.*
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/rust_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/rust_cuda-129_arch-x86_64.yaml
@@ -6,8 +6,8 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
@@ -16,7 +16,7 @@ dependencies:
 - cuda-version=12.9
 - cxx-compiler
 - gcc_linux-64=14.*
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/rust_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/rust_cuda-131_arch-aarch64.yaml
@@ -6,8 +6,8 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
@@ -16,7 +16,7 @@ dependencies:
 - cuda-version=13.1
 - cxx-compiler
 - gcc_linux-aarch64=14.*
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/conda/environments/rust_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/rust_cuda-131_arch-x86_64.yaml
@@ -6,8 +6,8 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
@@ -16,7 +16,7 @@ dependencies:
 - cuda-version=13.1
 - cxx-compiler
 - gcc_linux-64=14.*
-- libclang==20.1.4
+- libclang==20.1.8
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev

--- a/cpp/scripts/run-clang-tidy.py
+++ b/cpp/scripts/run-clang-tidy.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -17,7 +17,7 @@ import shutil
 import subprocess
 
 
-EXPECTED_VERSIONS = ("20.1.4",)
+EXPECTED_VERSIONS = ("20.1.8",)
 VERSION_REGEX = re.compile(r"clang version ([0-9.]+)")
 CMAKE_COMPILER_REGEX = re.compile(
     r"^\s*CMAKE_CXX_COMPILER:FILEPATH=(.+)\s*$", re.MULTILINE

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -285,9 +285,9 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - clang==20.1.4
-          - clang-tools==20.1.4
-          - libclang==20.1.4
+          - clang==20.1.8
+          - clang-tools==20.1.8
+          - libclang==20.1.8
   # 'cuda_version' intentionally does not contain fallback entries... we want
   # a loud error if an unsupported 'cuda' value is passed
   cuda_version:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/267

This PR updates the clang version to 20.1.8.
