### PR TITLE
fix(visibility): add symbol visibility controls to cuvs

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1072,6 +1072,7 @@ if(NOT BUILD_CPU_ONLY)
                CUDA_STANDARD_REQUIRED ON
                POSITION_INDEPENDENT_CODE ON
                CXX_VISIBILITY_PRESET hidden
+               CUDA_VISIBILITY_PRESET hidden
                VISIBILITY_INLINES_HIDDEN ON
   )
   target_compile_options(

--- a/cpp/include/cuvs/core/cuda_fp16.hpp
+++ b/cpp/include/cuvs/core/cuda_fp16.hpp
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+// Wrapper for cuda_fp16.h that ensures __half gets default symbol visibility.
+//
+// GCC's "type visibility" rule causes template instantiations over __half to
+// inherit hidden visibility when -fvisibility=hidden is in effect, because
+// __half is a user-defined type first seen under hidden visibility. By
+// including cuda_fp16.h under #pragma GCC visibility push(default), the __half
+// type acquires default visibility, and downstream template instantiations
+// (e.g., index<__half, ...>) will be properly exported from shared libraries.
+#pragma GCC visibility push(default)
+#include <cuda_fp16.h>  // NOLINT
+#pragma GCC visibility pop

--- a/cpp/include/cuvs/distance/distance.hpp
+++ b/cpp/include/cuvs/distance/distance.hpp
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <cstdint>
-#include <cuda_fp16.h>
+#include <cuvs/core/cuda_fp16.hpp>
 #include <cuvs/core/export.hpp>
 #include <raft/core/device_csr_matrix.hpp>
 #include <raft/core/device_mdspan.hpp>

--- a/cpp/include/cuvs/neighbors/brute_force.hpp
+++ b/cpp/include/cuvs/neighbors/brute_force.hpp
@@ -35,7 +35,7 @@ struct search_params : cuvs::neighbors::search_params {};
  * @tparam T data element type
  */
 template <typename T, typename DistT = T>
-struct index : cuvs::neighbors::index {
+struct CUVS_EXPORT index : cuvs::neighbors::index {
   using index_params_type  = brute_force::index_params;
   using search_params_type = brute_force::search_params;
   using index_type         = int64_t;

--- a/cpp/include/cuvs/neighbors/brute_force.hpp
+++ b/cpp/include/cuvs/neighbors/brute_force.hpp
@@ -12,7 +12,7 @@
 #include <raft/core/handle.hpp>
 #include <raft/core/host_mdspan.hpp>
 
-#include <cuda_fp16.h>
+#include <cuvs/core/cuda_fp16.hpp>
 #include <cuvs/core/export.hpp>
 
 namespace CUVS_EXPORT cuvs {
@@ -166,6 +166,7 @@ struct CUVS_EXPORT index : cuvs::neighbors::index {
   raft::device_matrix_view<const T, int64_t, raft::row_major> dataset_view_;
   DistT metric_arg_;
 };
+
 /**
  * @}
  */

--- a/cpp/include/cuvs/neighbors/cagra.hpp
+++ b/cpp/include/cuvs/neighbors/cagra.hpp
@@ -391,7 +391,7 @@ static_assert(std::is_aggregate_v<search_params>);
  *
  */
 template <typename T, typename IdxT>
-struct index : cuvs::neighbors::index {
+struct CUVS_EXPORT index : cuvs::neighbors::index {
   using index_params_type  = cagra::index_params;
   using search_params_type = cagra::search_params;
   using index_type         = IdxT;

--- a/cpp/include/cuvs/neighbors/cagra.hpp
+++ b/cpp/include/cuvs/neighbors/cagra.hpp
@@ -878,7 +878,7 @@ struct index : cuvs::neighbors::index {
   std::optional<cuvs::util::file_descriptor> graph_fd_;
   std::optional<cuvs::util::file_descriptor> mapping_fd_;
 
-  void compute_dataset_norms_(raft::resources const& res);
+  CUVS_EXPORT void compute_dataset_norms_(raft::resources const& res);
   size_t n_rows_       = 0;
   size_t dim_          = 0;
   size_t graph_degree_ = 0;

--- a/cpp/include/cuvs/neighbors/cagra.hpp
+++ b/cpp/include/cuvs/neighbors/cagra.hpp
@@ -878,11 +878,12 @@ struct CUVS_EXPORT index : cuvs::neighbors::index {
   std::optional<cuvs::util::file_descriptor> graph_fd_;
   std::optional<cuvs::util::file_descriptor> mapping_fd_;
 
-  CUVS_EXPORT void compute_dataset_norms_(raft::resources const& res);
+  void compute_dataset_norms_(raft::resources const& res);
   size_t n_rows_       = 0;
   size_t dim_          = 0;
   size_t graph_degree_ = 0;
 };
+
 /**
  * @}
  */

--- a/cpp/include/cuvs/neighbors/common.hpp
+++ b/cpp/include/cuvs/neighbors/common.hpp
@@ -19,6 +19,7 @@
 
 #include <cuvs/core/bitmap.hpp>
 #include <cuvs/core/bitset.hpp>
+#include <cuvs/core/export.hpp>
 #include <raft/core/detail/macros.hpp>
 
 #include <memory>
@@ -27,7 +28,6 @@
 
 #ifdef __cpp_lib_bitops
 #include <bit>
-#include <cuvs/core/export.hpp>
 #endif
 
 namespace CUVS_EXPORT cuvs {

--- a/cpp/include/cuvs/neighbors/common.hpp
+++ b/cpp/include/cuvs/neighbors/common.hpp
@@ -811,11 +811,11 @@ using enable_if_valid_list_t = typename enable_if_valid_list<ListT, T>::type;
  *       `cuvs::neighbors::ivf_pq::helpers::resize_list` which handle type casting internally.
  */
 template <typename ListT>
-void resize_list(raft::resources const& res,
-                 std::shared_ptr<ListT>& orig_list,  // NOLINT
-                 const typename ListT::spec_type& spec,
-                 typename ListT::size_type new_used_size,
-                 typename ListT::size_type old_used_size);
+CUVS_EXPORT void resize_list(raft::resources const& res,
+                             std::shared_ptr<ListT>& orig_list,  // NOLINT
+                             const typename ListT::spec_type& spec,
+                             typename ListT::size_type new_used_size,
+                             typename ListT::size_type old_used_size);
 
 /**
  * Serialize a list to an output stream.

--- a/cpp/include/cuvs/neighbors/composite/index.hpp
+++ b/cpp/include/cuvs/neighbors/composite/index.hpp
@@ -41,7 +41,7 @@ namespace composite {
  * @endcode
  */
 template <typename T, typename IdxT, typename OutputIdxT = IdxT>
-class composite_index {
+class CUVS_EXPORT composite_index {
  public:
   using value_type        = T;
   using index_type        = IdxT;

--- a/cpp/include/cuvs/neighbors/ivf_flat.hpp
+++ b/cpp/include/cuvs/neighbors/ivf_flat.hpp
@@ -3576,4 +3576,5 @@ __device__ __forceinline__ void compute_dist_udf_impl(AccT& acc, AccT x, AccT y)
 
 }  // namespace ivf_flat
 }  // namespace neighbors
+
 }  // namespace CUVS_EXPORT cuvs

--- a/cpp/include/cuvs/neighbors/ivf_pq.hpp
+++ b/cpp/include/cuvs/neighbors/ivf_pq.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <cuda_fp16.h>
+#include <cuvs/core/cuda_fp16.hpp>
 
 #include <cuvs/neighbors/common.hpp>
 

--- a/cpp/include/cuvs/neighbors/nn_descent.hpp
+++ b/cpp/include/cuvs/neighbors/nn_descent.hpp
@@ -16,7 +16,7 @@
 
 #include <cuvs/distance/distance.hpp>
 
-#include <cuda_fp16.h>
+#include <cuvs/core/cuda_fp16.hpp>
 #include <cuvs/core/export.hpp>
 
 namespace CUVS_EXPORT cuvs {

--- a/cpp/include/cuvs/preprocessing/quantize/binary.hpp
+++ b/cpp/include/cuvs/preprocessing/quantize/binary.hpp
@@ -11,7 +11,7 @@
 #include <raft/core/host_mdarray.hpp>
 #include <raft/core/host_mdspan.hpp>
 
-#include <cuda_fp16.h>
+#include <cuvs/core/cuda_fp16.hpp>
 #include <cuvs/core/export.hpp>
 
 namespace CUVS_EXPORT cuvs {

--- a/cpp/include/cuvs/preprocessing/quantize/scalar.hpp
+++ b/cpp/include/cuvs/preprocessing/quantize/scalar.hpp
@@ -11,7 +11,7 @@
 #include <raft/core/host_mdarray.hpp>
 #include <raft/core/host_mdspan.hpp>
 
-#include <cuda_fp16.h>
+#include <cuvs/core/cuda_fp16.hpp>
 #include <cuvs/core/export.hpp>
 
 namespace CUVS_EXPORT cuvs {

--- a/cpp/include/cuvs/selection/select_k.hpp
+++ b/cpp/include/cuvs/selection/select_k.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <cuda_fp16.h>
+#include <cuvs/core/cuda_fp16.hpp>
 
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/resources.hpp>

--- a/cpp/src/neighbors/brute_force.cu
+++ b/cpp/src/neighbors/brute_force.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -229,7 +229,7 @@ void index<T, DistT>::update_dataset(
       res, idx, queries, neighbors, distances, sample_filter);                                  \
   }                                                                                             \
                                                                                                 \
-  template struct cuvs::neighbors::brute_force::index<T, DistT>;
+  template struct CUVS_EXPORT cuvs::neighbors::brute_force::index<T, DistT>;
 
 CUVS_INST_BFKNN(float, float);
 CUVS_INST_BFKNN(half, float);

--- a/cpp/src/neighbors/brute_force.cu
+++ b/cpp/src/neighbors/brute_force.cu
@@ -1,7 +1,9 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <cuvs/core/cuda_fp16.hpp>
 
 #include "./detail/knn_brute_force.cuh"
 
@@ -9,7 +11,9 @@
 
 #include <raft/core/copy.hpp>
 
-namespace cuvs::neighbors::brute_force {
+namespace CUVS_EXPORT cuvs {
+namespace neighbors {
+namespace brute_force {
 
 template <typename T, typename DistT>
 index<T, DistT>::index(raft::resources const& res)
@@ -227,13 +231,16 @@ void index<T, DistT>::update_dataset(
   {                                                                                             \
     detail::search<T, int64_t, DistT, raft::col_major>(                                         \
       res, idx, queries, neighbors, distances, sample_filter);                                  \
-  }                                                                                             \
-                                                                                                \
-  template struct cuvs::neighbors::brute_force::index<T, DistT>;
+  }
 
 CUVS_INST_BFKNN(float, float);
 CUVS_INST_BFKNN(half, float);
 
+template class cuvs::neighbors::brute_force::index<float, float>;
+template class cuvs::neighbors::brute_force::index<half, float>;
+
 #undef CUVS_INST_BFKNN
 
-}  // namespace cuvs::neighbors::brute_force
+}  // namespace brute_force
+}  // namespace neighbors
+}  // namespace CUVS_EXPORT cuvs

--- a/cpp/src/neighbors/brute_force.cu
+++ b/cpp/src/neighbors/brute_force.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -229,7 +229,7 @@ void index<T, DistT>::update_dataset(
       res, idx, queries, neighbors, distances, sample_filter);                                  \
   }                                                                                             \
                                                                                                 \
-  template struct cuvs::neighbors::brute_force::index<T, DistT>;
+  template class CUVS_EXPORT cuvs::neighbors::brute_force::index<T, DistT>;
 
 CUVS_INST_BFKNN(float, float);
 CUVS_INST_BFKNN(half, float);

--- a/cpp/src/neighbors/brute_force.cu
+++ b/cpp/src/neighbors/brute_force.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -229,7 +229,7 @@ void index<T, DistT>::update_dataset(
       res, idx, queries, neighbors, distances, sample_filter);                                  \
   }                                                                                             \
                                                                                                 \
-  template class CUVS_EXPORT cuvs::neighbors::brute_force::index<T, DistT>;
+  template struct cuvs::neighbors::brute_force::index<T, DistT>;
 
 CUVS_INST_BFKNN(float, float);
 CUVS_INST_BFKNN(half, float);

--- a/cpp/src/neighbors/brute_force.cu
+++ b/cpp/src/neighbors/brute_force.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -229,7 +229,7 @@ void index<T, DistT>::update_dataset(
       res, idx, queries, neighbors, distances, sample_filter);                                  \
   }                                                                                             \
                                                                                                 \
-  template struct CUVS_EXPORT cuvs::neighbors::brute_force::index<T, DistT>;
+  template struct cuvs::neighbors::brute_force::index<T, DistT>;
 
 CUVS_INST_BFKNN(float, float);
 CUVS_INST_BFKNN(half, float);

--- a/cpp/src/neighbors/cagra.cuh
+++ b/cpp/src/neighbors/cagra.cuh
@@ -30,7 +30,7 @@ namespace cuvs::neighbors::cagra {
 
 // Member function implementations for cagra::index
 template <typename T, typename IdxT>
-CUVS_EXPORT void index<T, IdxT>::compute_dataset_norms_(raft::resources const& res)
+void index<T, IdxT>::compute_dataset_norms_(raft::resources const& res)
 {
   // Get the dataset view
   auto dataset_view = this->dataset();

--- a/cpp/src/neighbors/cagra.cuh
+++ b/cpp/src/neighbors/cagra.cuh
@@ -30,7 +30,7 @@ namespace cuvs::neighbors::cagra {
 
 // Member function implementations for cagra::index
 template <typename T, typename IdxT>
-void index<T, IdxT>::compute_dataset_norms_(raft::resources const& res)
+CUVS_EXPORT void index<T, IdxT>::compute_dataset_norms_(raft::resources const& res)
 {
   // Get the dataset view
   auto dataset_view = this->dataset();

--- a/cpp/src/neighbors/cagra_build_inst.cu.in
+++ b/cpp/src/neighbors/cagra_build_inst.cu.in
@@ -39,4 +39,6 @@ auto build(raft::resources const& handle,
   return cuvs::neighbors::cagra::build<data_t, index_t>(handle, params, dataset);
 }
 
+template class CUVS_EXPORT index<data_t, index_t>;
+
 }  // namespace cuvs::neighbors::cagra

--- a/cpp/src/neighbors/cagra_build_inst.cu.in
+++ b/cpp/src/neighbors/cagra_build_inst.cu.in
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cuvs/core/cuda_fp16.hpp>
+
 #include <cuvs/neighbors/cagra.hpp>
 #include <neighbors/cagra.cuh>
 

--- a/cpp/src/neighbors/cagra_build_inst.cu.in
+++ b/cpp/src/neighbors/cagra_build_inst.cu.in
@@ -39,6 +39,6 @@ auto build(raft::resources const& handle,
   return cuvs::neighbors::cagra::build<data_t, index_t>(handle, params, dataset);
 }
 
-template class CUVS_EXPORT index<data_t, index_t>;
+template struct index<data_t, index_t>;
 
 }  // namespace cuvs::neighbors::cagra

--- a/cpp/src/neighbors/cagra_extend_inst.cu.in
+++ b/cpp/src/neighbors/cagra_extend_inst.cu.in
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cuvs/core/cuda_fp16.hpp>
+
 #include <cuvs/neighbors/cagra.hpp>
 #include <neighbors/cagra.cuh>
 

--- a/cpp/src/neighbors/cagra_merge_inst.cu.in
+++ b/cpp/src/neighbors/cagra_merge_inst.cu.in
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cuvs/core/cuda_fp16.hpp>
+
 #include <cuvs/neighbors/cagra.hpp>
 #include <neighbors/cagra.cuh>
 

--- a/cpp/src/neighbors/cagra_serialize_inst.cu.in
+++ b/cpp/src/neighbors/cagra_serialize_inst.cu.in
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cuvs/core/cuda_fp16.hpp>
+
 #include <neighbors/cagra_serialize.cuh>
 
 namespace {

--- a/cpp/src/neighbors/composite/index.cu
+++ b/cpp/src/neighbors/composite/index.cu
@@ -111,13 +111,13 @@ void composite_index<T, IdxT, OutputIdxT>::search(
                             cuvs::selection::SelectAlgo::kAuto);
 }
 
-template class CUVS_EXPORT composite_index<float, uint32_t, uint32_t>;
-template class CUVS_EXPORT composite_index<float, uint32_t, int64_t>;
-template class CUVS_EXPORT composite_index<half, uint32_t, uint32_t>;
-template class CUVS_EXPORT composite_index<half, uint32_t, int64_t>;
-template class CUVS_EXPORT composite_index<int8_t, uint32_t, uint32_t>;
-template class CUVS_EXPORT composite_index<int8_t, uint32_t, int64_t>;
-template class CUVS_EXPORT composite_index<uint8_t, uint32_t, uint32_t>;
-template class CUVS_EXPORT composite_index<uint8_t, uint32_t, int64_t>;
+template class composite_index<float, uint32_t, uint32_t>;
+template class composite_index<float, uint32_t, int64_t>;
+template class composite_index<half, uint32_t, uint32_t>;
+template class composite_index<half, uint32_t, int64_t>;
+template class composite_index<int8_t, uint32_t, uint32_t>;
+template class composite_index<int8_t, uint32_t, int64_t>;
+template class composite_index<uint8_t, uint32_t, uint32_t>;
+template class composite_index<uint8_t, uint32_t, int64_t>;
 
 }  // namespace cuvs::neighbors::composite

--- a/cpp/src/neighbors/composite/index.cu
+++ b/cpp/src/neighbors/composite/index.cu
@@ -111,13 +111,13 @@ void composite_index<T, IdxT, OutputIdxT>::search(
                             cuvs::selection::SelectAlgo::kAuto);
 }
 
-template class composite_index<float, uint32_t, uint32_t>;
-template class composite_index<float, uint32_t, int64_t>;
-template class composite_index<half, uint32_t, uint32_t>;
-template class composite_index<half, uint32_t, int64_t>;
-template class composite_index<int8_t, uint32_t, uint32_t>;
-template class composite_index<int8_t, uint32_t, int64_t>;
-template class composite_index<uint8_t, uint32_t, uint32_t>;
-template class composite_index<uint8_t, uint32_t, int64_t>;
+template class CUVS_EXPORT composite_index<float, uint32_t, uint32_t>;
+template class CUVS_EXPORT composite_index<float, uint32_t, int64_t>;
+template class CUVS_EXPORT composite_index<half, uint32_t, uint32_t>;
+template class CUVS_EXPORT composite_index<half, uint32_t, int64_t>;
+template class CUVS_EXPORT composite_index<int8_t, uint32_t, uint32_t>;
+template class CUVS_EXPORT composite_index<int8_t, uint32_t, int64_t>;
+template class CUVS_EXPORT composite_index<uint8_t, uint32_t, uint32_t>;
+template class CUVS_EXPORT composite_index<uint8_t, uint32_t, int64_t>;
 
 }  // namespace cuvs::neighbors::composite

--- a/cpp/src/neighbors/detail/nn_descent_gnnd.hpp
+++ b/cpp/src/neighbors/detail/nn_descent_gnnd.hpp
@@ -192,7 +192,7 @@ struct CUVS_EXPORT GnndGraph {
 };
 
 template <typename Data_t = float, typename Index_t = int>
-class GNND {
+class CUVS_EXPORT GNND {
  public:
   GNND(raft::resources const& res, const BuildConfig& build_config);
   GNND(const GNND&)            = delete;

--- a/cpp/src/neighbors/detail/nn_descent_gnnd.hpp
+++ b/cpp/src/neighbors/detail/nn_descent_gnnd.hpp
@@ -151,7 +151,7 @@ class BloomFilter {
 };
 
 template <typename Index_t>
-struct GnndGraph {
+struct CUVS_EXPORT GnndGraph {
   raft::resources const& res;
   static constexpr int segment_size = 32;
   InternalID_t<Index_t>* h_graph;

--- a/cpp/src/neighbors/dynamic_batching.cu
+++ b/cpp/src/neighbors/dynamic_batching.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -21,7 +21,7 @@ namespace cuvs::neighbors::dynamic_batching {
 #define CUVS_INST_DYNAMIC_BATCHING_INDEX(T, IdxT, Namespace, ...)                         \
   template <>                                                                             \
   template <>                                                                             \
-  index<T, IdxT>::index<Namespace ::__VA_ARGS__>(                                         \
+  CUVS_EXPORT index<T, IdxT>::index<Namespace ::__VA_ARGS__>(                             \
     const raft::resources& res,                                                           \
     const cuvs::neighbors::dynamic_batching::index_params& params,                        \
     const Namespace ::__VA_ARGS__& upstream_index,                                        \

--- a/cpp/src/neighbors/ivf_flat/ivf_flat_build_extend_inst.cu.in
+++ b/cpp/src/neighbors/ivf_flat/ivf_flat_build_extend_inst.cu.in
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cuvs/core/cuda_fp16.hpp>
+
 #include <cuvs/neighbors/ivf_flat.hpp>
 
 #include <neighbors/ivf_flat/ivf_flat_build.cuh>
@@ -84,3 +86,14 @@ void extend(raft::resources const& handle,
 }
 
 }  // namespace cuvs::neighbors::ivf_flat
+
+namespace cuvs::neighbors::ivf {
+
+template void resize_list<list<cuvs::neighbors::ivf_flat::list_spec, uint32_t, data_t, index_t>>(
+  raft::resources const&,
+  std::shared_ptr<list<cuvs::neighbors::ivf_flat::list_spec, uint32_t, data_t, index_t>>&,
+  const list<cuvs::neighbors::ivf_flat::list_spec, uint32_t, data_t, index_t>::spec_type&,
+  list<cuvs::neighbors::ivf_flat::list_spec, uint32_t, data_t, index_t>::size_type,
+  list<cuvs::neighbors::ivf_flat::list_spec, uint32_t, data_t, index_t>::size_type);
+
+}  // namespace cuvs::neighbors::ivf

--- a/cpp/src/neighbors/ivf_flat/ivf_flat_helpers.cu
+++ b/cpp/src/neighbors/ivf_flat/ivf_flat_helpers.cu
@@ -1,11 +1,12 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cstdint>
 
 #include "../ivf_common.cuh"
+#include "../ivf_list.cuh"
 #include "ivf_flat_helpers.cuh"
 #include <cuvs/neighbors/ivf_flat.hpp>
 
@@ -206,3 +207,14 @@ void recompute_internal_state(const raft::resources& res, index<uint8_t, int64_t
 }
 
 }  // namespace cuvs::neighbors::ivf_flat::helpers
+
+namespace cuvs::neighbors::ivf {
+
+template CUVS_EXPORT void resize_list<ivf::list<ivf_flat::list_spec, uint32_t, half, int64_t>>(
+  raft::resources const&,
+  std::shared_ptr<ivf::list<ivf_flat::list_spec, uint32_t, half, int64_t>>&,
+  const ivf::list<ivf_flat::list_spec, uint32_t, half, int64_t>::spec_type&,
+  ivf::list<ivf_flat::list_spec, uint32_t, half, int64_t>::size_type,
+  ivf::list<ivf_flat::list_spec, uint32_t, half, int64_t>::size_type);
+
+}  // namespace cuvs::neighbors::ivf

--- a/cpp/src/neighbors/ivf_flat/ivf_flat_helpers.cu
+++ b/cpp/src/neighbors/ivf_flat/ivf_flat_helpers.cu
@@ -210,11 +210,12 @@ void recompute_internal_state(const raft::resources& res, index<uint8_t, int64_t
 
 namespace cuvs::neighbors::ivf {
 
-template CUVS_EXPORT void resize_list<ivf::list<ivf_flat::list_spec, uint32_t, half, int64_t>>(
+template CUVS_EXPORT void
+resize_list<list<cuvs::neighbors::ivf_flat::list_spec, uint32_t, half, int64_t>>(
   raft::resources const&,
-  std::shared_ptr<ivf::list<ivf_flat::list_spec, uint32_t, half, int64_t>>&,
-  const ivf::list<ivf_flat::list_spec, uint32_t, half, int64_t>::spec_type&,
-  ivf::list<ivf_flat::list_spec, uint32_t, half, int64_t>::size_type,
-  ivf::list<ivf_flat::list_spec, uint32_t, half, int64_t>::size_type);
+  std::shared_ptr<list<cuvs::neighbors::ivf_flat::list_spec, uint32_t, half, int64_t>>&,
+  const list<cuvs::neighbors::ivf_flat::list_spec, uint32_t, half, int64_t>::spec_type&,
+  list<cuvs::neighbors::ivf_flat::list_spec, uint32_t, half, int64_t>::size_type,
+  list<cuvs::neighbors::ivf_flat::list_spec, uint32_t, half, int64_t>::size_type);
 
 }  // namespace cuvs::neighbors::ivf

--- a/cpp/src/neighbors/ivf_list.cuh
+++ b/cpp/src/neighbors/ivf_list.cuh
@@ -62,11 +62,11 @@ list<SpecT, SizeT, SpecExtraArgs...>::list(raft::resources const& res,
 }
 
 template <typename ListT>
-CUVS_EXPORT void resize_list(raft::resources const& res,
-                             std::shared_ptr<ListT>& orig_list,  // NOLINT
-                             const typename ListT::spec_type& spec,
-                             typename ListT::size_type new_used_size,
-                             typename ListT::size_type old_used_size)
+void resize_list(raft::resources const& res,
+                 std::shared_ptr<ListT>& orig_list,  // NOLINT
+                 const typename ListT::spec_type& spec,
+                 typename ListT::size_type new_used_size,
+                 typename ListT::size_type old_used_size)
 {
   bool skip_resize = false;
   if (orig_list) {

--- a/cpp/src/neighbors/ivf_list.cuh
+++ b/cpp/src/neighbors/ivf_list.cuh
@@ -62,11 +62,11 @@ list<SpecT, SizeT, SpecExtraArgs...>::list(raft::resources const& res,
 }
 
 template <typename ListT>
-void resize_list(raft::resources const& res,
-                 std::shared_ptr<ListT>& orig_list,  // NOLINT
-                 const typename ListT::spec_type& spec,
-                 typename ListT::size_type new_used_size,
-                 typename ListT::size_type old_used_size)
+CUVS_EXPORT void resize_list(raft::resources const& res,
+                             std::shared_ptr<ListT>& orig_list,  // NOLINT
+                             const typename ListT::spec_type& spec,
+                             typename ListT::size_type new_used_size,
+                             typename ListT::size_type old_used_size)
 {
   bool skip_resize = false;
   if (orig_list) {

--- a/cpp/src/neighbors/mg/mg_cagra_inst.cu.in
+++ b/cpp/src/neighbors/mg/mg_cagra_inst.cu.in
@@ -5,87 +5,87 @@
 
 #include <neighbors/mg/snmg.cuh>
 
-#define CUVS_INST_MG_CAGRA(T, IdxT)                                                          \
-  namespace cuvs::neighbors::cagra {                                                         \
-  using namespace cuvs::neighbors;                                                           \
-                                                                                             \
-  cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT> build(                           \
-    const raft::resources& res,                                                              \
-    const mg_index_params<cagra::index_params>& index_params,                                \
-    raft::host_matrix_view<const T, int64_t, row_major> index_dataset)                       \
-  {                                                                                          \
-    cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT> index(res, index_params.mode); \
-    cuvs::neighbors::snmg::detail::build(                                                    \
-      res,                                                                                   \
-      index,                                                                                 \
-      static_cast<const cuvs::neighbors::index_params*>(&index_params),                      \
-      index_dataset);                                                                        \
-    return index;                                                                            \
-  }                                                                                          \
-                                                                                             \
-  void extend(const raft::resources& res,                                                    \
-              cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>& index,              \
-              raft::host_matrix_view<const T, int64_t, row_major> new_vectors,               \
-              std::optional<raft::host_vector_view<const IdxT, int64_t>> new_indices)        \
-  {                                                                                          \
-    cuvs::neighbors::snmg::detail::extend(res, index, new_vectors, new_indices);             \
-  }                                                                                          \
-                                                                                             \
-  void search(const raft::resources& res,                                                    \
-              const cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>& index,        \
-              const mg_search_params<cagra::search_params>& search_params,                   \
-              raft::host_matrix_view<const T, int64_t, row_major> queries,                   \
-              raft::host_matrix_view<int64_t, int64_t, row_major> neighbors,                 \
-              raft::host_matrix_view<float, int64_t, row_major> distances)                   \
-  {                                                                                          \
-    cuvs::neighbors::snmg::detail::search(                                                   \
-      res,                                                                                   \
-      index,                                                                                 \
-      static_cast<const cuvs::neighbors::search_params*>(&search_params),                    \
-      queries,                                                                               \
-      neighbors,                                                                             \
-      distances);                                                                            \
-  }                                                                                          \
-                                                                                             \
-  void search(const raft::resources& res,                                                    \
-              const cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>& index,        \
-              const mg_search_params<cagra::search_params>& search_params,                   \
-              raft::host_matrix_view<const T, int64_t, row_major> queries,                   \
-              raft::host_matrix_view<uint32_t, int64_t, row_major> neighbors,                \
-              raft::host_matrix_view<float, int64_t, row_major> distances)                   \
-  {                                                                                          \
-    cuvs::neighbors::snmg::detail::search(                                                   \
-      res,                                                                                   \
-      index,                                                                                 \
-      static_cast<const cuvs::neighbors::search_params*>(&search_params),                    \
-      queries,                                                                               \
-      neighbors,                                                                             \
-      distances);                                                                            \
-  }                                                                                          \
-                                                                                             \
-  void serialize(const raft::resources& res,                                                 \
-                 const cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>& index,     \
-                 const std::string& filename)                                                \
-  {                                                                                          \
-    cuvs::neighbors::snmg::detail::serialize(res, index, filename);                          \
-  }                                                                                          \
-                                                                                             \
-  template <>                                                                                \
-  cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT> deserialize<T, IdxT>(            \
-    const raft::resources& res, const std::string& filename)                                 \
-  {                                                                                          \
-    auto idx = cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>(res, filename);     \
-    return idx;                                                                              \
-  }                                                                                          \
-                                                                                             \
-  template <>                                                                                \
-  cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT> distribute<T, IdxT>(             \
-    const raft::resources& res, const std::string& filename)                                 \
-  {                                                                                          \
-    auto idx = cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>(res, REPLICATED);   \
-    cuvs::neighbors::snmg::detail::deserialize_and_distribute(res, idx, filename);           \
-    return idx;                                                                              \
-  }                                                                                          \
+#define CUVS_INST_MG_CAGRA(T, IdxT)                                                           \
+  namespace cuvs::neighbors::cagra {                                                          \
+  using namespace cuvs::neighbors;                                                            \
+                                                                                              \
+  cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT> build(                            \
+    const raft::resources& res,                                                               \
+    const mg_index_params<cagra::index_params>& index_params,                                 \
+    raft::host_matrix_view<const T, int64_t, row_major> index_dataset)                        \
+  {                                                                                           \
+    cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT> index(res, index_params.mode);  \
+    cuvs::neighbors::snmg::detail::build(                                                     \
+      res,                                                                                    \
+      index,                                                                                  \
+      static_cast<const cuvs::neighbors::index_params*>(&index_params),                       \
+      index_dataset);                                                                         \
+    return index;                                                                             \
+  }                                                                                           \
+                                                                                              \
+  void extend(const raft::resources& res,                                                     \
+              cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>& index,               \
+              raft::host_matrix_view<const T, int64_t, row_major> new_vectors,                \
+              std::optional<raft::host_vector_view<const IdxT, int64_t>> new_indices)         \
+  {                                                                                           \
+    cuvs::neighbors::snmg::detail::extend(res, index, new_vectors, new_indices);              \
+  }                                                                                           \
+                                                                                              \
+  void search(const raft::resources& res,                                                     \
+              const cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>& index,         \
+              const mg_search_params<cagra::search_params>& search_params,                    \
+              raft::host_matrix_view<const T, int64_t, row_major> queries,                    \
+              raft::host_matrix_view<int64_t, int64_t, row_major> neighbors,                  \
+              raft::host_matrix_view<float, int64_t, row_major> distances)                    \
+  {                                                                                           \
+    cuvs::neighbors::snmg::detail::search(                                                    \
+      res,                                                                                    \
+      index,                                                                                  \
+      static_cast<const cuvs::neighbors::search_params*>(&search_params),                     \
+      queries,                                                                                \
+      neighbors,                                                                              \
+      distances);                                                                             \
+  }                                                                                           \
+                                                                                              \
+  void search(const raft::resources& res,                                                     \
+              const cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>& index,         \
+              const mg_search_params<cagra::search_params>& search_params,                    \
+              raft::host_matrix_view<const T, int64_t, row_major> queries,                    \
+              raft::host_matrix_view<uint32_t, int64_t, row_major> neighbors,                 \
+              raft::host_matrix_view<float, int64_t, row_major> distances)                    \
+  {                                                                                           \
+    cuvs::neighbors::snmg::detail::search(                                                    \
+      res,                                                                                    \
+      index,                                                                                  \
+      static_cast<const cuvs::neighbors::search_params*>(&search_params),                     \
+      queries,                                                                                \
+      neighbors,                                                                              \
+      distances);                                                                             \
+  }                                                                                           \
+                                                                                              \
+  void serialize(const raft::resources& res,                                                  \
+                 const cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>& index,      \
+                 const std::string& filename)                                                 \
+  {                                                                                           \
+    cuvs::neighbors::snmg::detail::serialize(res, index, filename);                           \
+  }                                                                                           \
+                                                                                              \
+  template <>                                                                                 \
+  CUVS_EXPORT cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT> deserialize<T, IdxT>( \
+    const raft::resources& res, const std::string& filename)                                  \
+  {                                                                                           \
+    auto idx = cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>(res, filename);      \
+    return idx;                                                                               \
+  }                                                                                           \
+                                                                                              \
+  template <>                                                                                 \
+  CUVS_EXPORT cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT> distribute<T, IdxT>(  \
+    const raft::resources& res, const std::string& filename)                                  \
+  {                                                                                           \
+    auto idx = cuvs::neighbors::mg_index<cagra::index<T, IdxT>, T, IdxT>(res, REPLICATED);    \
+    cuvs::neighbors::snmg::detail::deserialize_and_distribute(res, idx, filename);            \
+    return idx;                                                                               \
+  }                                                                                           \
   }  // namespace cuvs::neighbors::cagra
 CUVS_INST_MG_CAGRA(@data_type@, uint32_t);
 

--- a/cpp/src/neighbors/mg/mg_flat_inst.cu.in
+++ b/cpp/src/neighbors/mg/mg_flat_inst.cu.in
@@ -5,71 +5,71 @@
 
 #include <neighbors/mg/snmg.cuh>
 
-#define CUVS_INST_MG_FLAT(T, IdxT)                                                              \
-  namespace cuvs::neighbors::ivf_flat {                                                         \
-  using namespace cuvs::neighbors;                                                              \
-                                                                                                \
-  cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT> build(                           \
-    const raft::resources& res,                                                                 \
-    const mg_index_params<ivf_flat::index_params>& index_params,                                \
-    raft::host_matrix_view<const T, int64_t, row_major> index_dataset)                          \
-  {                                                                                             \
-    cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT> index(res, index_params.mode); \
-    cuvs::neighbors::snmg::detail::build(                                                       \
-      res,                                                                                      \
-      index,                                                                                    \
-      static_cast<const cuvs::neighbors::index_params*>(&index_params),                         \
-      index_dataset);                                                                           \
-    return index;                                                                               \
-  }                                                                                             \
-                                                                                                \
-  void extend(const raft::resources& res,                                                       \
-              cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT>& index,              \
-              raft::host_matrix_view<const T, int64_t, row_major> new_vectors,                  \
-              std::optional<raft::host_vector_view<const IdxT, int64_t>> new_indices)           \
-  {                                                                                             \
-    cuvs::neighbors::snmg::detail::extend(res, index, new_vectors, new_indices);                \
-  }                                                                                             \
-                                                                                                \
-  void search(const raft::resources& res,                                                       \
-              const cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT>& index,        \
-              const mg_search_params<ivf_flat::search_params>& search_params,                   \
-              raft::host_matrix_view<const T, int64_t, row_major> queries,                      \
-              raft::host_matrix_view<IdxT, int64_t, row_major> neighbors,                       \
-              raft::host_matrix_view<float, int64_t, row_major> distances)                      \
-  {                                                                                             \
-    cuvs::neighbors::snmg::detail::search(                                                      \
-      res,                                                                                      \
-      index,                                                                                    \
-      static_cast<const cuvs::neighbors::search_params*>(&search_params),                       \
-      queries,                                                                                  \
-      neighbors,                                                                                \
-      distances);                                                                               \
-  }                                                                                             \
-                                                                                                \
-  void serialize(const raft::resources& res,                                                    \
-                 const cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT>& index,     \
-                 const std::string& filename)                                                   \
-  {                                                                                             \
-    cuvs::neighbors::snmg::detail::serialize(res, index, filename);                             \
-  }                                                                                             \
-                                                                                                \
-  template <>                                                                                   \
-  cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT> deserialize<T, IdxT>(            \
-    const raft::resources& res, const std::string& filename)                                    \
-  {                                                                                             \
-    auto idx = cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT>(res, filename);     \
-    return idx;                                                                                 \
-  }                                                                                             \
-                                                                                                \
-  template <>                                                                                   \
-  cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT> distribute<T, IdxT>(             \
-    const raft::resources& res, const std::string& filename)                                    \
-  {                                                                                             \
-    auto idx = cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT>(res, REPLICATED);   \
-    cuvs::neighbors::snmg::detail::deserialize_and_distribute(res, idx, filename);              \
-    return idx;                                                                                 \
-  }                                                                                             \
+#define CUVS_INST_MG_FLAT(T, IdxT)                                                               \
+  namespace cuvs::neighbors::ivf_flat {                                                          \
+  using namespace cuvs::neighbors;                                                               \
+                                                                                                 \
+  cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT> build(                            \
+    const raft::resources& res,                                                                  \
+    const mg_index_params<ivf_flat::index_params>& index_params,                                 \
+    raft::host_matrix_view<const T, int64_t, row_major> index_dataset)                           \
+  {                                                                                              \
+    cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT> index(res, index_params.mode);  \
+    cuvs::neighbors::snmg::detail::build(                                                        \
+      res,                                                                                       \
+      index,                                                                                     \
+      static_cast<const cuvs::neighbors::index_params*>(&index_params),                          \
+      index_dataset);                                                                            \
+    return index;                                                                                \
+  }                                                                                              \
+                                                                                                 \
+  void extend(const raft::resources& res,                                                        \
+              cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT>& index,               \
+              raft::host_matrix_view<const T, int64_t, row_major> new_vectors,                   \
+              std::optional<raft::host_vector_view<const IdxT, int64_t>> new_indices)            \
+  {                                                                                              \
+    cuvs::neighbors::snmg::detail::extend(res, index, new_vectors, new_indices);                 \
+  }                                                                                              \
+                                                                                                 \
+  void search(const raft::resources& res,                                                        \
+              const cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT>& index,         \
+              const mg_search_params<ivf_flat::search_params>& search_params,                    \
+              raft::host_matrix_view<const T, int64_t, row_major> queries,                       \
+              raft::host_matrix_view<IdxT, int64_t, row_major> neighbors,                        \
+              raft::host_matrix_view<float, int64_t, row_major> distances)                       \
+  {                                                                                              \
+    cuvs::neighbors::snmg::detail::search(                                                       \
+      res,                                                                                       \
+      index,                                                                                     \
+      static_cast<const cuvs::neighbors::search_params*>(&search_params),                        \
+      queries,                                                                                   \
+      neighbors,                                                                                 \
+      distances);                                                                                \
+  }                                                                                              \
+                                                                                                 \
+  void serialize(const raft::resources& res,                                                     \
+                 const cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT>& index,      \
+                 const std::string& filename)                                                    \
+  {                                                                                              \
+    cuvs::neighbors::snmg::detail::serialize(res, index, filename);                              \
+  }                                                                                              \
+                                                                                                 \
+  template <>                                                                                    \
+  CUVS_EXPORT cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT> deserialize<T, IdxT>( \
+    const raft::resources& res, const std::string& filename)                                     \
+  {                                                                                              \
+    auto idx = cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT>(res, filename);      \
+    return idx;                                                                                  \
+  }                                                                                              \
+                                                                                                 \
+  template <>                                                                                    \
+  CUVS_EXPORT cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT> distribute<T, IdxT>(  \
+    const raft::resources& res, const std::string& filename)                                     \
+  {                                                                                              \
+    auto idx = cuvs::neighbors::mg_index<ivf_flat::index<T, IdxT>, T, IdxT>(res, REPLICATED);    \
+    cuvs::neighbors::snmg::detail::deserialize_and_distribute(res, idx, filename);               \
+    return idx;                                                                                  \
+  }                                                                                              \
   }  // namespace cuvs::neighbors::ivf_flat
 CUVS_INST_MG_FLAT(@data_type@, int64_t);
 

--- a/cpp/src/neighbors/mg/mg_pq_inst.cu.in
+++ b/cpp/src/neighbors/mg/mg_pq_inst.cu.in
@@ -5,71 +5,71 @@
 
 #include <neighbors/mg/snmg.cuh>
 
-#define CUVS_INST_MG_PQ(T, IdxT)                                                           \
-  namespace cuvs::neighbors::ivf_pq {                                                      \
-  using namespace cuvs::neighbors;                                                         \
-                                                                                           \
-  cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT> build(                           \
-    const raft::resources& res,                                                            \
-    const mg_index_params<ivf_pq::index_params>& index_params,                             \
-    raft::host_matrix_view<const T, int64_t, row_major> index_dataset)                     \
-  {                                                                                        \
-    cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT> index(res, index_params.mode); \
-    cuvs::neighbors::snmg::detail::build(                                                  \
-      res,                                                                                 \
-      index,                                                                               \
-      static_cast<const cuvs::neighbors::index_params*>(&index_params),                    \
-      index_dataset);                                                                      \
-    return index;                                                                          \
-  }                                                                                        \
-                                                                                           \
-  void extend(const raft::resources& res,                                                  \
-              cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT>& index,              \
-              raft::host_matrix_view<const T, int64_t, row_major> new_vectors,             \
-              std::optional<raft::host_vector_view<const IdxT, int64_t>> new_indices)      \
-  {                                                                                        \
-    cuvs::neighbors::snmg::detail::extend(res, index, new_vectors, new_indices);           \
-  }                                                                                        \
-                                                                                           \
-  void search(const raft::resources& res,                                                  \
-              const cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT>& index,        \
-              const mg_search_params<ivf_pq::search_params>& search_params,                \
-              raft::host_matrix_view<const T, int64_t, row_major> queries,                 \
-              raft::host_matrix_view<IdxT, int64_t, row_major> neighbors,                  \
-              raft::host_matrix_view<float, int64_t, row_major> distances)                 \
-  {                                                                                        \
-    cuvs::neighbors::snmg::detail::search(                                                 \
-      res,                                                                                 \
-      index,                                                                               \
-      static_cast<const cuvs::neighbors::search_params*>(&search_params),                  \
-      queries,                                                                             \
-      neighbors,                                                                           \
-      distances);                                                                          \
-  }                                                                                        \
-                                                                                           \
-  void serialize(const raft::resources& res,                                               \
-                 const cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT>& index,     \
-                 const std::string& filename)                                              \
-  {                                                                                        \
-    cuvs::neighbors::snmg::detail::serialize(res, index, filename);                        \
-  }                                                                                        \
-                                                                                           \
-  template <>                                                                              \
-  cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT> deserialize<T, IdxT>(            \
-    const raft::resources& res, const std::string& filename)                               \
-  {                                                                                        \
-    auto idx = cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT>(res, filename);     \
-    return idx;                                                                            \
-  }                                                                                        \
-                                                                                           \
-  template <>                                                                              \
-  cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT> distribute<T, IdxT>(             \
-    const raft::resources& res, const std::string& filename)                               \
-  {                                                                                        \
-    auto idx = cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT>(res, REPLICATED);   \
-    cuvs::neighbors::snmg::detail::deserialize_and_distribute(res, idx, filename);         \
-    return idx;                                                                            \
-  }                                                                                        \
+#define CUVS_INST_MG_PQ(T, IdxT)                                                            \
+  namespace cuvs::neighbors::ivf_pq {                                                       \
+  using namespace cuvs::neighbors;                                                          \
+                                                                                            \
+  cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT> build(                            \
+    const raft::resources& res,                                                             \
+    const mg_index_params<ivf_pq::index_params>& index_params,                              \
+    raft::host_matrix_view<const T, int64_t, row_major> index_dataset)                      \
+  {                                                                                         \
+    cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT> index(res, index_params.mode);  \
+    cuvs::neighbors::snmg::detail::build(                                                   \
+      res,                                                                                  \
+      index,                                                                                \
+      static_cast<const cuvs::neighbors::index_params*>(&index_params),                     \
+      index_dataset);                                                                       \
+    return index;                                                                           \
+  }                                                                                         \
+                                                                                            \
+  void extend(const raft::resources& res,                                                   \
+              cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT>& index,               \
+              raft::host_matrix_view<const T, int64_t, row_major> new_vectors,              \
+              std::optional<raft::host_vector_view<const IdxT, int64_t>> new_indices)       \
+  {                                                                                         \
+    cuvs::neighbors::snmg::detail::extend(res, index, new_vectors, new_indices);            \
+  }                                                                                         \
+                                                                                            \
+  void search(const raft::resources& res,                                                   \
+              const cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT>& index,         \
+              const mg_search_params<ivf_pq::search_params>& search_params,                 \
+              raft::host_matrix_view<const T, int64_t, row_major> queries,                  \
+              raft::host_matrix_view<IdxT, int64_t, row_major> neighbors,                   \
+              raft::host_matrix_view<float, int64_t, row_major> distances)                  \
+  {                                                                                         \
+    cuvs::neighbors::snmg::detail::search(                                                  \
+      res,                                                                                  \
+      index,                                                                                \
+      static_cast<const cuvs::neighbors::search_params*>(&search_params),                   \
+      queries,                                                                              \
+      neighbors,                                                                            \
+      distances);                                                                           \
+  }                                                                                         \
+                                                                                            \
+  void serialize(const raft::resources& res,                                                \
+                 const cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT>& index,      \
+                 const std::string& filename)                                               \
+  {                                                                                         \
+    cuvs::neighbors::snmg::detail::serialize(res, index, filename);                         \
+  }                                                                                         \
+                                                                                            \
+  template <>                                                                               \
+  CUVS_EXPORT cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT> deserialize<T, IdxT>( \
+    const raft::resources& res, const std::string& filename)                                \
+  {                                                                                         \
+    auto idx = cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT>(res, filename);      \
+    return idx;                                                                             \
+  }                                                                                         \
+                                                                                            \
+  template <>                                                                               \
+  CUVS_EXPORT cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT> distribute<T, IdxT>(  \
+    const raft::resources& res, const std::string& filename)                                \
+  {                                                                                         \
+    auto idx = cuvs::neighbors::mg_index<ivf_pq::index<IdxT>, T, IdxT>(res, REPLICATED);    \
+    cuvs::neighbors::snmg::detail::deserialize_and_distribute(res, idx, filename);          \
+    return idx;                                                                             \
+  }                                                                                         \
   }  // namespace cuvs::neighbors::ivf_pq
 CUVS_INST_MG_PQ(@data_type@, int64_t);
 

--- a/cpp/src/neighbors/nn_descent_gnnd_inst.cu
+++ b/cpp/src/neighbors/nn_descent_gnnd_inst.cu
@@ -18,7 +18,6 @@ using index_t = uint32_t;
 namespace cuvs::neighbors::nn_descent {
 
 template class CUVS_EXPORT detail::GNND<const data_t, int>;
-template struct CUVS_EXPORT detail::GnndGraph<int>;
 
 template void detail::GNND<const data_t, int>::build<
   cuvs::neighbors::detail::reachability::ReachabilityPostProcess<int, data_t>>(

--- a/cpp/src/neighbors/nn_descent_gnnd_inst.cu
+++ b/cpp/src/neighbors/nn_descent_gnnd_inst.cu
@@ -17,7 +17,8 @@ using index_t = uint32_t;
 
 namespace cuvs::neighbors::nn_descent {
 
-template class detail::GNND<const data_t, int>;
+template class CUVS_EXPORT detail::GNND<const data_t, int>;
+template struct CUVS_EXPORT detail::GnndGraph<int>;
 
 template void detail::GNND<const data_t, int>::build<
   cuvs::neighbors::detail::reachability::ReachabilityPostProcess<int, data_t>>(


### PR DESCRIPTION
Add proper symbol visibility controls to libcuvs.so, compatible with the raft visibility restrictions in rapidsai/raft#3019.

### Motivation

With raft restricting exports to only `core/` and `raft_runtime/`, cuvs needs its own visibility controls to:
1. Prevent symbol interposition between libcuml.so and libcuvs.so
2. Export only the intended public API from libcuvs.so
3. Keep internal implementation details hidden

### Changes

- **Add `CUDA_VISIBILITY_PRESET hidden` to `cuvs_objs`** — all symbols hidden by default
- **Add `CUVS_EXPORT` to public API symbols** — mark symbols that must be visible in libcuvs.so
- **Fix NVCC compatibility** — use `struct CUVS_EXPORT` on definitions (not instantiations) for NVCC
- **Fix `__half` type visibility** — add cuda_fp16.hpp wrapper to handle type visibility across TUs
- **Fix brute_force, cagra, resize_list exports** — ensure all needed symbols are exported
- **Fix remaining linker errors** — 4 additional hidden symbols that needed export
- **Fix CI rattler-build** — restore `rapids-rattler-channel-string` in both build_cpp.sh and build_python.sh

### CI note

The `test(ci): build against vyasr/raft#3019` commit that pins raft to the visibility branch will be reverted before merge (once raft#3019 is merged to release/26.06).

Depends on https://github.com/rapidsai/raft/pull/3019

Contributes to https://github.com/rapidsai/build-infra/issues/53