### PR TITLE
CAGRA ACE build: avoid rounding down graph degree during sub-index build

### DIFF
--- a/cpp/src/neighbors/detail/cagra/cagra_build.cuh
+++ b/cpp/src/neighbors/detail/cagra/cagra_build.cuh
@@ -1390,6 +1390,8 @@ index<T, IdxT> build_ace(raft::resources const& res,
         ef_construction,
         cuvs::neighbors::cagra::hnsw_heuristic_type::SAME_GRAPH_FOOTPRINT,
         params.metric);
+      // avoid rounding down graph_degree via heuristics doing `(graph_degree / 2) * 2`
+      sub_index_params.graph_degree            = graph_degree;
       sub_index_params.attach_dataset_on_build = false;
       sub_index_params.guarantee_connectivity  = params.guarantee_connectivity;
 


### PR DESCRIPTION
Passing `graph_degree / 2` to `from_hnsw` heuristics to get `graph_degree` back as a result unintentionally rounds down odd degrees, which corrupts subsequent copy operations during ACE index build.
We workaround this issue by assigning the graph_degree explicitly on top of the heuristics.