### PR TITLE
Require C++20 for C++ CUDA examples

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -22,6 +22,11 @@ rapids_cuda_init_architectures(test_cuvs)
 project(test_cuvs LANGUAGES CXX CUDA)
 find_package(Threads)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CUDA_STANDARD 20)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
 # ------------- configure cuvs -----------------#
 
 rapids_cpm_init()


### PR DESCRIPTION
## Summary
- Set `CMAKE_CXX_STANDARD` and `CMAKE_CUDA_STANDARD` to 20 in `examples/cpp/CMakeLists.txt`
- Fixes example builds that include CAGRA Dataset API headers using C++20 concepts