### PR TITLE
feat(rust): add IVF-SQ bindings

### DIFF
--- a/rust/cuvs-sys/src/bindings.rs
+++ b/rust/cuvs-sys/src/bindings.rs
@@ -1765,6 +1765,182 @@ unsafe extern "C" {
         index: cuvsIvfFlatIndex_t,
     ) -> cuvsError_t;
 }
+#[doc = " @defgroup ivf_sq_c_index_params IVF-SQ index build parameters\n @{\n/\n/**\n @brief Supplemental parameters to build IVF-SQ Index\n"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct cuvsIvfSqIndexParams {
+    #[doc = " Distance type."]
+    pub metric: cuvsDistanceType,
+    #[doc = " The argument used by some distance metrics."]
+    pub metric_arg: f32,
+    #[doc = " Whether to add the dataset content to the index, i.e.:\n\n  - `true` means the index is filled with the dataset vectors and ready to search after calling\n `build`.\n  - `false` means `build` only trains the underlying model (e.g. quantizer or clustering), but\n the index is left empty; you'd need to call `extend` on the index afterwards to populate it."]
+    pub add_data_on_build: bool,
+    #[doc = " The number of inverted lists (clusters)"]
+    pub n_lists: u32,
+    #[doc = " The number of iterations searching for kmeans centers (index building)."]
+    pub kmeans_n_iters: u32,
+    #[doc = " The number of data vectors per cluster to use during iterative kmeans building.\n The index uses at most `n_lists * max_train_points_per_cluster` rows for training."]
+    pub max_train_points_per_cluster: u32,
+    #[doc = " By default, the algorithm allocates more space than necessary for individual clusters\n (`list_data`). This allows to amortize the cost of memory allocation and reduce the number of\n data copies during repeated calls to `extend` (extending the database).\n\n The alternative is the conservative allocation behavior; when enabled, the algorithm always\n allocates the minimum amount of memory required to store the given number of records. Set this\n flag to `true` if you prefer to use as little GPU memory for the database as possible."]
+    pub conservative_memory_allocation: bool,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of cuvsIvfSqIndexParams"][::std::mem::size_of::<cuvsIvfSqIndexParams>() - 28usize];
+    ["Alignment of cuvsIvfSqIndexParams"][::std::mem::align_of::<cuvsIvfSqIndexParams>() - 4usize];
+    ["Offset of field: cuvsIvfSqIndexParams::metric"]
+        [::std::mem::offset_of!(cuvsIvfSqIndexParams, metric) - 0usize];
+    ["Offset of field: cuvsIvfSqIndexParams::metric_arg"]
+        [::std::mem::offset_of!(cuvsIvfSqIndexParams, metric_arg) - 4usize];
+    ["Offset of field: cuvsIvfSqIndexParams::add_data_on_build"]
+        [::std::mem::offset_of!(cuvsIvfSqIndexParams, add_data_on_build) - 8usize];
+    ["Offset of field: cuvsIvfSqIndexParams::n_lists"]
+        [::std::mem::offset_of!(cuvsIvfSqIndexParams, n_lists) - 12usize];
+    ["Offset of field: cuvsIvfSqIndexParams::kmeans_n_iters"]
+        [::std::mem::offset_of!(cuvsIvfSqIndexParams, kmeans_n_iters) - 16usize];
+    ["Offset of field: cuvsIvfSqIndexParams::max_train_points_per_cluster"]
+        [::std::mem::offset_of!(cuvsIvfSqIndexParams, max_train_points_per_cluster) - 20usize];
+    ["Offset of field: cuvsIvfSqIndexParams::conservative_memory_allocation"]
+        [::std::mem::offset_of!(cuvsIvfSqIndexParams, conservative_memory_allocation) - 24usize];
+};
+pub type cuvsIvfSqIndexParams_t = *mut cuvsIvfSqIndexParams;
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " @brief Allocate IVF-SQ Index params, and populate with default values\n\n @param[in] index_params cuvsIvfSqIndexParams_t to allocate\n @return cuvsError_t"]
+    pub fn cuvsIvfSqIndexParamsCreate(index_params: *mut cuvsIvfSqIndexParams_t) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " @brief De-allocate IVF-SQ Index params\n\n @param[in] index_params\n @return cuvsError_t"]
+    pub fn cuvsIvfSqIndexParamsDestroy(index_params: cuvsIvfSqIndexParams_t) -> cuvsError_t;
+}
+#[doc = " @defgroup ivf_sq_c_search_params IVF-SQ index search parameters\n @{\n/\n/**\n @brief Supplemental parameters to search IVF-SQ index\n"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct cuvsIvfSqSearchParams {
+    #[doc = " The number of clusters to search."]
+    pub n_probes: u32,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of cuvsIvfSqSearchParams"][::std::mem::size_of::<cuvsIvfSqSearchParams>() - 4usize];
+    ["Alignment of cuvsIvfSqSearchParams"]
+        [::std::mem::align_of::<cuvsIvfSqSearchParams>() - 4usize];
+    ["Offset of field: cuvsIvfSqSearchParams::n_probes"]
+        [::std::mem::offset_of!(cuvsIvfSqSearchParams, n_probes) - 0usize];
+};
+pub type cuvsIvfSqSearchParams_t = *mut cuvsIvfSqSearchParams;
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " @brief Allocate IVF-SQ search params, and populate with default values\n\n @param[in] params cuvsIvfSqSearchParams_t to allocate\n @return cuvsError_t"]
+    pub fn cuvsIvfSqSearchParamsCreate(params: *mut cuvsIvfSqSearchParams_t) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " @brief De-allocate IVF-SQ search params\n\n @param[in] params\n @return cuvsError_t"]
+    pub fn cuvsIvfSqSearchParamsDestroy(params: cuvsIvfSqSearchParams_t) -> cuvsError_t;
+}
+#[doc = " @defgroup ivf_sq_c_index IVF-SQ index\n @{\n/\n/**\n @brief Struct to hold address of cuvs::neighbors::ivf_sq::index and its active trained dtype\n"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct cuvsIvfSqIndex {
+    pub addr: usize,
+    pub dtype: DLDataType,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of cuvsIvfSqIndex"][::std::mem::size_of::<cuvsIvfSqIndex>() - 16usize];
+    ["Alignment of cuvsIvfSqIndex"][::std::mem::align_of::<cuvsIvfSqIndex>() - 8usize];
+    ["Offset of field: cuvsIvfSqIndex::addr"]
+        [::std::mem::offset_of!(cuvsIvfSqIndex, addr) - 0usize];
+    ["Offset of field: cuvsIvfSqIndex::dtype"]
+        [::std::mem::offset_of!(cuvsIvfSqIndex, dtype) - 8usize];
+};
+pub type cuvsIvfSqIndex_t = *mut cuvsIvfSqIndex;
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " @brief Allocate IVF-SQ index\n\n @param[in] index cuvsIvfSqIndex_t to allocate\n @return cuvsError_t"]
+    pub fn cuvsIvfSqIndexCreate(index: *mut cuvsIvfSqIndex_t) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " @brief De-allocate IVF-SQ index\n\n @param[in] index cuvsIvfSqIndex_t to de-allocate"]
+    pub fn cuvsIvfSqIndexDestroy(index: cuvsIvfSqIndex_t) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " Get the number of clusters/inverted lists"]
+    pub fn cuvsIvfSqIndexGetNLists(index: cuvsIvfSqIndex_t, n_lists: *mut i64) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " Get the dimensionality of the data"]
+    pub fn cuvsIvfSqIndexGetDim(index: cuvsIvfSqIndex_t, dim: *mut i64) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " Get the size of the index"]
+    pub fn cuvsIvfSqIndexGetSize(index: cuvsIvfSqIndex_t, size: *mut i64) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " @brief Get the cluster centers corresponding to the lists [n_lists, dim]\n\n @param[in] index cuvsIvfSqIndex_t Built Ivf-SQ Index\n @param[out] centers Preallocated array on host or device memory to store output, [n_lists, dim]\n @return cuvsError_t"]
+    pub fn cuvsIvfSqIndexGetCenters(
+        index: cuvsIvfSqIndex_t,
+        centers: *mut DLManagedTensor,
+    ) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " @defgroup ivf_sq_c_index_build IVF-SQ index build\n @{\n/\n/**\n @brief Build an IVF-SQ index with a `DLManagedTensor` which has underlying\n        `DLDeviceType` equal to `kDLCUDA`, `kDLCUDAHost`, `kDLCUDAManaged`,\n        or `kDLCPU`. Also, acceptable underlying types are:\n        1. `kDLDataType.code == kDLFloat` and `kDLDataType.bits = 32`\n        2. `kDLDataType.code == kDLFloat` and `kDLDataType.bits = 16`\n\n @code {.c}\n #include <cuvs/core/c_api.h>\n #include <cuvs/neighbors/ivf_sq.h>\n\n // Create cuvsResources_t\n cuvsResources_t res;\n cuvsError_t res_create_status = cuvsResourcesCreate(&res);\n\n // Assume a populated `DLManagedTensor` type here\n DLManagedTensor dataset;\n\n // Create default index params\n cuvsIvfSqIndexParams_t index_params;\n cuvsError_t params_create_status = cuvsIvfSqIndexParamsCreate(&index_params);\n\n // Create IVF-SQ index\n cuvsIvfSqIndex_t index;\n cuvsError_t index_create_status = cuvsIvfSqIndexCreate(&index);\n\n // Build the IVF-SQ Index\n cuvsError_t build_status = cuvsIvfSqBuild(res, index_params, &dataset, index);\n\n // de-allocate `index_params`, `index` and `res`\n cuvsError_t params_destroy_status = cuvsIvfSqIndexParamsDestroy(index_params);\n cuvsError_t index_destroy_status = cuvsIvfSqIndexDestroy(index);\n cuvsError_t res_destroy_status = cuvsResourcesDestroy(res);\n @endcode\n\n @param[in] res cuvsResources_t opaque C handle\n @param[in] index_params cuvsIvfSqIndexParams_t used to build IVF-SQ index\n @param[in] dataset DLManagedTensor* training dataset\n @param[out] index cuvsIvfSqIndex_t Newly built IVF-SQ index\n @return cuvsError_t"]
+    pub fn cuvsIvfSqBuild(
+        res: cuvsResources_t,
+        index_params: cuvsIvfSqIndexParams_t,
+        dataset: *mut DLManagedTensor,
+        index: cuvsIvfSqIndex_t,
+    ) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " @defgroup ivf_sq_c_index_search IVF-SQ index search\n @{\n/\n/**\n @brief Search an IVF-SQ index with a `DLManagedTensor` which has underlying\n        `DLDeviceType` equal to `kDLCUDA`, `kDLCUDAHost`, `kDLCUDAManaged`.\n        Types for input are:\n        1. `queries`: `kDLDataType.code == kDLFloat` and `kDLDataType.bits = 32` or 16\n        2. `neighbors`: `kDLDataType.code == kDLInt` and `kDLDataType.bits = 64`\n        3. `distances`: `kDLDataType.code == kDLFloat` and `kDLDataType.bits = 32`\n\n @code {.c}\n #include <cuvs/core/c_api.h>\n #include <cuvs/neighbors/ivf_sq.h>\n\n // Create cuvsResources_t\n cuvsResources_t res;\n cuvsError_t res_create_status = cuvsResourcesCreate(&res);\n\n // Assume a populated `DLManagedTensor` type here\n DLManagedTensor queries;\n DLManagedTensor neighbors;\n DLManagedTensor distances;\n\n // Create default search params\n cuvsIvfSqSearchParams_t search_params;\n cuvsError_t params_create_status = cuvsIvfSqSearchParamsCreate(&search_params);\n\n // Search the `index` built using `cuvsIvfSqBuild`\n cuvsError_t search_status = cuvsIvfSqSearch(\n   res, search_params, index, &queries, &neighbors, &distances, (cuvsFilter){});\n\n // de-allocate `search_params` and `res`\n cuvsError_t params_destroy_status = cuvsIvfSqSearchParamsDestroy(search_params);\n cuvsError_t res_destroy_status = cuvsResourcesDestroy(res);\n @endcode\n\n @param[in] res cuvsResources_t opaque C handle\n @param[in] search_params cuvsIvfSqSearchParams_t used to search IVF-SQ index\n @param[in] index ivfSqIndex which has been returned by `cuvsIvfSqBuild`\n @param[in] queries DLManagedTensor* queries dataset to search\n @param[out] neighbors DLManagedTensor* output `k` neighbors for queries\n @param[out] distances DLManagedTensor* output `k` distances for queries\n @param[in] filter cuvsFilter input filter that can be used\n            to filter queries and neighbors based on the given bitset."]
+    pub fn cuvsIvfSqSearch(
+        res: cuvsResources_t,
+        search_params: cuvsIvfSqSearchParams_t,
+        index: cuvsIvfSqIndex_t,
+        queries: *mut DLManagedTensor,
+        neighbors: *mut DLManagedTensor,
+        distances: *mut DLManagedTensor,
+        filter: cuvsFilter,
+    ) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " @defgroup ivf_sq_c_index_serialize IVF-SQ C-API serialize functions\n @{\n/\n/**\n Save the index to file.\n\n Experimental, both the API and the serialization format are subject to change.\n\n @code{.c}\n #include <cuvs/neighbors/ivf_sq.h>\n\n // Create cuvsResources_t\n cuvsResources_t res;\n cuvsError_t res_create_status = cuvsResourcesCreate(&res);\n\n // create an index with `cuvsIvfSqBuild`\n cuvsIvfSqSerialize(res, \"/path/to/index\", index);\n @endcode\n\n @param[in] res cuvsResources_t opaque C handle\n @param[in] filename the file name for saving the index\n @param[in] index IVF-SQ index"]
+    pub fn cuvsIvfSqSerialize(
+        res: cuvsResources_t,
+        filename: *const ::std::os::raw::c_char,
+        index: cuvsIvfSqIndex_t,
+    ) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " Load index from file.\n\n Experimental, both the API and the serialization format are subject to change.\n\n @param[in] res cuvsResources_t opaque C handle\n @param[in] filename the name of the file that stores the index\n @param[out] index IVF-SQ index loaded from disk"]
+    pub fn cuvsIvfSqDeserialize(
+        res: cuvsResources_t,
+        filename: *const ::std::os::raw::c_char,
+        index: cuvsIvfSqIndex_t,
+    ) -> cuvsError_t;
+}
+unsafe extern "C" {
+    #[must_use]
+    #[doc = " @defgroup ivf_sq_c_index_extend IVF-SQ index extend\n @{\n/\n/**\n @brief Extend the index with the new data.\n\n @param[in] res cuvsResources_t opaque C handle\n @param[in] new_vectors DLManagedTensor* the new vectors to add to the index\n @param[in] new_indices DLManagedTensor* vector of new indices for the new vectors. If the index\n            is empty, this can be NULL to imply a continuous range `[0...n_rows)`.\n @param[inout] index IVF-SQ index to be extended\n @return cuvsError_t"]
+    pub fn cuvsIvfSqExtend(
+        res: cuvsResources_t,
+        new_vectors: *mut DLManagedTensor,
+        new_indices: *mut DLManagedTensor,
+        index: cuvsIvfSqIndex_t,
+    ) -> cuvsError_t;
+}
 unsafe extern "C" {
     #[must_use]
     #[doc = " @defgroup ann_refine_c Approximate Nearest Neighbors Refinement C-API\n @{\n/\n/**\n @brief Refine nearest neighbor search.\n\n Refinement is an operation that follows an approximate NN search. The approximate search has\n already selected n_candidates neighbor candidates for each query. We narrow it down to k\n neighbors. For each query, we calculate the exact distance between the query and its\n n_candidates neighbor candidate, and select the k nearest ones.\n\n @param[in] res cuvsResources_t opaque C handle\n @param[in] dataset device matrix that stores the dataset [n_rows, dims]\n @param[in] queries device matrix of the queries [n_queris, dims]\n @param[in] candidates indices of candidate vectors [n_queries, n_candidates], where\n   n_candidates >= k\n @param[in] metric distance metric to use. Euclidean (L2) is used by default\n @param[out] indices device matrix that stores the refined indices [n_queries, k]\n @param[out] distances device matrix that stores the refined distances [n_queries, k]"]

--- a/rust/cuvs/src/ivf_sq/index.rs
+++ b/rust/cuvs/src/ivf_sq/index.rs
@@ -1,0 +1,477 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::ffi::CString;
+use std::io::{Write, stderr};
+use std::path::Path;
+
+use crate::dlpack::{AsDlTensor, AsDlTensorMut};
+use crate::error::{Error, Result, check_cuvs};
+use crate::ivf_sq::{IndexParams, SearchParams};
+use crate::resources::Resources;
+
+/// IVF-SQ ANN Index
+#[derive(Debug)]
+pub struct Index(ffi::cuvsIvfSqIndex_t);
+
+/// Convert a filesystem path into a `CString` suitable for the cuVS C API,
+/// returning `Error::InvalidArgument` instead of panicking for paths that are
+/// not valid UTF-8 or that contain an interior NUL byte.
+fn path_to_cstring(path: &Path) -> Result<CString> {
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| Error::InvalidArgument(format!("path is not valid UTF-8: {path:?}")))?;
+    CString::new(path_str)
+        .map_err(|e| Error::InvalidArgument(format!("path contains an interior NUL byte: {e}")))
+}
+
+impl Index {
+    /// Builds an IVF-SQ index over `dataset` for efficient search.
+    ///
+    /// `dataset` is a row-major matrix on the host or device implementing
+    /// [`AsDlTensor`]. It is copied (and quantized) into the index, so the
+    /// caller may free it once this call returns (hence `Index` carries no
+    /// lifetime).
+    pub fn build<T>(res: &Resources, params: &IndexParams, dataset: &T) -> Result<Index>
+    where
+        T: AsDlTensor + ?Sized,
+    {
+        let dataset = dataset.as_dl_tensor()?;
+        let index = Index::new()?;
+        unsafe {
+            check_cuvs(ffi::cuvsIvfSqBuild(res.0, params.0, dataset.to_c().as_mut_ptr(), index.0))?;
+        }
+        Ok(index)
+    }
+
+    /// Creates a new empty index
+    pub fn new() -> Result<Index> {
+        unsafe {
+            let mut index = std::mem::MaybeUninit::<ffi::cuvsIvfSqIndex_t>::uninit();
+            check_cuvs(ffi::cuvsIvfSqIndexCreate(index.as_mut_ptr()))?;
+            Ok(Index(index.assume_init()))
+        }
+    }
+
+    /// Searches the index for the `k` nearest neighbors of each query.
+    ///
+    /// `queries`, `neighbors`, and `distances` must reside in device memory and
+    /// implement [`AsDlTensor`] /
+    /// [`AsDlTensorMut`]. `neighbors` receives the
+    /// neighbor indices and `distances` their distances; both are written in
+    /// place.
+    pub fn search<Q, N, D>(
+        &self,
+        res: &Resources,
+        params: &SearchParams,
+        queries: &Q,
+        neighbors: &mut N,
+        distances: &mut D,
+    ) -> Result<()>
+    where
+        Q: AsDlTensor + ?Sized,
+        N: AsDlTensorMut + ?Sized,
+        D: AsDlTensorMut + ?Sized,
+    {
+        let queries = queries.as_dl_tensor()?;
+        let neighbors = neighbors.as_dl_tensor_mut()?;
+        let distances = distances.as_dl_tensor_mut()?;
+        unsafe {
+            let prefilter = ffi::cuvsFilter { addr: 0, type_: ffi::cuvsFilterType::NO_FILTER };
+
+            check_cuvs(ffi::cuvsIvfSqSearch(
+                res.0,
+                params.0,
+                self.0,
+                queries.to_c().as_mut_ptr(),
+                neighbors.to_c().as_mut_ptr(),
+                distances.to_c().as_mut_ptr(),
+                prefilter,
+            ))
+        }
+    }
+
+    /// Perform a filtered Approximate Nearest Neighbors search on the Index
+    ///
+    /// Like [`search`](Self::search), but applies a bitset filter to exclude
+    /// vectors from the candidate set. Filtered vectors are never returned,
+    /// giving better recall than post-filtering.
+    ///
+    /// `queries`, `neighbors`, and `distances` are as in [`search`](Self::search).
+    /// `bitset` is a 1-D `uint32` device tensor of `ceil(n_rows / 32)` elements,
+    /// where each bit corresponds to a dataset row: bit 1 = include, bit 0 =
+    /// exclude.
+    pub fn search_with_filter<Q, N, D, B>(
+        &self,
+        res: &Resources,
+        params: &SearchParams,
+        queries: &Q,
+        neighbors: &mut N,
+        distances: &mut D,
+        bitset: &B,
+    ) -> Result<()>
+    where
+        Q: AsDlTensor + ?Sized,
+        N: AsDlTensorMut + ?Sized,
+        D: AsDlTensorMut + ?Sized,
+        B: AsDlTensor + ?Sized,
+    {
+        let queries = queries.as_dl_tensor()?;
+        let neighbors = neighbors.as_dl_tensor_mut()?;
+        let distances = distances.as_dl_tensor_mut()?;
+        let bitset = bitset.as_dl_tensor()?;
+        // The bitset pointer is cast to `usize` and stored in `prefilter`, then read
+        // by the search call, so its `ManagedTensorRef` must outlive both.
+        // Hence we keep it bound instead of chaining `to_c().as_mut_ptr()`.
+        let mut bitset_c = bitset.to_c();
+        unsafe {
+            let prefilter = ffi::cuvsFilter {
+                addr: bitset_c.as_mut_ptr() as usize,
+                type_: ffi::cuvsFilterType::BITSET,
+            };
+
+            check_cuvs(ffi::cuvsIvfSqSearch(
+                res.0,
+                params.0,
+                self.0,
+                queries.to_c().as_mut_ptr(),
+                neighbors.to_c().as_mut_ptr(),
+                distances.to_c().as_mut_ptr(),
+                prefilter,
+            ))
+        }
+    }
+
+    /// Extend the index with new vectors.
+    ///
+    /// `new_vectors` is a row-major matrix on the host or device implementing
+    /// [`AsDlTensor`]. `new_indices` is an optional 1-D tensor of indices for
+    /// the new vectors; if `None`, a continuous range `[0..n_rows)` is implied,
+    /// which is only valid when the index is currently empty.
+    pub fn extend<V>(
+        &mut self,
+        res: &Resources,
+        new_vectors: &V,
+        new_indices: Option<&dyn AsDlTensor>,
+    ) -> Result<()>
+    where
+        V: AsDlTensor + ?Sized,
+    {
+        let new_vectors = new_vectors.as_dl_tensor()?;
+        // Bind the optional index view, then its `ManagedTensorRef`, so both
+        // outlive the FFI call whose pointer borrows them.
+        let new_indices = new_indices.map(|t| t.as_dl_tensor()).transpose()?;
+        let mut new_indices_c = new_indices.as_ref().map(|v| v.to_c());
+        let new_indices_ptr =
+            new_indices_c.as_mut().map_or(std::ptr::null_mut(), |c| c.as_mut_ptr());
+        unsafe {
+            check_cuvs(ffi::cuvsIvfSqExtend(
+                res.0,
+                new_vectors.to_c().as_mut_ptr(),
+                new_indices_ptr,
+                self.0,
+            ))
+        }
+    }
+
+    // `cuvsIvfSqIndexGetCenters` is deliberately not wrapped, matching the
+    // cagra and ivf_pq Rust modules: it fills a caller-allocated
+    // DLManagedTensor, which has no ergonomic safe-Rust shape yet.
+
+    /// The number of clusters / inverted lists in the index.
+    pub fn n_lists(&self) -> Result<i64> {
+        let mut n_lists: i64 = 0;
+        unsafe {
+            check_cuvs(ffi::cuvsIvfSqIndexGetNLists(self.0, &mut n_lists))?;
+        }
+        Ok(n_lists)
+    }
+
+    /// The dimensionality of the vectors stored in the index.
+    pub fn dim(&self) -> Result<i64> {
+        let mut dim: i64 = 0;
+        unsafe {
+            check_cuvs(ffi::cuvsIvfSqIndexGetDim(self.0, &mut dim))?;
+        }
+        Ok(dim)
+    }
+
+    /// The number of vectors stored in the index.
+    pub fn size(&self) -> Result<i64> {
+        let mut size: i64 = 0;
+        unsafe {
+            check_cuvs(ffi::cuvsIvfSqIndexGetSize(self.0, &mut size))?;
+        }
+        Ok(size)
+    }
+
+    /// Save the IVF-SQ index to file.
+    ///
+    /// Experimental, both the API and the serialization format are subject to change.
+    ///
+    /// # Arguments
+    ///
+    /// * `res` - Resources to use
+    /// * `filename` - The file path for saving the index
+    pub fn serialize<P: AsRef<Path>>(&self, res: &Resources, filename: P) -> Result<()> {
+        let c_filename = path_to_cstring(filename.as_ref())?;
+        unsafe { check_cuvs(ffi::cuvsIvfSqSerialize(res.0, c_filename.as_ptr(), self.0)) }
+    }
+
+    /// Load an IVF-SQ index from file.
+    ///
+    /// Experimental, both the API and the serialization format are subject to change.
+    ///
+    /// # Arguments
+    ///
+    /// * `res` - Resources to use
+    /// * `filename` - The path of the file that stores the index
+    pub fn deserialize<P: AsRef<Path>>(res: &Resources, filename: P) -> Result<Index> {
+        let c_filename = path_to_cstring(filename.as_ref())?;
+        let index = Index::new()?;
+        unsafe {
+            check_cuvs(ffi::cuvsIvfSqDeserialize(res.0, c_filename.as_ptr(), index.0))?;
+        }
+        Ok(index)
+    }
+}
+
+impl Drop for Index {
+    fn drop(&mut self) {
+        if let Err(e) = check_cuvs(unsafe { ffi::cuvsIvfSqIndexDestroy(self.0) }) {
+            write!(stderr(), "failed to call cuvsIvfSqIndexDestroy {:?}", e)
+                .expect("failed to write to stderr");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::DeviceTensor;
+    use ndarray::s;
+    use ndarray_rand::RandomExt;
+    use ndarray_rand::rand_distr::Uniform;
+
+    const N_DATAPOINTS: usize = 1024;
+    const N_FEATURES: usize = 16;
+
+    /// Build a small random dataset and an IVF-SQ index over it.
+    fn build_test_index(
+        res: &Resources,
+        build_params: &IndexParams,
+    ) -> (ndarray::Array2<f32>, Index) {
+        let dataset = ndarray::Array::<f32, _>::random(
+            (N_DATAPOINTS, N_FEATURES),
+            Uniform::new(0., 1.0).unwrap(),
+        );
+        let dataset_device = DeviceTensor::from_host(res, &dataset).unwrap();
+        let index =
+            Index::build(res, build_params, &dataset_device).expect("failed to build ivf-sq index");
+        (dataset, index)
+    }
+
+    /// Search the first `n_queries` rows of `dataset` against `index` and assert
+    /// each query finds itself as the top-1 neighbor. IVF-SQ search requires
+    /// queries and outputs to live in device memory.
+    fn search_and_verify_self_neighbors(
+        res: &Resources,
+        index: &Index,
+        dataset: &ndarray::Array2<f32>,
+        n_queries: usize,
+        k: usize,
+    ) {
+        let queries = dataset.slice(s![0..n_queries, ..]).to_owned();
+        let queries = DeviceTensor::from_host(res, &queries).unwrap();
+
+        let mut neighbors_host = ndarray::Array::<i64, _>::zeros((n_queries, k));
+        let mut neighbors = DeviceTensor::<i64>::zeros(res, &[n_queries, k]).unwrap();
+
+        let mut distances_host = ndarray::Array::<f32, _>::zeros((n_queries, k));
+        let mut distances = DeviceTensor::<f32>::zeros(res, &[n_queries, k]).unwrap();
+
+        let search_params = SearchParams::new().unwrap();
+        index
+            .search(res, &search_params, &queries, &mut neighbors, &mut distances)
+            .expect("search failed");
+
+        distances.copy_to_host(res, &mut distances_host).unwrap();
+        neighbors.copy_to_host(res, &mut neighbors_host).unwrap();
+
+        for i in 0..n_queries {
+            assert_eq!(
+                neighbors_host[[i, 0]],
+                i as i64,
+                "query {i} should be its own nearest neighbor"
+            );
+        }
+    }
+
+    #[test]
+    fn test_ivf_sq() {
+        let build_params = IndexParams::new().unwrap().set_n_lists(64);
+        let res = Resources::new().unwrap();
+        let (dataset, index) = build_test_index(&res, &build_params);
+        search_and_verify_self_neighbors(&res, &index, &dataset, 4, 10);
+    }
+
+    /// Test that an index can be searched multiple times without rebuilding.
+    /// This validates that `search()` takes `&self` instead of `self`.
+    #[test]
+    fn test_ivf_sq_multiple_searches() {
+        let build_params = IndexParams::new().unwrap().set_n_lists(64);
+        let res = Resources::new().unwrap();
+        let (dataset, index) = build_test_index(&res, &build_params);
+
+        for _ in 0..3 {
+            search_and_verify_self_neighbors(&res, &index, &dataset, 4, 5);
+        }
+    }
+
+    /// Test the index introspection getters against the build parameters.
+    #[test]
+    fn test_ivf_sq_index_getters() {
+        let build_params = IndexParams::new().unwrap().set_n_lists(64);
+        let res = Resources::new().unwrap();
+        let (_dataset, index) = build_test_index(&res, &build_params);
+
+        assert_eq!(index.n_lists().unwrap(), 64);
+        assert_eq!(index.dim().unwrap(), N_FEATURES as i64);
+        assert_eq!(index.size().unwrap(), N_DATAPOINTS as i64);
+    }
+
+    /// Test extending an index that was built with `add_data_on_build == false`.
+    #[test]
+    fn test_ivf_sq_extend() {
+        let build_params = IndexParams::new().unwrap().set_n_lists(64).set_add_data_on_build(false);
+        let res = Resources::new().unwrap();
+
+        let dataset = ndarray::Array::<f32, _>::random(
+            (N_DATAPOINTS, N_FEATURES),
+            Uniform::new(0., 1.0).unwrap(),
+        );
+        let dataset_device = DeviceTensor::from_host(&res, &dataset).unwrap();
+
+        // Build only trains the quantizer/clustering; the index is left empty.
+        let mut index = Index::build(&res, &build_params, &dataset_device)
+            .expect("failed to build ivf-sq index");
+        assert_eq!(index.size().unwrap(), 0, "index should be empty before extend");
+
+        // Populate the index with the dataset using a continuous index range.
+        let extend_vectors = DeviceTensor::from_host(&res, &dataset).unwrap();
+        index.extend(&res, &extend_vectors, None).expect("failed to extend ivf-sq index");
+        assert_eq!(index.size().unwrap(), N_DATAPOINTS as i64);
+
+        // The populated index should now find each query as its own neighbor.
+        search_and_verify_self_neighbors(&res, &index, &dataset, 4, 10);
+    }
+
+    /// Test bitset-filtered search: exclude odd-indexed rows, verify they don't appear.
+    #[test]
+    fn test_ivf_sq_search_with_filter() {
+        let res = Resources::new().unwrap();
+        let build_params = IndexParams::new().unwrap().set_n_lists(64);
+        let (dataset, index) = build_test_index(&res, &build_params);
+
+        // Build a bitset that includes only even-indexed rows.
+        let n_words = N_DATAPOINTS.div_ceil(32);
+        let mut bitset_host = ndarray::Array::<u32, _>::zeros(ndarray::Ix1(n_words));
+        for i in 0..N_DATAPOINTS {
+            if i % 2 == 0 {
+                bitset_host[i / 32] |= 1u32 << (i % 32);
+            }
+        }
+        let bitset = DeviceTensor::from_host(&res, &bitset_host).unwrap();
+
+        // Query with the first 4 even-indexed rows.
+        let n_queries = 4;
+        let queries = dataset.slice(s![0..n_queries * 2;2, ..]).to_owned(); // rows 0, 2, 4, 6
+        let queries = DeviceTensor::from_host(&res, &queries).unwrap();
+
+        let k = 10;
+        let mut neighbors_host = ndarray::Array::<i64, _>::zeros((n_queries, k));
+        let mut neighbors = DeviceTensor::<i64>::zeros(&res, &[n_queries, k]).unwrap();
+        let mut distances = DeviceTensor::<f32>::zeros(&res, &[n_queries, k]).unwrap();
+
+        let search_params = SearchParams::new().unwrap();
+        index
+            .search_with_filter(
+                &res,
+                &search_params,
+                &queries,
+                &mut neighbors,
+                &mut distances,
+                &bitset,
+            )
+            .unwrap();
+
+        neighbors.copy_to_host(&res, &mut neighbors_host).unwrap();
+
+        // All returned neighbors must be even-indexed (odd rows are filtered out).
+        for q in 0..n_queries {
+            for n in 0..k {
+                let neighbor_id = neighbors_host[[q, n]];
+                assert_eq!(
+                    neighbor_id % 2,
+                    0,
+                    "query {q}, neighbor {n}: got odd index {neighbor_id}, expected only even"
+                );
+            }
+        }
+
+        // First query (row 0) should find itself as the nearest neighbor.
+        assert_eq!(neighbors_host[[0, 0]], 0);
+    }
+
+    #[test]
+    fn test_ivf_sq_serialize_deserialize() {
+        let res = Resources::new().unwrap();
+        let build_params = IndexParams::new().unwrap().set_n_lists(64);
+        let (dataset, index) = build_test_index(&res, &build_params);
+
+        let unique = format!(
+            "test_ivf_sq_index_{}_{}.bin",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock before unix epoch")
+                .as_nanos()
+        );
+        let filepath = std::env::temp_dir().join(unique);
+        index.serialize(&res, &filepath).expect("failed to serialize ivf-sq index");
+
+        assert!(filepath.exists(), "serialized index file should exist");
+        assert!(
+            std::fs::metadata(&filepath).unwrap().len() > 0,
+            "serialized index file should not be empty"
+        );
+
+        let loaded_index =
+            Index::deserialize(&res, &filepath).expect("failed to deserialize ivf-sq index");
+
+        // The deserialized index should still find each query as its own
+        // nearest neighbor.
+        search_and_verify_self_neighbors(&res, &loaded_index, &dataset, 4, 10);
+
+        let _ = std::fs::remove_file(&filepath);
+    }
+
+    /// Passing a filename containing an interior NUL byte must surface as an
+    /// `InvalidArgument` error rather than panicking inside the serializer.
+    #[test]
+    fn test_ivf_sq_serialize_rejects_interior_nul() {
+        let res = Resources::new().unwrap();
+        let build_params = IndexParams::new().unwrap().set_n_lists(64);
+        let (_dataset, index) = build_test_index(&res, &build_params);
+
+        // `PathBuf::from` on Unix preserves arbitrary bytes, so we can embed a
+        // NUL byte in the path and confirm the helper rejects it.
+        let bad_path = std::path::PathBuf::from("/tmp/has\0nul.bin");
+        let err = index
+            .serialize(&res, &bad_path)
+            .expect_err("serialize should reject paths with interior NUL");
+        assert!(matches!(err, Error::InvalidArgument(_)), "expected InvalidArgument, got {err:?}");
+    }
+}

--- a/rust/cuvs/src/ivf_sq/index_params.rs
+++ b/rust/cuvs/src/ivf_sq/index_params.rs
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::distance_type::DistanceType;
+use crate::error::{Result, check_cuvs};
+use std::fmt;
+use std::io::{Write, stderr};
+
+pub struct IndexParams(pub ffi::cuvsIvfSqIndexParams_t);
+
+impl IndexParams {
+    /// Returns a new IndexParams
+    pub fn new() -> Result<IndexParams> {
+        unsafe {
+            let mut params = std::mem::MaybeUninit::<ffi::cuvsIvfSqIndexParams_t>::uninit();
+            check_cuvs(ffi::cuvsIvfSqIndexParamsCreate(params.as_mut_ptr()))?;
+            Ok(IndexParams(params.assume_init()))
+        }
+    }
+
+    /// DistanceType to use for building the index
+    pub fn set_metric(self, metric: DistanceType) -> IndexParams {
+        unsafe {
+            (*self.0).metric = metric;
+        }
+        self
+    }
+
+    /// The argument used by some distance metrics
+    pub fn set_metric_arg(self, metric_arg: f32) -> IndexParams {
+        unsafe {
+            (*self.0).metric_arg = metric_arg;
+        }
+        self
+    }
+
+    /// The number of clusters used in the coarse quantizer.
+    pub fn set_n_lists(self, n_lists: u32) -> IndexParams {
+        unsafe {
+            (*self.0).n_lists = n_lists;
+        }
+        self
+    }
+
+    /// The number of iterations searching for kmeans centers during index building.
+    pub fn set_kmeans_n_iters(self, kmeans_n_iters: u32) -> IndexParams {
+        unsafe {
+            (*self.0).kmeans_n_iters = kmeans_n_iters;
+        }
+        self
+    }
+
+    /// The number of data vectors per cluster to use during iterative kmeans
+    /// building. The index uses at most `n_lists * max_train_points_per_cluster`
+    /// rows for training.
+    pub fn set_max_train_points_per_cluster(
+        self,
+        max_train_points_per_cluster: u32,
+    ) -> IndexParams {
+        unsafe {
+            (*self.0).max_train_points_per_cluster = max_train_points_per_cluster;
+        }
+        self
+    }
+
+    /// After training the quantizer and clustering, we will populate
+    /// the index with the dataset if add_data_on_build == true, otherwise
+    /// the index is left empty, and the extend method can be used
+    /// to add new vectors to the index.
+    pub fn set_add_data_on_build(self, add_data_on_build: bool) -> IndexParams {
+        unsafe {
+            (*self.0).add_data_on_build = add_data_on_build;
+        }
+        self
+    }
+
+    /// If set to `true`, the algorithm always allocates the minimum amount of
+    /// memory required to store the given number of records, trading reduced GPU
+    /// memory usage for more frequent reallocations during `extend`.
+    pub fn set_conservative_memory_allocation(
+        self,
+        conservative_memory_allocation: bool,
+    ) -> IndexParams {
+        unsafe {
+            (*self.0).conservative_memory_allocation = conservative_memory_allocation;
+        }
+        self
+    }
+}
+
+impl fmt::Debug for IndexParams {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // custom debug trait here, default value will show the pointer address
+        // for the inner params object which isn't that useful.
+        write!(f, "IndexParams({:?})", unsafe { *self.0 })
+    }
+}
+
+impl Drop for IndexParams {
+    fn drop(&mut self) {
+        if let Err(e) = check_cuvs(unsafe { ffi::cuvsIvfSqIndexParamsDestroy(self.0) }) {
+            write!(stderr(), "failed to call cuvsIvfSqIndexParamsDestroy {:?}", e)
+                .expect("failed to write to stderr");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_index_params() {
+        let params = IndexParams::new().unwrap().set_n_lists(128).set_add_data_on_build(false);
+
+        unsafe {
+            assert_eq!((*params.0).n_lists, 128);
+            assert_eq!((*params.0).add_data_on_build, false);
+        }
+    }
+}

--- a/rust/cuvs/src/ivf_sq/mod.rs
+++ b/rust/cuvs/src/ivf_sq/mod.rs
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+//! IVF-SQ: an inverted-file index that scalar-quantizes the vectors. Like
+//! IVF-Flat it partitions the dataset into `n_lists` clusters and scans the
+//! `n_probes` closest at query time, but stores each vector with scalar
+//! quantization (SQ) — a smaller memory footprint, traded against a small
+//! amount of accuracy.
+//!
+//! Build an [`Index`] from a dataset, then [`search`](Index::search) it with
+//! device-resident queries and output buffers. Tensors are passed through the
+//! [`AsDlTensor`](crate::AsDlTensor) /
+//! [`AsDlTensorMut`](crate::AsDlTensorMut) traits; see the
+//! [`dlpack`](crate::dlpack) module for the tensor model and `examples/cagra.rs`
+//! for the same build/search workflow.
+
+mod index;
+mod index_params;
+mod search_params;
+
+pub use index::Index;
+pub use index_params::IndexParams;
+pub use search_params::SearchParams;

--- a/rust/cuvs/src/ivf_sq/search_params.rs
+++ b/rust/cuvs/src/ivf_sq/search_params.rs
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::error::{Result, check_cuvs};
+use std::fmt;
+use std::io::{Write, stderr};
+
+/// Supplemental parameters to search IVF-SQ index
+pub struct SearchParams(pub ffi::cuvsIvfSqSearchParams_t);
+
+impl SearchParams {
+    /// Returns a new SearchParams object
+    pub fn new() -> Result<SearchParams> {
+        unsafe {
+            let mut params = std::mem::MaybeUninit::<ffi::cuvsIvfSqSearchParams_t>::uninit();
+            check_cuvs(ffi::cuvsIvfSqSearchParamsCreate(params.as_mut_ptr()))?;
+            Ok(SearchParams(params.assume_init()))
+        }
+    }
+
+    /// The number of clusters to search.
+    pub fn set_n_probes(self, n_probes: u32) -> SearchParams {
+        unsafe {
+            (*self.0).n_probes = n_probes;
+        }
+        self
+    }
+}
+
+impl fmt::Debug for SearchParams {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // custom debug trait here, default value will show the pointer address
+        // for the inner params object which isn't that useful.
+        write!(f, "SearchParams {{ params: {:?} }}", unsafe { *self.0 })
+    }
+}
+
+impl Drop for SearchParams {
+    fn drop(&mut self) {
+        if let Err(e) = check_cuvs(unsafe { ffi::cuvsIvfSqSearchParamsDestroy(self.0) }) {
+            write!(stderr(), "failed to call cuvsIvfSqSearchParamsDestroy {:?}", e)
+                .expect("failed to write to stderr");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_search_params() {
+        let params = SearchParams::new().unwrap().set_n_probes(128);
+
+        unsafe {
+            assert_eq!((*params.0).n_probes, 128);
+        }
+    }
+}

--- a/rust/cuvs/src/lib.rs
+++ b/rust/cuvs/src/lib.rs
@@ -18,6 +18,7 @@ pub mod dlpack;
 mod error;
 pub mod ivf_flat;
 pub mod ivf_pq;
+pub mod ivf_sq;
 mod resources;
 #[cfg(test)]
 pub(crate) mod test_utils;


### PR DESCRIPTION
Adds Rust bindings for the IVF-SQ index, wrapping the C API introduced in v26.06 ("IVF-SQ C API"). Follow-up to the CAGRA serialize/deserialize and `search_with_filter` wrappers (#2019 lineage).

## What

- New `rust/cuvs/src/ivf_sq/` module mirroring the `cagra` module structure: `IndexParams` / `SearchParams` builders, `Index` with `build`, `search`, `search_with_filter` (`cuvsFilter` bitset), `extend`, `serialize` / `deserialize`, and the `n_lists` / `dim` / `size` getters.
- `rust/cuvs-sys/src/bindings.rs` regenerated via `rust/scripts/generate-bindings.sh` — purely additive (`cuvsIvfSq*` block).

## Notes for reviewers

- `cuvsIvfSqIndexGetCenters` is deliberately not wrapped, matching the cagra and ivf_pq modules — it fills a caller-allocated `DLManagedTensor`, which has no ergonomic safe-Rust shape yet (commented in `index.rs`).
- IVF-SQ exposes getters + `extend` where the ivf_pq Rust module currently doesn't; the C API supports them for both, so this module simply wraps the full practical surface. Happy to trim for symmetry if preferred.

## Testing

9 GPU tests (single-process): params builders, build + self-neighbor search, repeated search, getters, extend-from-empty (NULL indices path), bitset-filtered search asserting exclusion, serialize/deserialize round-trip re-verifying search on the loaded index, interior-NUL path rejection. `cargo fmt` / clippy clean. Validated against both the v26.06.00 tag (conda libcuvs 26.06) and current `main` — the `ivf_sq.h` header is byte-identical between the two.
