### PR TITLE
Remove legacy RAPIDS Doxygen theme assets

### DIFF
--- a/cpp/doxygen/header.html
+++ b/cpp/doxygen/header.html
@@ -17,10 +17,6 @@ $mathjax
 <link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
 $extrastylesheet
 
-<!-- RAPIDS CUSTOM JS & CSS: START, Please add these two lines back after every version upgrade -->
-<script defer src="https://docs.rapids.ai/assets/js/custom.js"></script>
-<link rel="stylesheet" href="https://docs.rapids.ai/assets/css/custom.css">
-<!-- RAPIDS CUSTOM JS & CSS: END -->
 
 </head>
 <body>

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://schema.buildwithfern.dev/docs-yml.json
 
 global-theme: nvidia
-title: "cuVS"
+title: "NVIDIA cuVS"
 instances:
   - url: "nvidia-cuvs.docs.buildwithfern.com/cuvs"
     custom-domain: docs.nvidia.com/cuvs
@@ -12,7 +12,7 @@ logo:
   dark: "./theme/nvidia/assets/NVIDIA_dark.svg"
   height: 20
   href: "https://developer.nvidia.com/cuvs"
-  right-text: "cuVS"
+  right-text: "NVIDIA cuVS"
 favicon: "./theme/nvidia/assets/NVIDIA_symbol.svg"
 colors:
   accentPrimary:

--- a/fern/pages/index.md
+++ b/fern/pages/index.md
@@ -1,4 +1,4 @@
-# NVIDIA cuVS Documentation
+# NVIDIA cuVS: A library for vector search on the GPU
 
 NVIDIA cuVS is a GPU-accelerated library for vector search on the GPU. Vector search includes nearest neighbors, vector compression and clustering. It provides both core building blocks for constructing new algorithms and end-to-end algorithms that can be used directly or through a growing list of [integrations](/getting-started/integrations).
 

--- a/fern/pages/index.md
+++ b/fern/pages/index.md
@@ -1,4 +1,4 @@
-# NVIDIA cuVS: A library for vector search on the GPU
+# NVIDIA cuVS Documentation
 
 NVIDIA cuVS is a GPU-accelerated library for vector search on the GPU. Vector search includes nearest neighbors, vector compression and clustering. It provides both core building blocks for constructing new algorithms and end-to-end algorithms that can be used directly or through a growing list of [integrations](/getting-started/integrations).
 

--- a/fern/theme/nvidia/components/CustomFooter.tsx
+++ b/fern/theme/nvidia/components/CustomFooter.tsx
@@ -87,7 +87,7 @@ export default function CustomFooter() {
             </div>
           </div>
           <div className="footer-item">
-            <p className="copyright">Copyright &#169; 2024-{currentYear}, NVIDIA Corporation.</p>
+            <p className="copyright">Copyright &#169; 2020-{currentYear}, NVIDIA Corporation.</p>
           </div>
         </div>
       </div>

--- a/fern/theme/nvidia/components/CustomFooter.tsx
+++ b/fern/theme/nvidia/components/CustomFooter.tsx
@@ -87,7 +87,7 @@ export default function CustomFooter() {
             </div>
           </div>
           <div className="footer-item">
-            <p className="copyright">Copyright &#169; {currentYear}, NVIDIA Corporation.</p>
+            <p className="copyright">Copyright &#169; 2024-{currentYear}, NVIDIA Corporation.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

Removes the legacy shared RAPIDS CSS/JavaScript injection from the cuVS Doxygen header.

cuVS documentation has already moved from Sphinx to Fern, so this removes the remaining obsolete theme customization rather than changing a Sphinx configuration.

Contributes to rapidsai/build-planning#300.

## Validation

- Commit-time pre-commit hooks passed.
- `fern/build_docs.sh check` passed in the CUDA 13.3 devcontainer with zero errors; all 239 MDX files are valid.
- Fern reported only the existing unauthenticated redirect-check and color-contrast advisories.

