### PR TITLE
Re-enable verify-codeowners pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,9 +180,8 @@ repos:
                 cpp/src/neighbors/detail/faiss_distance_utils[.]h$
               )
           - id: verify-alpha-spec
-          # TODO: Re-enable once org is configurable
-          # - id: verify-codeowners
-          #   args: [--fix, --project-prefix=cuvs]
+          - id: verify-codeowners
+            args: [--fix, --org=NVIDIA, --project-prefix=cuvs]
           - id: verify-pyproject-license
             # ignore the top-level pyproject.toml, which doesn't
             # have or need a [project] table

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 repos:
@@ -117,7 +117,7 @@ repos:
                     ^cpp/cmake/patches/cutlass/build-export[.]patch$|
                     ^rust/cuvs-sys/src/bindings[.]rs$
       - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v1.3.3
+        rev: v1.6.0
         hooks:
           - id: verify-copyright
             name: verify-copyright-cuvs


### PR DESCRIPTION
Let's re-enable the `verify-codeowners` pre-commit check now that https://github.com/rapidsai/pre-commit-hooks supports parameterizing the organization.

This is blocked on the next release of https://github.com/rapidsai/pre-commit-hooks

XREF:
- https://github.com/rapidsai/pre-commit-hooks/pull/135
- https://github.com/rapidsai/build-infra/issues/367