### PR TITLE
Use ``main`` branch for C ABI baseline

### DIFF
--- a/.github/workflows/check-c-abi.yaml
+++ b/.github/workflows/check-c-abi.yaml
@@ -31,8 +31,8 @@ jobs:
       - name: Find merge base commit
         id: merge-base
         run: |
-          git fetch origin release/26.08
-          MERGE_BASE=$(git merge-base HEAD origin/release/26.08)
+          git fetch origin main
+          MERGE_BASE=$(git merge-base HEAD origin/main)
           echo "merge_base_sha=${MERGE_BASE}" >> $GITHUB_OUTPUT
           echo "Merge base commit: ${MERGE_BASE}"
 
@@ -46,40 +46,40 @@ jobs:
           commit: ${{ steps.merge-base.outputs.merge_base_sha }}
           path: baseline/
 
-      - name: Try to download latest release/26.08 baseline (fallback 1)
+      - name: Try to download latest main baseline (fallback 1)
         id: download-main
         if: steps.download-merge-base.outcome == 'failure'
         continue-on-error: true
         uses: dawidd6/action-download-artifact@8a338493df3d275e4a7a63bcff3b8fe97e51a927 # v19
         with:
-          name: c-abi-baseline-release/26.08
+          name: c-abi-baseline-main
           workflow: check-c-abi.yaml
-          branch: release/26.08
+          branch: main
           path: baseline/
 
-      - name: Extract baseline ABI from release/26.08 branch (fallback 2)
+      - name: Extract baseline ABI from main branch (fallback 2)
         if: steps.download-merge-base.outcome == 'failure' && steps.download-main.outcome == 'failure'
         run: |
-          echo "⚠️ No baseline artifacts found, extracting from release/26.08 branch..."
+          echo "⚠️ No baseline artifacts found, extracting from main branch..."
           echo "This is slower but ensures we always have a baseline for comparison."
-          git worktree add ../cuvs-release-26.08 origin/release/26.08
+          git worktree add ../cuvs-main origin/main
           mkdir -p baseline
           check-c-abi extract \
-            --header-path ../cuvs-release-26.08/c/include \
+            --header-path ../cuvs-main/c/include \
             --include-file cuvs/core/all.h \
             --output-file baseline/c_abi.json.gz \
             --dlpack-include-path dlpack/include
 
-          echo "✓ Baseline ABI extracted from release/26.08 branch"
+          echo "✓ Baseline ABI extracted from main branch"
 
       - name: Report baseline source
         run: |
           if [ "$DOWNLOAD_MERGE_BASE_OUTCOME" == "success" ]; then
             echo "✓ Using baseline from merge-base commit: $MERGE_BASE_SHA"
           elif [ "$DOWNLOAD_MAIN_OUTCOME" == "success" ]; then
-            echo "✓ Using latest release/26.08 baseline (merge-base baseline not yet available)"
+            echo "✓ Using latest main baseline (merge-base baseline not yet available)"
           else
-            echo "✓ Using freshly extracted baseline from release/26.08 branch"
+            echo "✓ Using freshly extracted baseline from main branch"
           fi
         env:
           DOWNLOAD_MERGE_BASE_OUTCOME: ${{ steps.download-merge-base.outcome }}


### PR DESCRIPTION
This is the opposite of the changes here https://github.com/NVIDIA/cuvs/pull/2331 

Closes https://github.com/NVIDIA/cuvs/issues/2387