### PR TITLE
Fixing advanced topics in docs

### DIFF
--- a/docs/source/abi_stability.md
+++ b/docs/source/abi_stability.md
@@ -1,0 +1,70 @@
+# ABI Stability
+
+ABI stands for **Application Binary Interface**. It defines how compiled
+programs interact with a shared library at runtime.
+
+For cuVS, ABI stability means that an application built against one supported
+version of the **cuVS C library** can run with a compatible newer cuVS runtime
+without being rebuilt.
+
+ABI stability is different from API stability:
+
+| Concept | Meaning |
+|---|---|
+| API stability | Source code continues to compile. |
+| ABI stability | Already-compiled binaries continue to run. |
+
+## Compatibility Rule
+
+A cuVS runtime is ABI-compatible with an application when both of the following
+are true:
+
+1. The runtime has the same ABI major version as the version used at build time.
+2. The runtime cuVS version is the same or newer than the version used at build
+   time.
+
+For example, an application built against cuVS 26.04 can use a cuVS 26.06
+runtime when both versions use the same ABI major version. An older runtime or a
+runtime with a different ABI major version is not considered compatible.
+
+## Scope
+
+The ABI stability guarantee applies to the public **C ABI**:
+
+- Public C headers installed under `include/cuvs/`
+- Functions, enums, and structs declared in `.h` headers
+- Public symbols exposed through `extern "C"`
+
+The guarantee does not generally apply to internal implementation details or to
+the C++ implementation ABI.
+
+## Public Structs
+
+Public structs require care because compiled applications may depend on their
+binary layout. Prefer create and destroy functions for objects that own memory
+or expose implementation details.
+
+Recommended pattern:
+
+```c
+cuvsHnswIndex_t index;
+cuvsHnswIndexCreate(&index);
+
+cuvsHnswIndexParams_t params;
+cuvsHnswIndexParamsCreate(&params);
+
+cuvsHnswFromCagra(res, params, cagra_index, index);
+```
+
+Avoid requiring users to allocate or initialize structs directly when future
+fields may need to be added.
+
+## C++ ABI
+
+Guaranteeing ABI stability for C++ is difficult because the binary interface can
+change when templates, inline functions, namespaces, class layouts, standard
+library types, compiler versions, or CUDA compilation details change.
+
+For this reason, cuVS treats the C API as the stable ABI boundary. Language
+bindings and downstream integrations should call the C API rather than depending
+on C++ symbols directly when binary compatibility across releases is required.

--- a/docs/source/advanced_topics.rst
+++ b/docs/source/advanced_topics.rst
@@ -19,4 +19,5 @@ Currently, the following capabilities will trigger a JIT compilation:
 .. toctree::
    :maxdepth: 2
 
+   abi_stability
    jit_lto_guide

--- a/docs/source/developer_guide.md
+++ b/docs/source/developer_guide.md
@@ -3,6 +3,15 @@
 ## General
 Please start by reading the [Contributor Guide](contributing.md).
 
+## Advanced Topics
+
+```eval_rst
+.. toctree::
+   :maxdepth: 2
+
+   advanced_topics
+```
+
 ## Performance
 1. In performance critical sections of the code, favor `cudaDeviceGetAttribute` over `cudaDeviceGetProperties`. See corresponding CUDA devblog [here](https://devblogs.nvidia.com/cuda-pro-tip-the-fast-way-to-query-device-properties/) to know more.
 2. If an algo requires you to launch GPU work in multiple cuda streams, do not create multiple `raft::resources` objects, one for each such work stream. Instead, use the stream pool configured on the given `raft::resources` instance's `raft::resources::get_stream_from_stream_pool()` to pick up the right cuda stream. Refer to the section on [CUDA Resources](#resource-management) and the section on [Threading](#threading-model) for more details. TIP: use `raft::resources::get_stream_pool_size()` to know how many such streams are available at your disposal.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -87,6 +87,5 @@ Contents
    integrations.rst
    cuvs_bench/index.rst
    api_docs.rst
-   advanced_topics.rst
    contributing.md
    developer_guide.md


### PR DESCRIPTION
A recent bad merge of the docs moved Advanced Topics under the user guide. This PR moves it back to the developer guide and re-nests some of the other things in developer guide underneath. 