### PR TITLE
Pin CMake to < 4.4

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools==20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools==20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools==20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools==20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/bench_ann_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-133_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/bench_ann_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-133_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/go_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/go_cuda-129_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools==20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/go_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/go_cuda-129_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools==20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/go_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/go_cuda-133_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools==20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/go_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/go_cuda-133_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools==20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/rust_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/rust_cuda-129_arch-aarch64.yaml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/rust_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/rust_cuda-129_arch-x86_64.yaml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/rust_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/rust_cuda-133_arch-aarch64.yaml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/rust_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/rust_cuda-133_arch-x86_64.yaml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/recipes/cuvs-bench-cpu/conda_build_config.yaml
+++ b/conda/recipes/cuvs-bench-cpu/conda_build_config.yaml
@@ -11,7 +11,7 @@ c_stdlib_version:
   - "2.28"
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 glog_version:
   - ">=0.6.0"

--- a/conda/recipes/cuvs/conda_build_config.yaml
+++ b/conda/recipes/cuvs/conda_build_config.yaml
@@ -14,4 +14,4 @@ c_stdlib_version:
   - "2.28"
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"

--- a/conda/recipes/libcuvs/conda_build_config.yaml
+++ b/conda/recipes/libcuvs/conda_build_config.yaml
@@ -14,7 +14,7 @@ c_stdlib_version:
   - "2.28"
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 h5py_version:
   - ">=3.8.0"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -247,7 +247,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &cmake_ver cmake>=4.0
+          - &cmake_ver cmake>=4.0,<4.4
           - ninja
       - output_types: [conda]
         packages:

--- a/python/cuvs/pyproject.toml
+++ b/python/cuvs/pyproject.toml
@@ -106,7 +106,7 @@ regex = "(?P<value>.*)"
 
 [tool.rapids-build-backend]
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "cuda-bindings>=13.0.1,<14.0",
     "cython>=3.2.2",
     "libcuvs==26.8.*,>=0.0.0a0",

--- a/python/libcuvs/pyproject.toml
+++ b/python/libcuvs/pyproject.toml
@@ -80,7 +80,7 @@ regex = "(?P<value>.*)"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "libraft==26.8.*,>=0.0.0a0",
     "librmm==26.8.*,>=0.0.0a0",
     "ninja",


### PR DESCRIPTION
## Description

rapids-cmake is currently broken by CMake 4.4, so pin CMake until we have a fix.

Issue: https://github.com/rapidsai/build-planning/issues/302
