### PR TITLE
docs: RAFT->cuVS in issue templates

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,8 +1,8 @@
-# RAFT Development Containers
+# cuVS Development Containers
 
 This directory contains [devcontainer configurations](https://containers.dev/implementors/json_reference/) for using VSCode to [develop in a container](https://code.visualstudio.com/docs/devcontainers/containers) via the `Remote Containers` [extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) or [GitHub Codespaces](https://github.com/codespaces).
 
-This container is a turnkey development environment for building and testing the RAFT C++ and Python libraries.
+This container is a turnkey development environment for building and testing the cuVS C++ and Python libraries.
 
 ## Table of Contents
 
@@ -30,7 +30,7 @@ This ensures caches, configurations, dependencies, and your commits are persiste
 
 ## Launch a Dev Container
 
-To launch a devcontainer from VSCode, open the RAFT repo and select the "Reopen in Container" button in the bottom right:<br/><img src="https://user-images.githubusercontent.com/178183/221771999-97ab29d5-e718-4e5f-b32f-2cdd51bba25c.png"/>
+To launch a devcontainer from VSCode, open the cuVS repo and select the "Reopen in Container" button in the bottom right:<br/><img src="https://user-images.githubusercontent.com/178183/221771999-97ab29d5-e718-4e5f-b32f-2cdd51bba25c.png"/>
 
 Alternatively, open the VSCode command palette (typically `cmd/ctrl + shift + P`) and run the "Rebuild and Reopen in Container" command.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a bug report to help us improve RAFT
+about: Create a bug report to help us improve cuVS
 title: "[BUG]"
 labels: "? - Needs Triage, bug"
 assignees: ''
@@ -18,7 +18,7 @@ A clear and concise description of what you expected to happen.
 
 **Environment details (please complete the following information):**
  - Environment location: [Bare-metal, Docker, Cloud(specify cloud provider)]
- - Method of RAFT install: [conda, Docker, or from source]
+ - Method of cuVS install: [conda, Docker, or from source]
    - If method of install is [Docker], provide `docker pull` & `docker run` commands used
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for RAFT
+about: Suggest an idea for cuVS
 title: "[FEA]"
 labels: "? - Needs Triage, feature request"
 assignees: ''
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I wish I could use RAFT to do [...]
+A clear and concise description of what the problem is. Ex. I wish I could use cuVS to do [...]
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.

--- a/.github/ISSUE_TEMPLATE/submit-question.md
+++ b/.github/ISSUE_TEMPLATE/submit-question.md
@@ -1,6 +1,6 @@
 ---
 name: Submit question
-about: Ask a general question about RAFT
+about: Ask a general question about cuVS
 title: "[QST]"
 labels: "? - Needs Triage, question"
 assignees: ''


### PR DESCRIPTION
Noticed that a few issue templates still reference RAFT, e.g. "Suggest an idea for RAFT".

This updates those references to "cuVS".

Looked for other references like this:

```shell
git grep -i raft
```

And the only other one I found was in the devcontainer docs (also fixed here).