### PR TITLE
skip CuPy 14.1.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dlpack>=0.8,<1.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dlpack>=0.8,<1.0

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dlpack>=0.8,<1.0

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dlpack>=0.8,<1.0

--- a/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.6.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2

--- a/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.6.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2

--- a/conda/environments/bench_ann_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-132_arch-aarch64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.6.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2

--- a/conda/environments/bench_ann_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-132_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.6.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2

--- a/conda/recipes/cuvs-bench/recipe.yaml
+++ b/conda/recipes/cuvs-bench/recipe.yaml
@@ -42,7 +42,7 @@ requirements:
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - click
-    - cupy >=13.6.0
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
     - cuvs =${{ version }}
     - h5py ${{ h5py_version }}
     - libcuvs-bench-ann =${{ version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -427,7 +427,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - cupy>=13.6.0
+          - cupy>=13.6.0,!=14.0.0,!=14.1.0
     # NOTE: This is intentionally not broken into groups by a 'cuda_suffixed' selector like
     #       other packages with -cu{nn}x suffixes in this file.
     #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
@@ -437,11 +437,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0
+              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - &cupy_cu13 cupy-cuda13x>=13.6.0
+              - &cupy_cu13 cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
   test_libcuvs:
     common:
       - output_types: [conda]

--- a/python/cuvs/pyproject.toml
+++ b/python/cuvs/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-    "cupy-cuda13x>=13.6.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "pytest",
     "pytest-cov",
     "scikit-learn>=1.5",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/284

To reduce the risk of users encountering a known runtime issue with `cupy` and `torch`, RAPIDS 26.06 is taking on a requirement `cupy!=14.1.0`.

See the linked issue for details.
