### PR TITLE
java: get nightly test matrix from shared-workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,16 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/test_python.sh
       sha: ${{ inputs.sha }}
-  conda-java-tests:
+  conda-java-build-and-tests-matrix:
+    permissions:
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@main
+    with:
+      build_type: ${{ inputs.build_type }}
+      matrix_name: conda-cpp-build
+      matrix_filter: map(select(.ARCH == "amd64"))
+  conda-java-build-and-tests:
+    needs: conda-java-build-and-tests-matrix
     permissions:
       actions: read
       contents: read
@@ -83,19 +92,15 @@ jobs:
     # If these jobs start producing artifacts, the names will have to differentiate between CUDA versions.
     strategy:
       fail-fast: false
-      matrix:
-        cuda_version:
-          - '12.9.1'
-          - '13.3.0'
+      matrix: ${{ fromJSON(needs.conda-java-build-and-tests-matrix.outputs.matrix) }}
     with:
-      build_type: ${{ inputs.build_type }}
-      branch: ${{ inputs.branch }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
+      build_type: pull-request
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.cuda_version }}-ubuntu24.04-py3.13"
+      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       script: "ci/test_java.sh"
+      artifact-name: "cuvs-java-cuda${{ matrix.CUDA_VER }}"
+      file_to_upload: "java/cuvs-java/target/"
   wheel-tests-cuvs:
     permissions:
       actions: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,6 +95,9 @@ jobs:
       matrix: ${{ fromJSON(needs.conda-java-build-and-tests-matrix.outputs.matrix) }}
     with:
       build_type: ${{ inputs.build_type }}
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,7 +94,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.conda-java-build-and-tests-matrix.outputs.matrix) }}
     with:
-      build_type: pull-request
+      build_type: ${{ inputs.build_type }}
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"


### PR DESCRIPTION
Nightly Java tests are failing like this:

> _Error response from daemon: failed to resolve reference "docker.io/rapidsai/ci-conda:26.10-cuda12.9.1-ubuntu24.04-py3.13": docker.io/rapidsai/ci-conda:26.10-cuda12.9.1-ubuntu24.04-py3.13: not found_

([build link](https://github.com/NVIDIA/cuvs/actions/runs/29819519444/job/88660368468))

CI jobs here were updated from hard-coded lists of CUDA versions to a shared matrix from `shared-workflows` in #2034, to avoid exactly this situation... but `test.yaml` was missed in that PR.

This updates `test.yaml` to match the way the Java tests run in PRs.

## Notes for Reviewers

### How I tested this

Manually triggered a run from this branch.

```shell
gh workflow run \
  --repo NVIDIA/cuvs \
  --ref 'fix/build-matrix' \
  -f branch=main \
  -f build_type=nightly \
  -f date=2026-07-21 \
  -f sha=c38d9a77d4840d344369d472e9cafc87882d2a30 \
  test.yaml
```

That generated this run: https://github.com/NVIDIA/cuvs/actions/runs/29853648565

Which had 2 Java test jobs (1 for CUDA 12, 1 for CUDA 13)

<img width="273" height="192" alt="image" src="https://github.com/user-attachments/assets/cc8b1d8f-88b2-4f17-b399-cb8f75221f39" />

Which failed, but with real test errors (so got past the pulling-a-nonexistent-image issue).