### PR TITLE
remove pypi.nvidia.com from install docs

### DIFF
--- a/fern/pages/installation/python.md
+++ b/fern/pages/installation/python.md
@@ -20,10 +20,10 @@ You can also install through pip:
 
 ```bash
 # CUDA 13
-pip install cuvs-cu13 --extra-index-url=https://pypi.nvidia.com
+pip install cuvs-cu13
 
 # CUDA 12
-pip install cuvs-cu12 --extra-index-url=https://pypi.nvidia.com
+pip install cuvs-cu12
 ```
 
 The pip packages statically link the C and C++ libraries, so `libcuvs` and `libcuvs_c` shared libraries are not readily available for use by external code.


### PR DESCRIPTION
cuVS packages are now available from `pypi.org`, without involving `pypi.nvidia.com`

* https://pypi.org/project/cuvs-cu12/
* https://pypi.org/project/cuvs-cu13/
* https://pypi.org/project/libcuvs-cu12/
* https://pypi.org/project/libcuvs-cu13/

This removes `pypi.nvidia.com` from the install docs.

## Notes for Reviewers

These were the only uses of it I found:

```shell
git grep -E 'pypi\.nvidia.com'
```

Note that installing cuVS packages from `pypi.org` won't work quiiiite yet because the release is still in progress (as of this writing) and packages like `pylibraft-cu13==26.6` aren't published yet, but that should be resolved within the next day.