### PR TITLE
Revert "Update DLPack to 1.0 (#2354)"

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-aarch64=14.*
 - go
 - libclang==20.1.8

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-64=14.*
 - go
 - libclang==20.1.8

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-aarch64=14.*
 - go
 - libclang==20.1.8

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -19,7 +19,7 @@ dependencies:
 - cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-64=14.*
 - go
 - libclang==20.1.8

--- a/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-aarch64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-aarch64=14.*
 - glog>=0.6.0
 - h5py>=3.8.0

--- a/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-129_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-64=14.*
 - glog>=0.6.0
 - h5py>=3.8.0

--- a/conda/environments/bench_ann_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/bench_ann_cuda-133_arch-aarch64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-aarch64=14.*
 - glog>=0.6.0
 - h5py>=3.8.0

--- a/conda/environments/bench_ann_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/bench_ann_cuda-133_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-64=14.*
 - glog>=0.6.0
 - h5py>=3.8.0

--- a/conda/environments/go_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/go_cuda-129_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-version=12.9
 - cxx-compiler
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-aarch64=14.*
 - go
 - libclang==20.1.8

--- a/conda/environments/go_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/go_cuda-129_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-version=12.9
 - cxx-compiler
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-64=14.*
 - go
 - libclang==20.1.8

--- a/conda/environments/go_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/go_cuda-133_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-version=13.3
 - cxx-compiler
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-aarch64=14.*
 - go
 - libclang==20.1.8

--- a/conda/environments/go_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/go_cuda-133_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-version=13.3
 - cxx-compiler
-- dlpack>=1.0,<1.1
+- dlpack>=0.8,<1.0
 - gcc_linux-64=14.*
 - go
 - libclang==20.1.8

--- a/cpp/cmake/thirdparty/get_dlpack.cmake
+++ b/cpp/cmake/thirdparty/get_dlpack.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/cpp/cmake/thirdparty/get_dlpack.cmake
+++ b/cpp/cmake/thirdparty/get_dlpack.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -29,6 +29,6 @@ function(find_and_configure_dlpack VERSION)
   endif()
 endfunction()
 
-set(CUVS_MIN_VERSION_dlpack 1.0)
+set(CUVS_MIN_VERSION_dlpack 0.8)
 
 find_and_configure_dlpack(${CUVS_MIN_VERSION_dlpack})

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -287,7 +287,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - dlpack>=1.0,<1.1
+          - dlpack>=0.8,<1.0
   checks:
     common:
       - output_types: [conda, requirements]
@@ -513,7 +513,7 @@ dependencies:
         packages:
           - go
           - _go_select *=cgo
-          - dlpack>=1.0,<1.1
+          - dlpack>=0.8,<1.0
   build_wheels:
     common:
       - output_types: [requirements, pyproject]

--- a/examples/cmake/thirdparty/get_dlpack.cmake
+++ b/examples/cmake/thirdparty/get_dlpack.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/examples/cmake/thirdparty/get_dlpack.cmake
+++ b/examples/cmake/thirdparty/get_dlpack.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -29,6 +29,6 @@ function(find_and_configure_dlpack VERSION)
   endif()
 endfunction()
 
-set(CUVS_MIN_VERSION_dlpack 1.0)
+set(CUVS_MIN_VERSION_dlpack 0.8)
 
 find_and_configure_dlpack(${CUVS_MIN_VERSION_dlpack})


### PR DESCRIPTION
This reverts commit 350a3b0ffd48eba860d48a7fb564bb9fe77580cb.

This update introduced conflicts with cuDF, which is already in code freeze for 26.08. I have a proposal in https://github.com/rapidsai/build-planning/issues/308 to update to DLPack 1.x, which can occur in 26.10 or later because it is not an ABI breaking change (which was the original reason this targeted 26.08, because 26.08 is allowed to break ABI).
