### PR TITLE
Add code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+This project has adopted the [Contributor Covenant Code of Conduct](https://docs.rapids.ai/resources/conduct/).


### PR DESCRIPTION
Due to the migration, the code of conduct is missing since we don't have access to the global rapids org file https://github.com/rapidsai/.github/blob/main/CODE_OF_CONDUCT.md

Instead we can re-add it as a file in the .github folder of this repo.