### PR TITLE
Add CUVS_EXPORT for KMeans C Functions

### DIFF
--- a/c/include/cuvs/cluster/kmeans.h
+++ b/c/include/cuvs/cluster/kmeans.h
@@ -235,7 +235,7 @@ CUVS_EXPORT cuvsError_t cuvsKMeansParamsDestroy(cuvsKMeansParams_t params);
  * @param[in] params cuvsKMeansParams_v2_t to allocate
  * @return cuvsError_t
  */
-cuvsError_t cuvsKMeansParamsCreate_v2(cuvsKMeansParams_v2_t* params);
+CUVS_EXPORT cuvsError_t cuvsKMeansParamsCreate_v2(cuvsKMeansParams_v2_t* params);
 
 /**
  * @brief De-allocate KMeans params allocated by cuvsKMeansParamsCreate_v2.
@@ -243,7 +243,7 @@ cuvsError_t cuvsKMeansParamsCreate_v2(cuvsKMeansParams_v2_t* params);
  * @param[in] params
  * @return cuvsError_t
  */
-cuvsError_t cuvsKMeansParamsDestroy_v2(cuvsKMeansParams_v2_t params);
+CUVS_EXPORT cuvsError_t cuvsKMeansParamsDestroy_v2(cuvsKMeansParams_v2_t params);
 
 /**
  * @brief Type of k-means algorithm.
@@ -325,13 +325,13 @@ CUVS_EXPORT cuvsError_t cuvsKMeansFit(cuvsResources_t res,
  *                              closest cluster center.
  * @param[out]    n_iter        Number of iterations run.
  */
-cuvsError_t cuvsKMeansFit_v2(cuvsResources_t res,
-                             cuvsKMeansParams_v2_t params,
-                             DLManagedTensor* X,
-                             DLManagedTensor* sample_weight,
-                             DLManagedTensor* centroids,
-                             double* inertia,
-                             int* n_iter);
+CUVS_EXPORT cuvsError_t cuvsKMeansFit_v2(cuvsResources_t res,
+                                         cuvsKMeansParams_v2_t params,
+                                         DLManagedTensor* X,
+                                         DLManagedTensor* sample_weight,
+                                         DLManagedTensor* centroids,
+                                         double* inertia,
+                                         int* n_iter);
 
 /**
  * @brief Predict the closest cluster each sample in X belongs to.
@@ -386,14 +386,14 @@ CUVS_EXPORT cuvsError_t cuvsKMeansPredict(cuvsResources_t res,
  * @param[out]    inertia          Sum of squared distances of samples to
  *                                 their closest cluster center.
  */
-cuvsError_t cuvsKMeansPredict_v2(cuvsResources_t res,
-                                 cuvsKMeansParams_v2_t params,
-                                 DLManagedTensor* X,
-                                 DLManagedTensor* sample_weight,
-                                 DLManagedTensor* centroids,
-                                 DLManagedTensor* labels,
-                                 bool normalize_weight,
-                                 double* inertia);
+CUVS_EXPORT cuvsError_t cuvsKMeansPredict_v2(cuvsResources_t res,
+                                             cuvsKMeansParams_v2_t params,
+                                             DLManagedTensor* X,
+                                             DLManagedTensor* sample_weight,
+                                             DLManagedTensor* centroids,
+                                             DLManagedTensor* labels,
+                                             bool normalize_weight,
+                                             double* inertia);
 
 /**
  * @brief Compute cluster cost


### PR DESCRIPTION
The newly added breaking changes in #2015 did not add the CUVS_EXPORT directive before the new functions: `cuvsKMeansParamsCreate` and `cuvsKMeansParamsDestroy`