### PR TITLE
switch from 'cuda-python' to specific components (e.g. 'cuda-bindings')

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -17,7 +17,7 @@ rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
   --file-key test_python \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" \
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
   --prepend-channel "${CPP_CHANNEL}" \
   --prepend-channel "${PYTHON_CHANNEL}" \
   | tee env.yaml

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - cmake>=4.0
+- cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - cmake>=4.0
+- cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - cmake>=4.0
+- cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=13.0.1,<14.0
 - cuda-version=13.3
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - cmake>=4.0
+- cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=13.0.1,<14.0
 - cuda-version=13.3
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler

--- a/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - clang==20.1.8
 - click
 - cmake>=4.0
+- cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cupy>=14.0.1,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0

--- a/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - clang==20.1.8
 - click
 - cmake>=4.0
+- cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cupy>=14.0.1,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0

--- a/conda/environments/bench_ann_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-133_arch-aarch64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - clang==20.1.8
 - click
 - cmake>=4.0
+- cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=13.0.1,<14.0
 - cuda-version=13.3
 - cupy>=14.0.1,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0

--- a/conda/environments/bench_ann_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-133_arch-x86_64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - clang==20.1.8
 - click
 - cmake>=4.0
+- cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=13.0.1,<14.0
 - cuda-version=13.3
 - cupy>=14.0.1,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0

--- a/conda/recipes/cuvs/recipe.yaml
+++ b/conda/recipes/cuvs/recipe.yaml
@@ -80,8 +80,8 @@ requirements:
     - rapids-build-backend >=0.4.0,<0.5.0
     - scikit-build-core>=0.11.0
     - if: cuda_major == "12"
-      then: cuda-python >=12.9.2,<13.0
-      else: cuda-python >=13.0.1,<14.0
+      then: cuda-bindings >=12.9.2,<13.0
+      else: cuda-bindings >=13.0.1,<14.0
     - cuda-cudart-dev
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
@@ -90,8 +90,8 @@ requirements:
     - python
     - numpy >=2.0,<3.0
     - if: cuda_major == "12"
-      then: cuda-python >=12.9.2,<13.0
-      else: cuda-python >=13.0.1,<14.0
+      then: cuda-bindings >=12.9.2,<13.0
+      else: cuda-bindings >=13.0.1,<14.0
   ignore_run_exports:
     by_name:
       - cuda-version

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -545,6 +545,21 @@ dependencies:
         packages:
           - *pytest
           - pytest-cov
+    specific:
+      - output_types: [conda, requirements, pyproject]
+        matrices:
+          - matrix:
+              dependencies: "oldest"
+              cuda: "12.*"
+            packages:
+              - cuda-bindings==12.9.2
+          - matrix:
+              dependencies: "oldest"
+              cuda: "13.*"
+            packages:
+              - cuda-bindings==13.0.1
+          - matrix:
+            packages:
   test_py_cuvs:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -617,11 +632,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cuda-python>=12.9.2,<13.0
+              - cuda-bindings>=12.9.2,<13.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cuda-python>=13.0.1,<14.0
+              - cuda-bindings>=13.0.1,<14.0
   depends_on_cuvs:
     common:
       - output_types: conda

--- a/python/cuvs/pyproject.toml
+++ b/python/cuvs/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "cuda-python>=13.0.1,<14.0",
+    "cuda-bindings>=13.0.1,<14.0",
     "libcuvs==26.8.*,>=0.0.0a0",
     "numpy>=2.0,<3.0",
     "pylibraft==26.8.*,>=0.0.0a0",
@@ -107,7 +107,7 @@ regex = "(?P<value>.*)"
 [tool.rapids-build-backend]
 requires = [
     "cmake>=4.0",
-    "cuda-python>=13.0.1,<14.0",
+    "cuda-bindings>=13.0.1,<14.0",
     "cython>=3.2.2",
     "libcuvs==26.8.*,>=0.0.0a0",
     "libraft==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/285

`cuda-python` is a metapackage and sometimes pulls in components that RAPIDS libraries don't need. This PR is part of a series dropping direct use of `cuda-python` in favor of depending only on those specific components.

* drops dependency on `cuda-python`
* adds explicit dependencies on components:
  - `cuda-bindings >=12.9.2,<13.0` (CUDA 12), `cuda-bindings >=13.0.1,<14.0` (CUDA 13)
* adds explicit testing of oldest `cuda-bindings` in CI

## Notes for Reviewers

### Why these specific bounds?

* these roughly match what we were getting with `cuda-python`
* worked through finding compatible ranges in https://github.com/rapidsai/rmm/pull/2460#discussion_r3514148466
* `cuda-bindings` major version follows the CTK major version, so kept a ceiling just like we currently have for `cuda-python`