### PR TITLE
FIX: disable warpspeed scan

### DIFF
--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -37,6 +37,10 @@ if(CUDA_LOG_COMPILE_TIME)
   list(APPEND CUVS_CUDA_FLAGS "--time=nvcc_compile_log.csv")
 endif()
 
+# disable warpspeed scan / workaround for CCCL bug https://github.com/NVIDIA/cccl/issues/8838
+list(APPEND CUVS_CXX_FLAGS "-DCCCL_DISABLE_WARPSPEED_SCAN")
+list(APPEND CUVS_CUDA_FLAGS "-DCCCL_DISABLE_WARPSPEED_SCAN")
+
 list(APPEND CUVS_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr)
 list(APPEND CUVS_CXX_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")
 list(APPEND CUVS_CUDA_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")


### PR DESCRIPTION
This is a temporary workaround to disable CCCL warpspeed scan until [#8838](https://github.com/NVIDIA/cccl/issues/8838) is fixed.
CC @cjnolet @bdice 
