### PR TITLE
Fix MG kmeans intertia_check n_iters

### DIFF
--- a/cpp/src/cluster/detail/kmeans_mg.cuh
+++ b/cpp/src/cluster/detail/kmeans_mg.cuh
@@ -738,7 +738,7 @@ void fit(const raft::resources& handle,
              "Too few points and centroids being found is getting 0 cost from "
              "centers\n");
 
-      if (n_iter[0] > 0) {
+      if (n_iter[0] > 1) {
         DataT delta = curClusteringCost / priorClusteringCost;
         if (delta > 1 - params.tol) done = true;
       }


### PR DESCRIPTION
We should only check the intertia_check convergence on n_iters > 1 (on the second iteration). Otherwise we don't have a previous iteration to compare against. The SG path is already like this.

MG n_iters > 0 (bug)
SG  n_iters > 1