### PR TITLE
[REVIEW] Drop extra copy in `get_last_error_text`

### DIFF
--- a/python/cuvs/cuvs/common/exceptions.pyx
+++ b/python/cuvs/cuvs/common/exceptions.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 # cython: language_level=3

--- a/python/cuvs/cuvs/common/exceptions.pyx
+++ b/python/cuvs/cuvs/common/exceptions.pyx
@@ -16,8 +16,7 @@ def get_last_error_text():
     cdef const char* c_err = cuvsGetLastErrorText()
     if c_err is NULL:
         return
-    cdef bytes err = c_err
-    return err.decode("utf8", "ignore")
+    return c_err.decode("utf8", "ignore")
 
 
 def check_cuvs(status: cuvsError_t):

--- a/python/cuvs/cuvs/common/exceptions.pyx
+++ b/python/cuvs/cuvs/common/exceptions.pyx
@@ -14,9 +14,8 @@ class CuvsException(Exception):
 def get_last_error_text():
     """ returns the last error description from the cuvs c-api """
     cdef const char* c_err = cuvsGetLastErrorText()
-    if c_err is NULL:
-        return
-    return c_err.decode("utf8", "ignore")
+    if c_err is not NULL:
+        return c_err.decode("utf8", "ignore")
 
 
 def check_cuvs(status: cuvsError_t):


### PR DESCRIPTION
In `get_last_error_text`, the assignment of `const char*` to `bytes` results in a copy as `bytes` must own its memory. After that the `bytes` object is `decode`d to a Python `str`. However it is possible to `decode` directly from `const char*` to `str` avoiding the copy to the temporary `bytes` object. Hence this code makes that change.

Further Python and Cython `def` functions always `return None` if nothing else is `return`ed. Hence the logic can be simplified here to only focus on `return`ing the error text.