### PR TITLE
fix(deps): try to dynamically load nvrtc from wheel

### DIFF
--- a/python/libcuvs/libcuvs/load.py
+++ b/python/libcuvs/libcuvs/load.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -39,9 +39,11 @@ def load_library():
         # references their symbols
         import libraft
         import librmm
+        from cuda.pathfinder import load_nvidia_dynamic_lib
 
         librmm.load_library()
         libraft.load_library()
+        load_nvidia_dynamic_lib("nvrtc")
     except ModuleNotFoundError:
         # These runtime dependencies might be satisfied by conda packages
         # (which do not have any Python modules) instead of wheels. In that


### PR DESCRIPTION
Same patch as cudf#23089

I am testing a smaller base image for wheel testing in #2298 -- the current `dlopen` scripts find `libnvrtc.so.12` when the base image is the full cuda development image, but they don't find it when it's provided by nvidia-cuda-nvrtc-cu12.

Here's what the loading looks like with a before+after of this fix:

```python
>>> import libcuvs
>>> libcuvs.load_library()
[]

# so nothing was loaded above (silent failure due to the way wheel library loading is architected)
# try to directly load `libcuvs.so`

>>> from libcuvs.load import _load_wheel_installation
>>> _load_wheel_installation('libcuvs.so')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/pyenv/versions/3.11.15/lib/python3.11/site-packages/libcuvs/load.py", line 31, in _load_wheel_installation
    return ctypes.CDLL(lib, PREFERRED_LOAD_FLAG)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.11.15/lib/python3.11/ctypes/__init__.py", line 376, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: libnvrtc.so.12: cannot open shared object file: No such file or directory

# that's the issue preventing `libcuvs.so` from loading

# use cuda.pathfinder to load nvrtc
>>> from cuda.pathfinder import load_nvidia_dynamic_lib
>>> load_nvidia_dynamic_lib('nvrtc')
LoadedDL(abs_path='/pyenv/versions/3.11.15/lib/python3.11/site-packages/nvidia/cuda_nvrtc/lib/libnvrtc.so.12', was_already_loaded_from_elsewhere=False, _handle_uint=95154333901152, found_via='site-packages')

# now load `libcuvs.so` again:
>>> _load_wheel_installation('libcuvs.so')
<CDLL '/pyenv/versions/3.11.15/lib/python3.11/site-packages/libcuvs/lib64/libcuvs.so', handle 568ad84cc0c0 at 0x70554dc89b90>
```

xref rapidsai/build-planning#143
