### PR TITLE
Re-enable Python code coverage

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -452,7 +452,6 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
     with:
       build_type: pull-request
-      run_codecov: false
       script: ci/test_python.sh
   rocky8-clib-standalone-build-matrix:
     needs: checks

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,7 +68,6 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
-      run_codecov: false
       script: ci/test_python.sh
       sha: ${{ inputs.sha }}
   conda-java-tests:


### PR DESCRIPTION
Contributes to: https://github.com/rapidsai/build-infra/issues/367

We've finally found a `CODECOV_TOKEN` secret value and added it as a repo-scoped secret.

Let's turn code coverage back on for Python tests.