### PR TITLE
Exclude SPDX copyright lines from .clang-format

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -56,7 +56,7 @@ BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
 ColumnLimit: 100
-CommentPragmas: '^ IWYU pragma:'
+CommentPragmas: '^ (IWYU pragma:)|(SPDX-)'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 # Kept the below 2 to be the same as `IndentWidth` to keep everything uniform


### PR DESCRIPTION
NVIDIA's full copyright notice may exceed `ColumnLimit: 100` and cause clang-format to corrupt the header for multi-year files.
This PR excludes the copyright line from clang-format checks to workaround this problem.