### PR TITLE
update actions/checkout to fix zizmor

### DIFF
--- a/.github/workflows/check-c-abi.yaml
+++ b/.github/workflows/check-c-abi.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/publish-rust.yaml
+++ b/.github/workflows/publish-rust.yaml
@@ -21,7 +21,7 @@ jobs:
     container:
       image: "rapidsai/ci-conda:26.08-cuda${{ matrix.cuda_version }}-ubuntu24.04-py3.13"
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Check if release build

--- a/.github/workflows/store-c-abi-baseline.yaml
+++ b/.github/workflows/store-c-abi-baseline.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/update-c-abi-baseline.yaml
+++ b/.github/workflows/update-c-abi-baseline.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
`zizmor` flags when a comment on a GitHub Actions third-party action refers to the wrong git tag, and recently started failing like this:

```text
warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
  --> .github/workflows/check-c-abi.yaml:12:75
   |
12 |         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
   |         ---------------------------------------------------------------   ^^ points to commit 11d5960a3267
   |         |
   |         is pointed to by tag v4.3.1
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix
   = help: audit documentation → https://docs.zizmor.sh/audits/#ref-version-mismatch
```

([build link](https://github.com/NVIDIA/cuvs/actions/runs/29759754020/job/88411816429#step:7:277))

This fixes those references, to unblock CI.

