### PR TITLE
fix(ci): declare explicit secrets in `publish-rust.yaml`

### DIFF
--- a/.github/workflows/publish-rust.yaml
+++ b/.github/workflows/publish-rust.yaml
@@ -2,6 +2,9 @@ name: publish
 
 on:
   workflow_call:
+    secrets:
+      GPUTESTER_CRATES_TOKEN:
+        required: false
 
 defaults:
   run:


### PR DESCRIPTION
Fast follow to #2053 to fix build.yaml

xref rapidsai/build-planning#275
