### PR TITLE
fix: close issue #1863 Fix Cython CUDA stream pointer conversion

### DIFF
--- a/python/cuvs/cuvs/common/mg_resources.pyx
+++ b/python/cuvs/cuvs/common/mg_resources.pyx
@@ -1,12 +1,13 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 # cython: language_level=3
 
-from cuda.bindings.cyruntime cimport cudaStream_t
+from libc.stdint cimport uintptr_t
 
 from cuvs.common.c_api cimport (
+    cudaStream_t,
     cuvsMultiGpuResourcesCreate,
     cuvsMultiGpuResourcesCreateWithDeviceIds,
     cuvsMultiGpuResourcesDestroy,
@@ -84,11 +85,12 @@ cdef class MultiGpuResources:
         else:
             check_cuvs(cuvsMultiGpuResourcesCreate(&self.c_obj))
 
-        if stream:
-            check_cuvs(cuvsStreamSet(self.c_obj, <cudaStream_t>stream))
+        if stream is not None:
+            check_cuvs(cuvsStreamSet(
+                self.c_obj, <cudaStream_t><uintptr_t>stream))
 
     def sync(self):
-        check_cuvs(cuvsStreamSync(self.c_obj))
+            check_cuvs(cuvsStreamSync(self.c_obj))
 
     def set_memory_pool(self, percent_of_free_memory):
         """

--- a/python/cuvs/cuvs/common/resources.pyx
+++ b/python/cuvs/cuvs/common/resources.pyx
@@ -1,14 +1,15 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 # cython: language_level=3
 
 import functools
 
-from cuda.bindings.cyruntime cimport cudaStream_t
+from libc.stdint cimport uintptr_t
 
 from cuvs.common.c_api cimport (
+    cudaStream_t,
     cuvsResources_t,
     cuvsResourcesCreate,
     cuvsResourcesDestroy,
@@ -54,8 +55,8 @@ cdef class Resources:
 
     def __cinit__(self, stream=None):
         check_cuvs(cuvsResourcesCreate(&self.c_obj))
-        if stream:
-            check_cuvs(cuvsStreamSet(self.c_obj, <cudaStream_t>stream))
+        if stream is not None:
+            check_cuvs(cuvsStreamSet(self.c_obj, <cudaStream_t><uintptr_t>stream))
 
     def sync(self):
         check_cuvs(cuvsStreamSync(self.c_obj))

--- a/python/cuvs/cuvs/tests/test_resources.py
+++ b/python/cuvs/cuvs/tests/test_resources.py
@@ -1,10 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
-import gc
 
 import cupy as cp
-import cuvs.common.resources as resources_mod
 
 from cuvs.common import Resources
 

--- a/python/cuvs/cuvs/tests/test_resources.py
+++ b/python/cuvs/cuvs/tests/test_resources.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+
+import cupy as cp
+import cuvs.common.resources as resources_mod
+
+from cuvs.common import Resources
+
+
+def test_resources_syncs_cupy_stream_pointer():
+    # gh-issue: 1836 should not segfault when syncing a stream pointer from cupy
+    stream = cp.cuda.Stream()
+    resources = Resources(stream=stream.ptr)
+
+    resources.sync()


### PR DESCRIPTION
Convert Python stream pointer integers through uintptr_t before casting to cudaStream_t. This prevents Cython from treating the int object address as the CUDA stream handle when using Resources(stream=stream.ptr) or MultiGpuResources(stream=stream.ptr).

the reason as cython doc:

Cython type/cast syntax:
https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#statements-and-expressions
Cython pointer type documentation:
https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#types

The CPython documentation also states that extracting a C integer value from a Python int requires APIs such as PyLong_AsSize_t / PyLong_AsUnsignedLongLong:

PyLong_AsSize_t:
https://docs.python.org/3/c-api/long.html#c.PyLong_AsSize_t

At the same time, CPython also provides a dedicated PyLong_AsVoidPtr, which shows that converting a “Python integer to a C pointer value” is an explicit conversion step, and is not the same as directly casting a PyObject * to a pointer.

PyLong_AsVoidPtr:
https://docs.python.org/3/c-api/long.html#c.PyLong_AsVoidPtr

---

for the code side

```pyx

  from cuda.bindings.cyruntime cimport cudaStream_t
  from libc.stdint cimport uintptr_t

  def old(stream):
      return <uintptr_t><cudaStream_t>stream

  def new(stream):
      return <uintptr_t><cudaStream_t><uintptr_t>stream
 ```

the generated code
```cli
# old
__Pyx_PyLong_FromSize_t(((uintptr_t)((cudaStream_t)__pyx_v_stream)))
# new
  __pyx_t_1 = __Pyx_PyLong_As_size_t(__pyx_v_stream);
  __Pyx_PyLong_FromSize_t(
      ((uintptr_t)((cudaStream_t)((uintptr_t)__pyx_t_1)))
  )
```

the new code  make sure we get the value instead of the adress pyobject value


<!--

Thank you for contributing to cuvs :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
