### PR TITLE
Switch the remaining C++17 components to C++20

### DIFF
--- a/c/tests/CMakeLists.txt
+++ b/c/tests/CMakeLists.txt
@@ -54,6 +54,10 @@ function(ConfigureTest)
     ${TEST_NAME}
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUVS_C_BINARY_DIR}/gtests>"
                INSTALL_RPATH "\$ORIGIN/../../../${lib_dir}"
+               CXX_STANDARD 20
+               CXX_STANDARD_REQUIRED ON
+               CUDA_STANDARD 20
+               CUDA_STANDARD_REQUIRED ON
   )
 
   target_include_directories(

--- a/c/tests/neighbors/ann_mg_c.cu
+++ b/c/tests/neighbors/ann_mg_c.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -313,18 +313,15 @@ TEST_P(MgCTest, MgCagraTest)
 }
 
 // Test parameters that mirror the C++ test cases
-const std::vector<mg_test_params> test_inputs = {
+INSTANTIATE_TEST_SUITE_P(MgCTests, MgCTest, ::testing::Values(
   // IVF-Flat tests
-  {1000, 5000, 8, 16, MG_MODE_REPLICATED, MG_ALGO_IVF_FLAT, 40, 256, L2Expanded},
-  {1000, 5000, 8, 16, MG_MODE_SHARDED, MG_ALGO_IVF_FLAT, 40, 256, L2Expanded},
+  mg_test_params{1000, 5000, 8, 16, MG_MODE_REPLICATED, MG_ALGO_IVF_FLAT, 40, 256, L2Expanded},
+  mg_test_params{1000, 5000, 8, 16, MG_MODE_SHARDED, MG_ALGO_IVF_FLAT, 40, 256, L2Expanded},
 
   // IVF-PQ tests
-  {1000, 5000, 8, 16, MG_MODE_REPLICATED, MG_ALGO_IVF_PQ, 40, 256, L2Expanded},
-  {1000, 5000, 8, 16, MG_MODE_SHARDED, MG_ALGO_IVF_PQ, 40, 256, L2Expanded},
+  mg_test_params{1000, 5000, 8, 16, MG_MODE_REPLICATED, MG_ALGO_IVF_PQ, 40, 256, L2Expanded},
+  mg_test_params{1000, 5000, 8, 16, MG_MODE_SHARDED, MG_ALGO_IVF_PQ, 40, 256, L2Expanded},
 
   // CAGRA tests
-  {1000, 5000, 8, 16, MG_MODE_REPLICATED, MG_ALGO_CAGRA, 40, 256, L2Expanded},
-  {1000, 5000, 8, 16, MG_MODE_SHARDED, MG_ALGO_CAGRA, 40, 256, L2Expanded},
-};
-
-INSTANTIATE_TEST_SUITE_P(MgCTests, MgCTest, ::testing::ValuesIn(test_inputs));
+  mg_test_params{1000, 5000, 8, 16, MG_MODE_REPLICATED, MG_ALGO_CAGRA, 40, 256, L2Expanded},
+  mg_test_params{1000, 5000, 8, 16, MG_MODE_SHARDED, MG_ALGO_CAGRA, 40, 256, L2Expanded}));

--- a/cpp/bench/ann/CMakeLists.txt
+++ b/cpp/bench/ann/CMakeLists.txt
@@ -177,9 +177,9 @@ function(ConfigureAnnBench)
   set_target_properties(
     ${BENCH_NAME}
     PROPERTIES # set target compile options
-               CXX_STANDARD 17
+               CXX_STANDARD 20
                CXX_STANDARD_REQUIRED ON
-               CUDA_STANDARD 17
+               CUDA_STANDARD 20
                CUDA_STANDARD_REQUIRED ON
                POSITION_INDEPENDENT_CODE ON
                INTERFACE_POSITION_INDEPENDENT_CODE ON
@@ -390,9 +390,9 @@ if(CUVS_ANN_BENCH_SINGLE_EXE)
   set_target_properties(
     ANN_BENCH
     PROPERTIES # set target compile options
-               CXX_STANDARD 17
+               CXX_STANDARD 20
                CXX_STANDARD_REQUIRED ON
-               CUDA_STANDARD 17
+               CUDA_STANDARD 20
                CUDA_STANDARD_REQUIRED ON
                POSITION_INDEPENDENT_CODE ON
                INTERFACE_POSITION_INDEPENDENT_CODE ON

--- a/cpp/bench/ann/src/diskann/diskann_benchmark.cpp
+++ b/cpp/bench/ann/src/diskann/diskann_benchmark.cpp
@@ -7,7 +7,6 @@
 #include "../common/conf.hpp"
 #include "diskann_wrapper.h"
 
-#define JSON_DIAGNOSTICS 1
 #include <nlohmann/json.hpp>
 
 #include <algorithm>


### PR DESCRIPTION
Update to C++20 CMake components that are still C++17:
  - C tests
  - benchmarks

Also add a small workaround for a known nvcc issue.

Supersedes https://github.com/rapidsai/cuvs/pull/1795 and https://github.com/rapidsai/cuvs/pull/1796